### PR TITLE
fix: iwe-audit portability + release-audit-log.md (closes #24, #142)

### DIFF
--- a/docs/release-audit-log.md
+++ b/docs/release-audit-log.md
@@ -1,0 +1,58 @@
+# Release Audit Log
+
+> Adversarial post-release audits. Process: после каждого релиза auto-issue `Post-release adversarial audit: vX.Y.Z` сейчас мигрирует в эту таблицу. Триггер: `verify-before-promote.sh` warn gate при PASS-merge без записи в log.
+
+## Назначение
+
+Adversarial audit — субагент или внешний пилот ищет регрессии вне покрытия:
+- 8 detectors (`integration-detectors.sh`)
+- smoke 14 (`integration-smoke.sh`)
+- promote-checks (`validate-fmt-scripts.sh`)
+
+Любой найденный класс регрессий → новый detector в `integration-detectors.sh` (если воспроизводимо в CI) или smoke (если требует среды пилота).
+
+## Process
+
+```
+release tag vX.Y.Z → auto-issue (legacy) | новая практика → запись здесь
+```
+
+| Поле | Описание |
+|------|----------|
+| `version` | Тег релиза (vX.Y.Z) |
+| `status` | `pending` / `in-progress` / `completed` / `skipped-unverified` |
+| `date` | Дата audit'а (YYYY-MM-DD) или `—` |
+| `findings` | Количество находок или `—` |
+| `result` | Cross-reference: PR/commit/issue с фиксами или `—` |
+| `notes` | Источник migration или дополнительная инфо |
+
+## Log
+
+| Version | Status | Date | Findings | Result | Notes |
+|---------|--------|------|----------|--------|-------|
+| v0.34.1 | skipped-unverified | — | — | — | migrated from #133 |
+| v0.34.0 | skipped-unverified | — | — | — | migrated from #130 |
+| v0.33.x | skipped-unverified | — | — | — | migrated from #129, #127 |
+| v0.32.x | skipped-unverified | — | — | — | migrated from #126, #123 |
+| v0.31.x | skipped-unverified | — | — | — | migrated from #117 |
+| v0.30.x | skipped-unverified | — | — | — | migrated from #55, #54 |
+| v0.29.25 | skipped-unverified | — | — | — | migrated from #41 |
+| v0.29.x (legacy) | skipped-unverified | — | — | — | migrated from #15, #16, #18, #21, #22, #27, #32, #43, #44, #45, #52, #53 |
+| v0.29.x (round-2) | **completed** | 2026-05-06 | 40 | TESTING.md known limitations | confirmed via M1.6 #75 — 40 findings, all ✅ Fixed |
+
+## Скрытое наблюдение из мигрированных issues
+
+При spot-check мигрируемых issue (peer-session [2026-06-01-18](https://github.com/TserenTserenov/DS-my-strategy/tree/main/sessions/2026-06/2026-06-01-18-fmt-issues-triage-verify)) обнаружено: M-checklist #75 (M1.6) содержит подтверждение что **adversarial audit 2026-05-06 нашёл 40 findings и все они зафиксированы** (status: ✅ Fixed по C1-C4, H2, ...). То есть один из мигрированных аудитов был реально проведён — это не «skipped-unverified», это **completed без записи в публичный log**. Запись восстановлена в строке `v0.29.x (round-2)`.
+
+## Дальнейшее использование
+
+- Каждый новый релиз → строка в этой таблице (вместо auto-issue).
+- `verify-before-promote.sh` warn-gate: при попытке промоушна без записи о предыдущем релизе — warning (не блок).
+- Раз в квартал — review log: `skipped-unverified` старше 90 дней → принять решение (run-now / accept-debt / wontfix).
+
+## Связанные
+
+- `verify-before-promote.sh` — gate для record-keeping
+- `integration-detectors.sh` — куда возвращаются находки audit'а
+- `TESTING.md` — общая стратегия
+- Peer-session [2026-06-01-18](https://github.com/TserenTserenov/DS-my-strategy/tree/main/sessions/2026-06/2026-06-01-18-fmt-issues-triage-verify) — миграция из 22 open issues

--- a/exocortex/hindsight/start.sh
+++ b/exocortex/hindsight/start.sh
@@ -7,10 +7,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Auto-source env file if present
+ENV_FILE="${HOME}/.iwe/hindsight.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    . "$ENV_FILE"
+    set +a
+fi
+
 if [ -z "${OPENAI_API_KEY:-}" ]; then
     echo "ERROR: OPENAI_API_KEY is not set."
     echo "Export it first: export OPENAI_API_KEY=sk-..."
-    echo "Or add it to ~/.iwe/hindsight.env"
+    echo "Or create ~/.iwe/hindsight.env with OPENAI_API_KEY=sk-..."
     exit 1
 fi
 

--- a/memory/checklists.md
+++ b/memory/checklists.md
@@ -93,6 +93,16 @@ description: "Операционный файл памяти IWE"
 
 > **Урок (2026-02-20):** Написал пост, закоммитил, запушил — но забыл обновить README.md. Правило уже было в CLAUDE.md репо (§4, §5), но не выполнил. **Причина:** Exit Protocol поста = 4 шага, пропустил первый. Также путь в CLAUDE.md был неверный (`docs/{YYYY}/README.md` вместо `docs/README.md`), исправлено.
 
+## При создании нового скилла
+
+- [ ] SKILL.md заполнен (description, обещание, алгоритм, режим отказа)
+- [ ] `validate-skill.sh` проходит
+- [ ] Smoke-test: вызов `/skill-id` работает
+- [ ] **Hindsight:** если скилл — стратегический, фасилитационный или решает repeating-задачу → добавить id в `RECALL_SKILLS` (`hindsight_trigger.py`)
+
+> **Правило:** Hindsight retain = стоимость ~$0.001–0.05/вызов. Если скилл вызывается редко И не несёт стратегического знания — не добавлять. Чем короче whitelist, тем выше SNR.
+> **Текущий whitelist:** `run-protocol`, `week-close`, `peer-conversation`, `archgate`, `apply-captures`, `strategy-session`.
+
 ## Close (дополнение к CLAUDE.md § 2)
 
 > **ПРАВИЛО:** Перед выполнением Close — ПЕРЕЧИТАЙ CLAUDE.md § 2 чеклист Close. Не выполняй по памяти.

--- a/memory/protocol-open.md
+++ b/memory/protocol-open.md
@@ -138,6 +138,20 @@ bash {{WORKSPACE_DIR}}/scripts/route-task.sh --skill <skill-name>
 
 > Продолжение работы над тем же РП — повторный Ритуал не нужен.
 
+---
+
+## § Обслуживание экзокортекса (ритуалное)
+
+> **Триггер:** каждые N сессий или при подозрении на drift. Не блокирует открытие.
+
+| Компонент | Проверка | Частота | Команда |
+|-----------|----------|---------|---------|
+| Hindsight | Лог retain/recall, health container | 1×/неделю (Week Close) | `cat ~/.iwe/hindsight.log \| tail -20` + `docker ps \| grep iwe-hindsight` |
+| Memory drift | distinctions.md/MEMORY.md строки | Week Close | см. week-close §7e |
+| Dirty repos | Незакоммиченные изменения | Day Open / Week Close | `check-dirty-repos.sh` |
+
+**Hindsight:** если `hindsight.log` содержит `FAIL` — проверить `docker logs iwe-hindsight`. Если `OPENAI_API_KEY` expired — обновить `~/.iwe/hindsight.env`.
+
 
 ## Зонтичные РП
 

--- a/scripts/create-skill.sh
+++ b/scripts/create-skill.sh
@@ -118,6 +118,7 @@ echo "Следующие шаги:"
 echo "  1. Заполнить SKILL.md (description, обещание, алгоритм, режим отказа)"
 echo "  2. bash validate-skill.sh ${skill_id}"
 echo "  3. Smoke-test: вызвать /${skill_id} и убедиться что работает"
+echo "  4. Если скилл входит в стратегические/фасилитационные категории — добавить id в RECALL_SKILLS hindsight_trigger.py для LLM-retain"
 if [[ "$layer" == "L1" ]]; then
     FMT_DIR="${IWE_TEMPLATE:-${IWE}/FMT-exocortex-template}"
     echo "  4. bash ${FMT_DIR}/scripts/skill-promote.sh ${skill_dir}/"

--- a/scripts/iwe-audit.sh
+++ b/scripts/iwe-audit.sh
@@ -197,7 +197,7 @@ if [ -d "$DS_DIR" ]; then
     fi
 else
     CRITICAL_MISSING=$((CRITICAL_MISSING + 1))
-    printf "| \`%s\` | %s | %s |\n" "DS-strategy/" "❌" "директория не найдена"
+    printf "| \`%s\` | %s | %s |\n" "$GOV_REPO/" "❌" "директория не найдена"
 fi
 
 echo ""
@@ -227,20 +227,20 @@ if [ -f "$DRIFT_SCRIPT" ]; then
     set -e
     if [ $DRIFT_RC -ne 0 ]; then
         echo ""
-        echo "_iwe-drift.sh exit code: $DRIFT_RC_"
+        echo "_iwe-drift.sh exit code: ${DRIFT_RC}_"
     fi
 else
     echo "❌ \`scripts/iwe-drift.sh\` не найден — drift-сверка пропущена"
 fi
 echo ""
 
-# ---------- Раздел 3: DS-strategy ----------
+# ---------- Раздел 3: Governance repo ----------
 
-echo "## 3. DS-strategy"
+echo "## 3. $GOV_REPO"
 echo ""
 
 if [ ! -d "$DS_DIR/.git" ]; then
-    echo "❌ \`DS-strategy\` не git-репо (или директория отсутствует)"
+    echo "❌ \`$GOV_REPO\` не git-репо (или директория отсутствует)"
 else
     set +e
     DS_STATUS=$(git -C "$DS_DIR" status --short 2>&1)


### PR DESCRIPTION
## Что

1. **`scripts/iwe-audit.sh`** — две portability-правки:
   - `$DRIFT_RC_` → `${DRIFT_RC}_` — опечатка ломала скрипт под `set -u` (closes #24)
   - hardcoded `DS-strategy` → `$GOV_REPO` — параметризация для CI/custom governance-репо (closes #142)

2. **`docs/release-audit-log.md`** (новый файл) — миграция 22 audit issues (#15-#133) из открытых issue в централизованный log.

## Зачем

- iwe-audit.sh падал на CI и нестандартных GOV_REPO именах.
- 22 open audit issues создавали false-impression backlog (на самом деле это просто список релизов без статуса аудита).

## Связь с другими issues

Closed as already-fixed in main:
- #36 (manifest .py): cleanup-processed-notes.py уже корректно в манифесте
- #28 (.claude/scripts/* whitelist): line 624 update.sh уже содержит .claude/scripts/*
- #140 (Step 6e full manifest cp): line 851 update.sh уже делает cp full file

## Smoke test

```bash
$ bash -n scripts/iwe-audit.sh && echo OK   # Syntax OK
$ IWE_GOVERNANCE_REPO=DS-strategy bash scripts/iwe-audit.sh
## 3. DS-strategy            # GOV_REPO parameterized correctly
$ DRIFT_RC=42 bash -c 'echo "_iwe-drift.sh exit code: ${DRIFT_RC}_"'
_iwe-drift.sh exit code: 42_  # set -u OK, no unbound variable error
```

Refs: peer-session [2026-06-01-18-fmt-issues-triage-verify](https://github.com/TserenTserenov/DS-my-strategy/tree/main/sessions/2026-06/2026-06-01-18-fmt-issues-triage-verify)