### PR TITLE
fix(day-close): portability — HOME_SLUG + rsync --delete

### DIFF
--- a/scripts/day-close.sh
+++ b/scripts/day-close.sh
@@ -18,7 +18,10 @@ set -euo pipefail
 WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/IWE}"
 GOVERNANCE_REPO="${GOVERNANCE_REPO:-${IWE_GOVERNANCE_REPO:-DS-strategy}}"
 DS_STRATEGY="$WORKSPACE_DIR/$GOVERNANCE_REPO"
-MEMORY_SRC="$HOME/.claude/projects/-Users-$(whoami)-IWE/memory"
+# Slug = $HOME с '/' → '-' (macOS: /Users/x → -Users-x; Linux/WSL: /home/x → -home-x).
+# Переопределить можно через env IWE_MEMORY_SRC (например, для нестандартного $HOME).
+HOME_SLUG=$(echo "$HOME" | tr '/' '-')
+MEMORY_SRC="${IWE_MEMORY_SRC:-$HOME/.claude/projects/${HOME_SLUG}-IWE/memory}"
 EXOCORTEX_DST="$DS_STRATEGY/exocortex"
 # MCP reindex — опциональный компонент (WP-187 iwe-knowledge Gateway заменяет локальный knowledge-mcp).
 # Переопределить путь можно через env IWE_SELECTIVE_REINDEX.

--- a/scripts/day-close.sh
+++ b/scripts/day-close.sh
@@ -61,19 +61,27 @@ do_backup() {
 
   mkdir -p "$EXOCORTEX_DST"
 
-  local count=0
-  for f in "$MEMORY_SRC"/*.md "$MEMORY_SRC"/*.yaml "$MEMORY_SRC"/*.yml; do
-    [ -f "$f" ] || continue
-    cp "$f" "$EXOCORTEX_DST/"
-    count=$((count + 1))
-  done
+  # One-time cleanup: legacy nested directory left over from a deprecated recursive-backup prompt.
+  if [ -d "$EXOCORTEX_DST/memory" ]; then
+    warn "  Removing legacy nested directory: $EXOCORTEX_DST/memory"
+    rm -rf "$EXOCORTEX_DST/memory"
+  fi
+
+  # Mirror *.md/*.yaml/*.yml from auto-memory; --delete prunes files removed upstream.
+  # CLAUDE.md is excluded so the workspace copy below isn't deleted by --delete.
+  rsync -a --delete \
+    --exclude='CLAUDE.md' \
+    --include='*.md' --include='*.yaml' --include='*.yml' \
+    --exclude='*' \
+    "$MEMORY_SRC/" "$EXOCORTEX_DST/"
 
   if [ -f "$WORKSPACE_DIR/CLAUDE.md" ]; then
     cp "$WORKSPACE_DIR/CLAUDE.md" "$EXOCORTEX_DST/CLAUDE.md"
-    count=$((count + 1))
   fi
 
-  log "  Скопировано: $count файлов → $EXOCORTEX_DST/"
+  local count
+  count=$(find "$EXOCORTEX_DST" -maxdepth 1 -type f \( -name '*.md' -o -name '*.yaml' -o -name '*.yml' \) | wc -l | tr -d ' ')
+  log "  Синхронизировано: $count файлов → $EXOCORTEX_DST/"
 }
 
 # --- Шаг 2: Knowledge-MCP reindex ---


### PR DESCRIPTION
## Summary

`scripts/day-close.sh` had two related bugs in the `do_backup()` step:

1. **`MEMORY_SRC` hard-coded the macOS path prefix `-Users-$(whoami)`** — on Linux/WSL Claude Code derives the project slug differently (`/home/natty` → `-home-natty`), so backup fails with `Memory source not found: …-Users-…`.
2. **`do_backup()` used a `cp` loop (additive)** — files removed from auto-memory linger in `exocortex/` indefinitely (zombie copies; in my repo ~20 stale files survived 2-3 weeks).

This PR fixes both in two focused commits on one feature branch.

## Commits

### `fix(day-close): portable MEMORY_SRC path via HOME_SLUG`

Replace the hard-coded macOS prefix with `$HOME | tr '/' '-'` so the slug is derived dynamically on both macOS and Linux/WSL. Allow override via env `IWE_MEMORY_SRC` for non-standard `$HOME` layouts.

```bash
# Before
MEMORY_SRC="$HOME/.claude/projects/-Users-$(whoami)-IWE/memory"

# After
HOME_SLUG=$(echo "$HOME" | tr '/' '-')
MEMORY_SRC="${IWE_MEMORY_SRC:-$HOME/.claude/projects/${HOME_SLUG}-IWE/memory}"
```

### `fix(day-close): prune stale backup files via rsync --delete`

Replace the `cp` loop with `rsync -a --delete` — the backup becomes a true mirror. Filter rules preserve the workspace `CLAUDE.md` copy that's written separately:

```bash
rsync -a --delete \
  --exclude='CLAUDE.md' \
  --include='*.md' --include='*.yaml' --include='*.yml' \
  --exclude='*' \
  "$MEMORY_SRC/" "$EXOCORTEX_DST/"
```

Also: one-time cleanup of `exocortex/memory/` — a legacy nested directory left over from an older recursive-backup prompt. The current script never creates nesting, so any pre-existing nested directory is safe to remove. Cleanup is idempotent (no-op after the first run).

## Test plan

Tested on WSL2 Ubuntu (`$HOME=/home/natty`):

- [x] Fix 1 alone: `bash scripts/day-close.sh --backup` → `backup=ok` (was failing on Linux before)
- [x] Fix 2: stale files in `exocortex/` removed on first run
- [x] Fix 2: legacy nested `exocortex/memory/` removed on first run, no warning on second run (idempotent)
- [x] CLAUDE.md preserved across runs (workspace copy not pruned by `--delete`)
- [x] File count consistent: 31 from auto-memory + 1 CLAUDE.md = 32 files

Не тестировал на macOS — `HOME_SLUG=$(echo "/Users/natty" | tr '/' '-')` → `-Users-natty`, идентично прежнему хардкоду, поэтому поведение macOS должно сохраниться. Был бы признателен за подтверждение от пользователя на macOS перед merge.

## Closes

Two local bug reports in my governance repo:

- `bug-2026-05-11-day-close-backup-macos-path.md` (severity: medium)
- `bug-2026-05-14-day-close-stale-backup-files.md` (severity: low)