### PR TITLE
fix(dt-collect): hardcoded DS-strategy → $GOVERNANCE_DIR

### DIFF
--- a/roles/synchronizer/scripts/dt-collect.sh
+++ b/roles/synchronizer/scripts/dt-collect.sh
@@ -231,7 +231,7 @@ print(json.dumps(result))
 # ============================================================
 
 collect_sessions() {
-    local SESSION_LOG="$WORKSPACE/DS-strategy/inbox/open-sessions.log"
+    local SESSION_LOG="$GOVERNANCE_DIR/inbox/open-sessions.log"
 
     python3 -c "
 import json, os, re


### PR DESCRIPTION
## Summary
- Replace hardcoded `$WORKSPACE/DS-strategy/` on line 234 with `$GOVERNANCE_DIR/`
- The variable `GOVERNANCE_DIR` is already defined on line 34 but was not used in `collect_sessions()`
- Fixes CI smoke-test failure: `integration-contract` check [6a]

Closes #37

## Test plan
- [ ] `grep -n 'DS-strategy' roles/synchronizer/scripts/dt-collect.sh` should only return line 34 (the default value)
- [ ] CI smoke-test `integration-contract` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)