### PR TITLE
fix(verify): add model mapping for wp verification_class

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -60,7 +60,10 @@ argument-hint: "[code|archgate|capture|wp|chain|adversarial|auto] [путь ил
 - Прочитать WP context file (`DS-strategy/inbox/WP-{N}-*.md`)
 - Прочитать артефакт РП
 - Передать sub-agent'у: артефакт + критерии done + чеклист wp
-- Модель sub-agent'а: по verification_class
+- Модель sub-agent'а: по verification_class:
+  - `trivial` → Haiku
+  - `closed-loop` / `open-loop` → Sonnet
+  - `problem-framing` → Opus
 
 **Для `chain` (CoVe — Chain-of-Verification, Meta ACL 2024):**
 - Прочитать `git diff` изменённых файлов


### PR DESCRIPTION
## Summary
- Add explicit model mapping for `verification_class` values in the `wp` verification type
- Previously: "Модель sub-agent'а: по verification_class" with no table → arbitrary agent behavior
- Now: `trivial` → Haiku, `closed-loop`/`open-loop` → Sonnet, `problem-framing` → Opus

## Rationale
- `trivial`: binary check (criteria met yes/no) — Haiku is sufficient
- `closed-loop` / `open-loop`: evaluating conformance to spec — Sonnet reasoning needed
- `problem-framing`: evaluating quality of problem definition — most complex, Opus warranted

Closes #38

## Test plan
- [ ] Run `/verify wp` on a trivial WP — should use Haiku
- [ ] Run `/verify wp` on a closed-loop WP — should use Sonnet
- [ ] Confirm mapping is visible in SKILL.md Step 1, `wp` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)