### PR TITLE
feat: stale-bot + TG alert env fallback (hardening)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,144 @@
+name: Stale Issues Bot
+
+# routing: github-actions  trigger=cron  deterministic=true
+# Connected to peer-session 2026-06-01-25 (WP-386 hardening).
+#
+# Goals:
+# 1) needs-reproduction: автор не ответил 30d → stale-needs-reproduction → +14d close (autoclose).
+# 2) maintainer-unattended: issue open 14d без любого triaged-* label → stale-unattended (warn only, no close).
+#
+# Anti-pattern guards (peer-consensus Kimi):
+# - keep-alive label = opt-out, никогда не stale
+# - exempt: critical, deadline, roadmap, pinned, triaged-accepted
+# - operations-per-run: 30 (предотвращает comment-spam если 30+ issues станут stale)
+# - remove-stale-when-updated: true (автоматическая отмена при ответе)
+
+on:
+  schedule:
+    - cron: '0 8 * * *'   # daily at 08:00 UTC (11:00 МСК)
+  workflow_dispatch: {}    # manual trigger для тестов
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  stale-needs-reproduction:
+    name: Auto-close needs-reproduction (30d to stale, +14d close)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-labels: 'needs-reproduction'
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: 'stale-needs-reproduction'
+          exempt-issue-labels: 'keep-alive,critical,deadline,roadmap,pinned,triaged-accepted'
+          stale-issue-message: |
+            This issue has been waiting for reproduction info for **30 days** without response from the original reporter.
+
+            Closing automatically in 14 more days if no reply.
+
+            If still relevant — comment with: OS, IWE version (`bash update.sh --check`), reproducing command, expected vs actual behavior.
+
+            To opt out of stale-bot for this issue, apply label `keep-alive`.
+          close-issue-message: |
+            Auto-closed after 44 days without response.
+
+            Reopen with reproduction details if still relevant.
+          operations-per-run: 30
+          remove-stale-when-updated: true
+          ascending: true
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+  stale-unattended:
+    name: Flag unattended issues (14d to stale-unattended, warn-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const STALE_DAYS = 14;
+            const EXEMPT_LABELS = ['keep-alive', 'critical', 'deadline', 'roadmap', 'pinned', 'triaged-accepted', 'stale-needs-reproduction', 'stale-unattended'];
+            const OPS_LIMIT = 30;
+
+            const cutoff = new Date();
+            cutoff.setDate(cutoff.getDate() - STALE_DAYS);
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'created',
+              direction: 'asc',
+              per_page: 100,
+            });
+
+            let ops = 0;
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+              if (ops >= OPS_LIMIT) break;
+
+              const labels = issue.labels.map(l => typeof l === 'string' ? l : l.name);
+
+              if (EXEMPT_LABELS.some(e => labels.includes(e))) continue;
+              if (labels.some(l => l.startsWith('triaged-'))) continue;
+
+              const created = new Date(issue.created_at);
+              if (created > cutoff) continue;
+
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: ['stale-unattended'],
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `This issue has been open for **${STALE_DAYS}+ days** without maintainer triage (no \`triaged-*\` label applied).\n\nFlagging as \`stale-unattended\` for visibility. Maintainer will respond within 1 week per [CONTRIBUTING.md](/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md).\n\nTo opt out: apply label \`keep-alive\`.`,
+                });
+                ops++;
+                console.log(`Flagged #${issue.number} as stale-unattended`);
+              } catch (e) {
+                console.error(`Failed on #${issue.number}: ${e.message}`);
+              }
+            }
+            console.log(`Total flagged: ${ops}`);
+
+  remove-stale-on-triage:
+    name: Remove stale-unattended when triaged label applied
+    runs-on: ubuntu-latest
+    needs: stale-unattended   # sequential ordering: cleanup AFTER apply-pass
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: stale } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'stale-unattended',
+              per_page: 100,
+            });
+
+            for (const issue of stale) {
+              const labels = issue.labels.map(l => typeof l === 'string' ? l : l.name);
+              const hasTriaged = labels.some(l => l.startsWith('triaged-'));
+              if (hasTriaged) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: 'stale-unattended',
+                  });
+                  console.log(`Removed stale-unattended from #${issue.number} (now triaged)`);
+                } catch (e) {
+                  console.error(`Failed to remove stale-unattended from #${issue.number}: ${e.message}`);
+                }
+              }
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,19 @@ Use [GitHub Issues](https://github.com/TserenTserenov/FMT-exocortex-template/iss
 
 Maintainer responds within 1 week, applies a categorization label, and either schedules a fix or marks as `needs-reproduction` / `needs-discussion`.
 
+### Stale & lifecycle
+
+To keep the backlog actionable, a [stale-bot](.github/workflows/stale.yml) runs daily:
+
+- **`needs-reproduction` without reply for 30 days** → labeled `stale-needs-reproduction` with a reminder comment. After **+14 days** without reply (44d total) → auto-closed. Re-open with reproduction details if still relevant.
+- **Any open issue 14+ days without `triaged-*` label** → labeled `stale-unattended` (warn-only, no close). This is a maintainer-side signal: «you missed this one».
+
+**Opt out:** apply `keep-alive` label to any issue where the conversation is active but slow. The bot will skip it.
+
+**Exempt labels (never stale):** `keep-alive`, `critical`, `deadline`, `roadmap`, `pinned`, `triaged-accepted`.
+
+**Notification channel:** if you maintain a fork, you can set `TG_BOT_TOKEN` / `TG_CHAT_ID` (or `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID`) env vars and run `bash scripts/fmt-critical-alert.sh` in your Day Open / Week Close — it'll Telegram you any open `critical` or `deadline` issues. Useful for weekend-P0 detection.
+
 ### Share Your Setup
 
 Show how you use IWE in [GitHub Discussions](https://github.com/TserenTserenov/FMT-exocortex-template/discussions):

--- a/scripts/fmt-critical-alert.sh
+++ b/scripts/fmt-critical-alert.sh
@@ -74,13 +74,55 @@ if ! gh auth status >/dev/null 2>&1; then
 fi
 
 # Запрос issues
+# Note: gh issue list --label "X,Y" применяет AND-логику (issue должен иметь оба label).
+# Нам нужен OR — issue хотя бы с одним из label'ов. Используем gh api repos/.../issues?labels=
+# (REST API также AND) с отдельным запросом per label + jq merge с dedup.
 set +e
-ISSUES_JSON=$(gh issue list -R "$REPO" --state open --label "$LABEL_QUERY" --json number,title,labels,url 2>&1)
-GH_RC=$?
+LABELS_ARRAY=()
+IFS=',' read -ra LABELS_ARRAY <<< "$LABEL_QUERY"
+if [ ${#LABELS_ARRAY[@]} -eq 0 ] || { [ ${#LABELS_ARRAY[@]} -eq 1 ] && [ -z "${LABELS_ARRAY[0]}" ]; }; then
+    echo "Error: --labels is empty" >&2
+    exit 2
+fi
+TMP_JSONS=()
+for label in "${LABELS_ARRAY[@]}"; do
+    tmp=$(mktemp)
+    label_trim=$(echo "$label" | tr -d '[:space:]')
+    encoded_label=$(printf '%s' "$label_trim" | python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read()))")
+    gh api "repos/${REPO}/issues?state=open&labels=${encoded_label}" \
+        --jq '[.[] | select(.pull_request == null) | {number, title, labels: [.labels[].name], url: .html_url}]' \
+        > "$tmp" 2>/dev/null
+    api_rc=$?
+    if [ $api_rc -ne 0 ]; then
+        echo "Error: gh api failed for label='$label_trim' (rc=$api_rc)" >&2
+        rm -f "$tmp"
+        if [ ${#TMP_JSONS[@]} -gt 0 ]; then
+            rm -f "${TMP_JSONS[@]}"
+        fi
+        exit 2
+    fi
+    TMP_JSONS+=("$tmp")
+done
+
+# Merge + dedup by number
+ISSUES_JSON=$(python3 -c "
+import json, sys
+seen = set()
+out = []
+for f in sys.argv[1:]:
+    with open(f) as fh:
+        for i in json.load(fh):
+            if i['number'] not in seen:
+                seen.add(i['number'])
+                out.append(i)
+print(json.dumps(out, ensure_ascii=False))
+" "${TMP_JSONS[@]}" 2>&1)
+PY_RC=$?
+rm -f "${TMP_JSONS[@]}"
 set -e
 
-if [ $GH_RC -ne 0 ]; then
-    echo "Error: gh issue list failed (rc=$GH_RC):" >&2
+if [ $PY_RC -ne 0 ]; then
+    echo "Error: failed to merge label-query results (python rc=$PY_RC):" >&2
     echo "$ISSUES_JSON" >&2
     exit 2
 fi
@@ -91,7 +133,7 @@ COUNT=$(echo "$ISSUES_JSON" | jq 'length' 2>&1)
 JQ_RC=$?
 set -e
 if [ $JQ_RC -ne 0 ]; then
-    echo "Error: invalid JSON from gh (jq rc=$JQ_RC). Output:" >&2
+    echo "Error: invalid JSON (jq rc=$JQ_RC). Output:" >&2
     echo "$ISSUES_JSON" | head -5 >&2
     exit 2
 fi
@@ -106,13 +148,16 @@ echo "## ⚠️ FMT критические issues ($COUNT)"
 echo ""
 echo "| # | Issue | Labels |"
 echo "|---|---|---|"
-echo "$ISSUES_JSON" | jq -r '.[] | "| #\(.number) | [\(.title)](\(.url)) | \([.labels[].name] | join(", ")) |"'
+echo "$ISSUES_JSON" | jq -r '.[] | "| #\(.number) | [\(.title)](\(.url)) | \(.labels | join(", ")) |"'
 echo ""
 
 # Telegram alert (MVP)
 if $SEND_TG; then
-    if [ -z "${TG_BOT_TOKEN:-}" ] || [ -z "${TG_CHAT_ID:-}" ]; then
-        echo "_TG alert skipped:_ TG_BOT_TOKEN or TG_CHAT_ID not set in environment."
+    # Fallback chain: TG_BOT_TOKEN → TELEGRAM_BOT_TOKEN (legacy/IWE-standard name from ~/.exocortex.env)
+    TG_TOKEN="${TG_BOT_TOKEN:-${TELEGRAM_BOT_TOKEN:-}}"
+    TG_CHAT="${TG_CHAT_ID:-${TELEGRAM_CHAT_ID:-}}"
+    if [ -z "$TG_TOKEN" ] || [ -z "$TG_CHAT" ]; then
+        echo "_TG alert skipped:_ TG_BOT_TOKEN/TELEGRAM_BOT_TOKEN or TG_CHAT_ID/TELEGRAM_CHAT_ID not set in environment."
         exit 1
     fi
 
@@ -124,8 +169,8 @@ if $SEND_TG; then
 
     # Send
     set +e
-    TG_RESPONSE=$(curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMessage" \
-        -d "chat_id=${TG_CHAT_ID}" \
+    TG_RESPONSE=$(curl -s -X POST "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
+        -d "chat_id=${TG_CHAT}" \
         --data-urlencode "text=${TG_MSG}" 2>&1)
     CURL_RC=$?
     set -e
@@ -137,7 +182,9 @@ if $SEND_TG; then
 
     OK=$(echo "$TG_RESPONSE" | jq -r '.ok // false' 2>/dev/null)
     if [ "$OK" = "true" ]; then
-        echo "_TG alert sent:_ chat ${TG_CHAT_ID}"
+        # Маскируем chat_id в STDOUT (DayPlan/WeekReport коммитятся в Git — PII-сигнал).
+        TG_CHAT_MASKED="${TG_CHAT:0:3}***"
+        echo "_TG alert sent:_ chat ${TG_CHAT_MASKED}"
     else
         echo "_TG alert response:_ $TG_RESPONSE"
         exit 1


### PR DESCRIPTION
## Что

Closes 2 failure modes from peer-session 18:

1. **SLA «1 week» был paper-only** → stale-unattended bot теперь флагует issues 14d+ open без `triaged-*` label
2. **needs-reproduction issues висели бесконечно** → actions/stale@v9 auto-close после 30d→stale→+14d→close
3. **TG alert script** не работал с реальным env (TELEGRAM_*) — fallback added

## Файлы

- `scripts/fmt-critical-alert.sh` — env fallback + gh api OR-merge + chat_id mask + bash 3.2 fix
- `.github/workflows/stale.yml` — НОВЫЙ workflow, 3 sequential jobs
- `CONTRIBUTING.md` — секция "Stale & lifecycle"

## Anti-pattern guards (Kimi review)

- `keep-alive` opt-out
- exempt: `critical`, `deadline`, `roadmap`, `pinned`, `triaged-accepted`
- operations-per-run: 30
- remove-stale-when-updated: true

## Smoke

End-to-end TG alert: chat `748***` (masked) received message about test critical issue. Все 3 stale jobs YAML-valid, actions/stale@v9 + github-script@v8 exist на GitHub.

Refs: peer-session [2026-06-01-25-fmt-hardening-stale-bot](https://github.com/TserenTserenov/DS-my-strategy/tree/main/sessions/2026-06/2026-06-01-25-fmt-hardening-stale-bot)