### PR TITLE
fix: 4 portability bugs (#37, #38, #39, #40)

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -60,7 +60,16 @@ argument-hint: "[code|archgate|capture|wp|chain|adversarial|auto] [путь ил
 - Прочитать WP context file (`DS-strategy/inbox/WP-{N}-*.md`)
 - Прочитать артефакт РП
 - Передать sub-agent'у: артефакт + критерии done + чеклист wp
-- Модель sub-agent'а: по verification_class
+- Модель sub-agent'а: по `verification_class` из WP context:
+
+  | verification_class | Модель | Когда применять |
+  |--------------------|--------|-----------------|
+  | `trivial` | Haiku | Бинарная проверка (критерии да/нет, формальный чеклист) |
+  | `closed-loop` | Sonnet | Известный эталон, eval по критериям (тесты, smoke-test, sample comparison) |
+  | `open-loop` | Sonnet | Эталон сформулирован абстрактно, требуется суждение по принципам |
+  | `problem-framing` | Opus | Постановка задачи неоднозначна, нужна декомпозиция и рефлексия по альтернативам |
+
+  Если `verification_class` отсутствует в WP context → СТОП. Спросить у автора РП, не угадывать.
 
 **Для `chain` (CoVe — Chain-of-Verification, Meta ACL 2024):**
 - Прочитать `git diff` изменённых файлов

--- a/roles/synchronizer/scripts/dt-collect.sh
+++ b/roles/synchronizer/scripts/dt-collect.sh
@@ -231,7 +231,7 @@ print(json.dumps(result))
 # ============================================================
 
 collect_sessions() {
-    local SESSION_LOG="$WORKSPACE/DS-strategy/inbox/open-sessions.log"
+    local SESSION_LOG="$GOVERNANCE_DIR/inbox/open-sessions.log"
 
     python3 -c "
 import json, os, re

--- a/roles/synchronizer/scripts/notify.sh
+++ b/roles/synchronizer/scripts/notify.sh
@@ -13,7 +13,9 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-TEMPLATES_DIR="$SCRIPT_DIR/templates"
+# TEMPLATES_DIR overridable: callers (e.g. strategist.sh) могут указать runtime-templates
+# с подставленными плейсхолдерами вместо FMT-шаблонов с `{{WORKSPACE_DIR}}/...`.
+TEMPLATES_DIR="${TEMPLATES_DIR:-$SCRIPT_DIR/templates}"
 ENV_FILE="$HOME/.config/aist/env"
 
 AVAILABLE=$(ls "$TEMPLATES_DIR"/*.sh 2>/dev/null | xargs -I{} basename {} .sh | tr '\n' '|' | sed 's/|$//')

--- a/update.sh
+++ b/update.sh
@@ -606,7 +606,7 @@ fi
 # Propagate skills, hooks, rules, lib, config, detectors to workspace if changed.
 # lib/config/detectors — runtime dependencies капчер-шины (capture-bus.sh) и детекторов.
 for f in "${NEW_FILES[@]}" "${UPDATED_FILES[@]}"; do
-    case "$f" in .claude/skills/*|.claude/hooks/*|.claude/rules/*|.claude/lib/*|.claude/config/*|.claude/detectors/*|.claude/settings.json)
+    case "$f" in .claude/skills/*|.claude/hooks/*|.claude/rules/*|.claude/lib/*|.claude/config/*|.claude/detectors/*|.claude/scripts/*|.claude/settings.json)
         src="$SCRIPT_DIR/$f"
         dst="$WORKSPACE_DIR/$f"
         mkdir -p "$(dirname "$dst")"


### PR DESCRIPTION
## Summary

Fixes 4 portability/correctness bugs blocking IWE on non-default workspaces and breaking silently in production:

- **#37** `dt-collect.sh:234` — replace hardcoded `DS-strategy` with `$GOVERNANCE_DIR` (CI smoke-test fix).
- **#38** `verify/SKILL.md` — add explicit `verification_class → model` mapping table.
- **#39** `update.sh` — propagate `.claude/scripts/` to workspace (so `load-extensions.sh` is shipped).
- **#40** `notify.sh` — make `TEMPLATES_DIR` overridable via env (fixes silent Telegram skip).

Each commit closes one issue. Minimal one-line/few-line fixes per the proposed solutions in each issue body.

## Test plan

- [ ] `update.sh` upgrade-test (.claude/scripts/load-extensions.sh present in workspace after run)
- [ ] CI smoke-test (no literal `/DS-strategy/` in runtime when `GOVERNANCE_DIR` overridden)
- [ ] `notify.sh strategist day-plan` succeeds with `TEMPLATES_DIR=$IWE_RUNTIME_TEMPLATES`
- [ ] Sub-agent verify routes Haiku for `trivial`, Sonnet for `closed-loop`/`open-loop`, Opus for `problem-framing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)