### PR TITLE
fix(notify): make TEMPLATES_DIR overridable via environment

### DIFF
--- a/roles/synchronizer/scripts/notify.sh
+++ b/roles/synchronizer/scripts/notify.sh
@@ -13,7 +13,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-TEMPLATES_DIR="$SCRIPT_DIR/templates"
+TEMPLATES_DIR="${TEMPLATES_DIR:-$SCRIPT_DIR/templates}"
 ENV_FILE="$HOME/.config/aist/env"
 
 AVAILABLE=$(ls "$TEMPLATES_DIR"/*.sh 2>/dev/null | xargs -I{} basename {} .sh | tr '\n' '|' | sed 's/|$//')


### PR DESCRIPTION
## Summary
- Make `TEMPLATES_DIR` overridable via environment variable
- One-line change: `$SCRIPT_DIR/templates` → `${TEMPLATES_DIR:-$SCRIPT_DIR/templates}`

## Problem
`notify.sh` hardcodes `TEMPLATES_DIR` to its own script directory (FMT templates), which contains **unsubstituted placeholders** like `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/current`. When called from a user's workspace, constructed paths don't exist → Telegram notifications silently skipped.

## Fix
Callers can now override:
```bash
TEMPLATES_DIR="$HOME/IWE/.iwe-runtime/roles/synchronizer/scripts/templates" \
  bash notify.sh strategist day-plan
```

Or `strategist.sh` can set it automatically when calling `notify_telegram`.

## Test plan
- [ ] Without TEMPLATES_DIR set — behavior unchanged (backward compatible)
- [ ] With TEMPLATES_DIR pointing to runtime templates — notifications use correct paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)