### PR TITLE
fix(skill): quote pack-new description (Pi YAML parser strict mode)

### DIFF
--- a/.claude/skills/pack-new/SKILL.md
+++ b/.claude/skills/pack-new/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pack-new
-description: Создание нового Pack — guided flow по SPF: выбор домена, имя Pack, scaffold структуры, дорожная карта наполнения.
+description: "Создание нового Pack — guided flow по SPF: выбор домена, имя Pack, scaffold структуры, дорожная карта наполнения."
 argument-hint: "[область знания или домен]"
 ---
 


### PR DESCRIPTION
## Summary

- `pack-new/SKILL.md` frontmatter `description` is unquoted and contains a `:` after «SPF» → strict YAML parsers (e.g. Pi `@earendil-works/pi-coding-agent` v0.74.1) raise «Nested mappings are not allowed in compact mappings»
- Claude Code parser tolerates this; Pi does not
- Fix: wrap value in `"..."` (same style as `extend/SKILL.md`)

## Detection

During WP-47 Ф2 smoke (installing IWE-on-Pi extension `pi-extension-iwe-claude-native`) on 2026-05-22. Pi failed to load the skill at startup. All other 21 skills parsed fine.

## Test plan

- [x] YAML parses correctly after fix (`python3 yaml.safe_load` confirms `description` is a string with the same value)
- [x] No behavior change — `description` content identical, only quoting added
- [x] Sister skills swept: only `pack-new` had this issue; `extend` already quoted; others have no `:` in description

🤖 Generated with [Claude Code](https://claude.com/claude-code)