### PR TITLE
feat: recurring Telegram reminders (WP-024, complements S-44)

### DIFF
--- a/docs/tg-recurring-reminders.md
+++ b/docs/tg-recurring-reminders.md
@@ -1,0 +1,120 @@
+# Telegram-напоминания: recurring канал
+
+> **see** CLAUDE.md Правило 8 (S-44), WP-024
+> **Дополняет** `send_telegram_message` (MCP) — этот канал для ad-hoc; LaunchAgent — для повторяющихся.
+
+## Зачем
+
+S-44 (`send_telegram_message` с `schedule_at`) покрывает разовые напоминания из сессии Claude
+(«напомни через 3 часа Y»). Но MCP-инструменты работают только пока есть сессия — для
+повторяющихся напоминаний по расписанию (cron-аналог) нужна system-level инфраструктура.
+
+Этот канал = bash-скрипт `tg-notify.sh` + macOS LaunchAgent.
+
+## Установка
+
+### 1. Создать бота и получить секреты
+
+1. В Telegram: [@BotFather](https://t.me/BotFather) → `/newbot` → имя → handle → получить токен.
+2. Написать своему боту `/start` (без этого Bot API вернёт Forbidden).
+3. В Telegram: [@userinfobot](https://t.me/userinfobot) → получить `chat_id`.
+
+### 2. Записать секреты
+
+```bash
+mkdir -p ~/.config/aist
+cat > ~/.config/aist/env <<EOF
+TELEGRAM_BOT_TOKEN=<токен>
+TELEGRAM_CHAT_ID=<chat_id>
+EOF
+chmod 600 ~/.config/aist/env
+```
+
+> Тот же `env`-файл используется существующим dispatcher'ом ролей (`roles/synchronizer/scripts/notify.sh`) — секреты пере-используются.
+
+### 3. Установить LaunchAgent-ы
+
+```bash
+bash scripts/install-tg-reminders.sh
+```
+
+Скрипт:
+1. Проверяет `~/.config/aist/env`.
+2. TZ sanity check: сравнивает macOS system TZ с `user_timezone` из `params.yaml` (если есть).
+3. Подставляет абсолютный путь `tg-notify.sh` в plist-шаблоны (placeholder `__TG_NOTIFY_PATH__`).
+4. Копирует обработанные plist в `~/Library/LaunchAgents/`.
+5. `launchctl load` каждый агент.
+
+### 4. Тест
+
+```bash
+# Прямой тест отправки
+bash scripts/tg-notify.sh "test message"
+
+# Проверить что агенты загружены
+launchctl list | grep iwe.tg-reminder
+
+# Логи
+tail -f /tmp/iwe.tg-reminder.day-plan.log /tmp/iwe.tg-reminder.day-plan.err
+```
+
+## Что устанавливается
+
+| Label | Когда срабатывает | Сообщение |
+|-------|-------------------|-----------|
+| `iwe.tg-reminder.day-plan` | будни 10:30 | План дня: собери ТОС и приоритеты по РП, открой /day-open |
+| `iwe.tg-reminder.day-close` | будни 22:00 | Пора закрывать день: /day-close |
+| `iwe.tg-reminder.week-close` | воскресенье 22:30 | Пора закрывать неделю: /week-close |
+
+Время в plist — **macOS local time**. См. ниже про TZ.
+
+## Часовые пояса
+
+LaunchAgent `StartCalendarInterval` использует local TZ системы. То есть:
+
+- Mac на TZ `Europe/Moscow` → 10:30 = 10:30 МСК.
+- Mac на TZ `America/Los_Angeles` → 10:30 = 10:30 PDT.
+
+При переезде между TZ:
+1. Поменять системный TZ в macOS: System Settings → Date & Time → Time Zone
+   (или: `sudo systemsetup -settimezone "America/Los_Angeles"`).
+2. (Опционально) Обновить `params.yaml`:
+   ```yaml
+   user_timezone: America/Los_Angeles
+   ```
+   Это нужно только для TZ sanity check в `install-tg-reminders.sh` — реальное расписание определяется системным TZ.
+3. LaunchAgent автоматически подхватит новый TZ при следующем срабатывании, перезагружать не надо.
+
+## Изменить расписание/текст
+
+Редактировать соответствующий plist в `setup/optional/iwe.tg-reminder.*.plist`:
+- `StartCalendarInterval` — массив словарей с `Weekday`/`Hour`/`Minute`.
+   `Weekday`: 0 (или 7) = Вс, 1 = Пн, ..., 6 = Сб.
+- `ProgramArguments` третий аргумент — текст сообщения.
+
+После правки: `bash scripts/install-tg-reminders.sh` (он сначала unload потом load).
+
+## Снять
+
+```bash
+bash scripts/install-tg-reminders.sh --unload
+```
+
+## Связь с S-44
+
+| Случай | Канал |
+|--------|-------|
+| «напомни через 3 часа Y» из сессии Claude | MCP `send_telegram_message(schedule_at=...)` — S-44 |
+| «каждые будни в 10:30 X» | этот канал (LaunchAgent + tg-notify.sh) |
+| Уведомление от роли (Стратег, Extractor) | `roles/synchronizer/scripts/notify.sh` — отдельная инфраструктура |
+
+Три канала, одно `~/.config/aist/env`, один Telegram-бот.
+
+## Troubleshooting
+
+**Сообщение не приходит.** Проверь `/tmp/iwe.tg-reminder.<label>.err` — там curl ошибка.
+Частые причины: токен/chat_id неверные, бот не запущен (`/start`), HTTP-proxy не настроен (`TELEGRAM_PROXY` в env).
+
+**LaunchAgent не срабатывает.** `launchctl list | grep iwe.tg-reminder` — должен показывать PID `-` (загружен, не запущен сейчас). Если нет — `launchctl load -w ~/Library/LaunchAgents/<label>.plist`.
+
+**Сработало не в то время.** Проверь macOS system TZ: `date` (последние буквы — `MSK`/`PDT`/...). Если не тот — изменить в System Settings.

--- a/scripts/install-tg-reminders.sh
+++ b/scripts/install-tg-reminders.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# install-tg-reminders.sh — устанавливает LaunchAgent-ы для повторяющихся Telegram-напоминаний
+# see WP-024, docs/tg-recurring-reminders.md
+#
+# Что делает:
+#   1. Проверяет ~/.config/aist/env (нужны TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID).
+#   2. TZ sanity check: macOS system TZ vs params.yaml user_timezone.
+#   3. Подставляет абсолютный путь tg-notify.sh в plist (placeholder __TG_NOTIFY_PATH__).
+#   4. Копирует plist-ы в ~/Library/LaunchAgents/ и launchctl load.
+#
+# Использование:
+#   bash install-tg-reminders.sh           # установить все 3
+#   bash install-tg-reminders.sh --unload  # снять все
+#   bash install-tg-reminders.sh --dry-run # показать что будет
+#
+# Напоминания, которые ставятся (можно отредактировать plist перед установкой):
+#   - day-plan:   будни 10:30 — план дня
+#   - day-close:  будни 22:00 — закрытие дня
+#   - week-close: воскресенье 22:30 — закрытие недели
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FMT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_PLIST_DIR="$FMT_ROOT/setup/optional"
+TARGET_DIR="$HOME/Library/LaunchAgents"
+TG_NOTIFY_PATH="$SCRIPT_DIR/tg-notify.sh"
+ENV_FILE="$HOME/.config/aist/env"
+
+REMINDER_LABELS=(
+  "iwe.tg-reminder.day-plan"
+  "iwe.tg-reminder.day-close"
+  "iwe.tg-reminder.week-close"
+)
+
+MODE="${1:-install}"
+
+# === TZ sanity check ===
+if [ -f "$FMT_ROOT/params.yaml" ]; then
+  expected_tz=$(grep -E '^user_timezone:' "$FMT_ROOT/params.yaml" 2>/dev/null | sed -E 's/user_timezone: *//; s/ *#.*//; s/^"//; s/"$//' || true)
+  if [ -n "${expected_tz:-}" ]; then
+    current_tz=$(readlink /etc/localtime 2>/dev/null | sed 's:.*/zoneinfo/::' || echo "unknown")
+    if [ "$expected_tz" != "$current_tz" ]; then
+      echo "⚠️  TZ mismatch: macOS = '$current_tz', params.yaml user_timezone = '$expected_tz'"
+      echo "    LaunchAgent triggers fire по macOS local time. Сначала синхронизируй TZ:"
+      echo "    System Settings → Date & Time → Time Zone (или: sudo systemsetup -settimezone '$expected_tz')"
+      echo ""
+    fi
+  fi
+fi
+
+# === Unload mode ===
+if [ "$MODE" = "--unload" ]; then
+  for label in "${REMINDER_LABELS[@]}"; do
+    target="$TARGET_DIR/${label}.plist"
+    if [ -f "$target" ]; then
+      launchctl unload "$target" 2>/dev/null || true
+      rm -f "$target"
+      echo "✓ unloaded $label"
+    else
+      echo "  $label не установлен"
+    fi
+  done
+  exit 0
+fi
+
+# === Pre-flight checks for install ===
+if [ ! -f "$ENV_FILE" ]; then
+  cat >&2 <<EOF
+ERROR: $ENV_FILE not found.
+
+Создай его с переменными:
+  TELEGRAM_BOT_TOKEN=<токен от @BotFather>
+  TELEGRAM_CHAT_ID=<твой chat_id от @userinfobot>
+
+Затем chmod 600 $ENV_FILE.
+Подробнее: docs/tg-recurring-reminders.md
+EOF
+  exit 1
+fi
+
+# Sanity-check token + chat_id are present
+# shellcheck disable=SC1090
+( set +u; source "$ENV_FILE"; [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ] ) || {
+  echo "ERROR: TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set in $ENV_FILE" >&2
+  exit 1
+}
+
+if [ ! -f "$TG_NOTIFY_PATH" ]; then
+  echo "ERROR: tg-notify.sh not found at $TG_NOTIFY_PATH" >&2
+  exit 1
+fi
+chmod +x "$TG_NOTIFY_PATH"
+
+mkdir -p "$TARGET_DIR"
+
+# === Install ===
+for label in "${REMINDER_LABELS[@]}"; do
+  src="$SOURCE_PLIST_DIR/${label}.plist"
+  if [ ! -f "$src" ]; then
+    echo "ERROR: source plist not found: $src" >&2
+    exit 1
+  fi
+  target="$TARGET_DIR/${label}.plist"
+
+  # Substitute __TG_NOTIFY_PATH__ with absolute path
+  sed "s|__TG_NOTIFY_PATH__|$TG_NOTIFY_PATH|g" "$src" > "$target"
+
+  if [ "$MODE" = "--dry-run" ]; then
+    echo "[dry-run] would install: $target"
+    continue
+  fi
+
+  launchctl unload "$target" 2>/dev/null || true
+  launchctl load "$target"
+  echo "✓ installed $label"
+done
+
+if [ "$MODE" != "--dry-run" ]; then
+  echo ""
+  echo "Готово. Проверь: launchctl list | grep iwe.tg-reminder"
+  echo "Тест отправки: bash $TG_NOTIFY_PATH 'test'"
+  echo "Логи: /tmp/iwe.tg-reminder.*.log /tmp/iwe.tg-reminder.*.err"
+fi

--- a/scripts/tg-notify.sh
+++ b/scripts/tg-notify.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# tg-notify.sh — отправка произвольного сообщения в Telegram (для recurring-напоминаний)
+# see WP-024, complements CLAUDE.md Правило 8 (S-44)
+#
+# Назначение: этот канал используется LaunchAgent-ами для повторяющихся
+# напоминаний по расписанию (cron-аналог). Для ad-hoc напоминаний
+# из сессии Claude используй MCP-инструмент `send_telegram_message`
+# с параметром `schedule_at` (см. CLAUDE.md Правило 8).
+#
+# Использование:
+#   tg-notify.sh "Текст сообщения"
+#
+# Требует ~/.config/aist/env с переменными:
+#   TELEGRAM_BOT_TOKEN=...
+#   TELEGRAM_CHAT_ID=...
+#   (опционально) TELEGRAM_PROXY=http://...
+set -euo pipefail
+
+ENV_FILE="${HOME}/.config/aist/env"
+if [ ! -f "$ENV_FILE" ]; then
+  echo "ERROR: $ENV_FILE not found. Configure TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID." >&2
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+  echo "ERROR: TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set in $ENV_FILE" >&2
+  exit 1
+fi
+
+MSG="${1:?usage: tg-notify.sh \"text\"}"
+
+curl_args=(-sS --fail)
+if [ -n "${TELEGRAM_PROXY:-}" ]; then
+  curl_args+=(--proxy "$TELEGRAM_PROXY")
+elif [ -n "${ALL_PROXY:-}" ]; then
+  curl_args+=(--proxy "$ALL_PROXY")
+fi
+
+curl "${curl_args[@]}" -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -d chat_id="${TELEGRAM_CHAT_ID}" \
+  --data-urlencode "text=${MSG}" \
+  -d parse_mode="HTML" \
+  -d disable_web_page_preview="true" >/dev/null
+
+echo "[tg-notify] sent: ${MSG:0:60}"

--- a/setup/optional/iwe.tg-reminder.day-close.plist
+++ b/setup/optional/iwe.tg-reminder.day-close.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>iwe.tg-reminder.day-close</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>__TG_NOTIFY_PATH__ "Пора закрывать день: /day-close"</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>0</integer></dict>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/tmp/iwe.tg-reminder.day-close.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/iwe.tg-reminder.day-close.err</string>
+</dict>
+</plist>

--- a/setup/optional/iwe.tg-reminder.day-plan.plist
+++ b/setup/optional/iwe.tg-reminder.day-plan.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>iwe.tg-reminder.day-plan</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>__TG_NOTIFY_PATH__ "План дня: собери ТОС и приоритеты по РП, открой /day-open"</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>10</integer><key>Minute</key><integer>30</integer></dict>
+        <dict><key>Weekday</key><integer>2</integer><key>Hour</key><integer>10</integer><key>Minute</key><integer>30</integer></dict>
+        <dict><key>Weekday</key><integer>3</integer><key>Hour</key><integer>10</integer><key>Minute</key><integer>30</integer></dict>
+        <dict><key>Weekday</key><integer>4</integer><key>Hour</key><integer>10</integer><key>Minute</key><integer>30</integer></dict>
+        <dict><key>Weekday</key><integer>5</integer><key>Hour</key><integer>10</integer><key>Minute</key><integer>30</integer></dict>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/tmp/iwe.tg-reminder.day-plan.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/iwe.tg-reminder.day-plan.err</string>
+</dict>
+</plist>

--- a/setup/optional/iwe.tg-reminder.week-close.plist
+++ b/setup/optional/iwe.tg-reminder.week-close.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>iwe.tg-reminder.week-close</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>__TG_NOTIFY_PATH__ "Пора закрывать неделю: /week-close"</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Weekday</key><integer>0</integer><key>Hour</key><integer>22</integer><key>Minute</key><integer>30</integer></dict>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/tmp/iwe.tg-reminder.week-close.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/iwe.tg-reminder.week-close.err</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Контекст

S-44 (Правило 8 в CLAUDE.md, промотировано 17 мая) описывает Telegram-напоминания через MCP-инструмент `send_telegram_message` с `schedule_at`. Это покрывает **ad-hoc** напоминания из сессии Claude («напомни через 3 часа Y»), но MCP-инструменты доступны только пока есть сессия — для **повторяющихся** напоминаний по расписанию (cron-аналог) нужна system-level инфраструктура.

Этот PR её добавляет: bash `tg-notify.sh` + macOS LaunchAgent.

Связан с WP-024 «Telegram push-канал IWE-напоминаний» (DS-strategy/inbox/WP-024-tg-push-channel.md) у пилота LariKing77. Изначальный WP-024 предполагал личную инфру в `~/IWE/bin/` — open-question был «promote в шаблон через STAGING.md». Этот PR закрывает этот open-question напрямую.

## Что добавлено

| Файл | Назначение |
|------|-----------|
| `scripts/tg-notify.sh` | curl-обёртка, читает `~/.config/aist/env` (тот же файл, что использует `roles/synchronizer/scripts/notify.sh` — секреты переиспользуются) |
| `scripts/install-tg-reminders.sh` | installer: TZ sanity check + path substitution + `launchctl load/unload`. Modes: `install` / `--dry-run` / `--unload` |
| `setup/optional/iwe.tg-reminder.day-plan.plist` | LaunchAgent: будни 10:30 → «План дня: собери ТОС и приоритеты по РП, открой /day-open» |
| `setup/optional/iwe.tg-reminder.day-close.plist` | будни 22:00 → «Пора закрывать день: /day-close» |
| `setup/optional/iwe.tg-reminder.week-close.plist` | воскресенье 22:30 → «Пора закрывать неделю: /week-close» |
| `docs/tg-recurring-reminders.md` | установка, TZ-handling, troubleshooting |

Plist-ы используют placeholder `__TG_NOTIFY_PATH__`, который installer заменяет на абсолютный путь — это делает шаблон портируемым.

## Часовые пояса

LaunchAgent `StartCalendarInterval` использует macOS local TZ. При переезде между TZ (актуальный кейс пилота: переезд в LA с 22 мая) — пользователь меняет macOS system TZ через System Settings, plist-ы автоматически подхватывают. Опциональный `user_timezone` в `params.yaml` используется только installer'ом для sanity-warning, реальное расписание определяется системой.

## Проверено локально

- `bash -n scripts/*.sh` → syntax OK
- `plutil -lint setup/optional/iwe.tg-reminder.*.plist` → all OK
- `bash scripts/install-tg-reminders.sh --dry-run` → корректно требует `~/.config/aist/env`, показывает что бы установилось

End-to-end smoke (curl reaches Telegram, LaunchAgent fires в указанное время) — пилот сделает после merge при настройке секретов.

## Связь с другими каналами Telegram в шаблоне

| Случай | Канал |
|--------|-------|
| Ad-hoc из сессии Claude | MCP `send_telegram_message(schedule_at=...)` — S-44 |
| Повторяющиеся по расписанию | этот PR (LaunchAgent + `tg-notify.sh`) |
| Уведомления от ролей (Стратег/Extractor) | `roles/synchronizer/scripts/notify.sh` |

Три канала, один `~/.config/aist/env`, один Telegram-бот.

## Out-of-scope (для последующих РП)

- Google Calendar события → Telegram автоматически
- Recurring через MCP-инструмент (если в `send_telegram_message` добавится cron-параметр — этот канал можно будет упростить или убрать)

🤖 Generated with [Claude Code](https://claude.com/claude-code)