### PR TITLE
fix(dry-run-gate): sentinel-agnostic discovery (closes #59)

### DIFF
--- a/.claude/hooks/dry-run-gate.sh
+++ b/.claude/hooks/dry-run-gate.sh
@@ -4,7 +4,10 @@
 # WP-265 Ф5.2 (ArchGate v3 — вариант F3 sentinel-only).
 #
 # Назначение: блокировать write-tools при наличии валидного sentinel-файла.
-# Sentinel: /tmp/iwe-dry-run-${CLAUDE_SESSION_ID:-noid}.flag
+# Sentinel: любой файл /tmp/iwe-dry-run-*.flag (sentinel-agnostic).
+# Причина glob-имени: CLAUDE_SESSION_ID не пробрасывается в окружение
+# субагентов, поэтому session-bound имя (iwe-dry-run-${SID}.flag) ненадёжно
+# в самом частом пути smoke-теста. TTL чистит застрявшие sentinel'ы.
 # TTL: 600 секунд (10 минут) от mtime.
 #
 # Принципы:
@@ -21,26 +24,35 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 2
 fi
 
-# SESSION_ID — от Claude Code или fallback
-SID="${CLAUDE_SESSION_ID:-noid}"
-SENTINEL="/tmp/iwe-dry-run-${SID}.flag"
+# Discovery: найти любой sentinel /tmp/iwe-dry-run-*.flag.
+# Не привязываемся к CLAUDE_SESSION_ID — он не пробрасывается в субагентов.
+shopt -s nullglob
+SENTINELS=( /tmp/iwe-dry-run-*.flag )
+shopt -u nullglob
 
-# Если sentinel не существует — dry-run неактивен, allow всё
-[ ! -f "$SENTINEL" ] && exit 0
+# Ни одного sentinel — dry-run неактивен, allow всё
+[ ${#SENTINELS[@]} -eq 0 ] && exit 0
 
-# TTL: проверить mtime, удалить и allow если старше 600s
+# Найти первый не-истёкший sentinel; устаревшие удалить попутно.
 NOW=$(date +%s)
-case "$(uname)" in
-    Darwin) MTIME=$(stat -f %m "$SENTINEL" 2>/dev/null) ;;
-    *)      MTIME=$(stat -c %Y "$SENTINEL" 2>/dev/null) ;;
-esac
-if [ -n "$MTIME" ]; then
+SENTINEL=""
+for f in "${SENTINELS[@]}"; do
+    case "$(uname)" in
+        Darwin) MTIME=$(stat -f %m "$f" 2>/dev/null) ;;
+        *)      MTIME=$(stat -c %Y "$f" 2>/dev/null) ;;
+    esac
+    [ -z "$MTIME" ] && continue
     AGE=$((NOW - MTIME))
     if [ "$AGE" -gt 600 ]; then
-        rm -f "$SENTINEL" 2>/dev/null
-        exit 0
+        rm -f "$f" 2>/dev/null
+    else
+        SENTINEL="$f"
+        break
     fi
-fi
+done
+
+# Все sentinel'ы оказались устаревшими и удалены — dry-run неактивен.
+[ -z "$SENTINEL" ] && exit 0
 
 # Прочитать tool_name и tool_input из stdin
 INPUT=$(cat)


### PR DESCRIPTION
## Summary

Fixes the sentinel-mismatch bug reported in #59. `CLAUDE_SESSION_ID` is not propagated into subagent envs, so the session-bound sentinel name (`iwe-dry-run-${SID}.flag`) was unreachable from the most common smoke-test path: parent agent creates the sentinel with the real SID, subagent's hook falls back to `SID=noid`, finds no matching file, lets writes through.

This PR implements alternative **F2** from the issue (sentinel-agnostic discovery) — the simplest of the three options and the one preferred in the bug report.

## Changes

`.claude/hooks/dry-run-gate.sh`:
- Replaces `SID="${CLAUDE_SESSION_ID:-noid}"` + single-file lookup with a `nullglob` over `/tmp/iwe-dry-run-*.flag`.
- TTL pruning extended to walk all matched files: expired sentinels are removed along the way, the first non-expired one is selected and used for blocking. Singleton-flag invariant preserved.
- Header docstring updated to describe the new sentinel naming.

Net: +27 / −15 LOC, single file touched.

## Local verification

7-case smoke matrix passed (run on Linux/WSL2, bash 5):

| # | Setup | Tool | Expected | Got |
|---|---|---|---|---|
| 1 | No sentinel | Edit | allow (0) | ✅ |
| 2 | Fresh sentinel | Edit | block (2) | ✅ |
| 3 | Fresh sentinel | Bash `ls` | allow (0) | ✅ |
| 4 | Fresh sentinel | Bash `git commit` | block (2) | ✅ |
| 5 | Mixed fresh + stale | Edit | block (2) — fresh wins | ✅ |
| 6 | Only stale (>600s) | Edit | allow (0) + stale removed | ✅ |
| 7 | Fresh sentinel | Empty tool_name | allow (0) — existing | ✅ |

## Acceptance test (downstream)

Re-run `/audit-installation` after the fix lands and `update.sh` propagates. Section 6 (smoke-test) should report:

> Block on write step after successful read steps → ✅ (read-logic works, expected smoke-test behavior)

instead of the current:

> hook не сработал — CLAUDE_SESSION_ID not set → SID=noid → sentinel mismatch

## Trade-offs considered

- **F1 (propagate SID):** harness-level change, may be impossible from the hook layer.
- **F2 (this PR):** trivial patch, no harness dependency. Cannot distinguish parallel dry-runs across sessions, but the contract assumes singleton-flag — acceptable.
- **F3 (fail-closed on empty SID):** false positives in normal subagent work if a stale sentinel exists.

Discovered via the `/audit-installation` skill smoke-test on 2026-05-09. Bug report kept downstream in the user's private governance repo (`DS-strategy/inbox/bugs/bug-2026-05-09-dry-run-gate-sid-fallback.md`), inlined into #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)