### PR TITLE
ci: migrate actions/checkout@v4 → v6, github-script@v7 → v8

### DIFF
--- a/.github/workflows/cloud-scheduler.yml
+++ b/.github/workflows/cloud-scheduler.yml
@@ -47,11 +47,12 @@ jobs:
     steps:
       - name: Checkout strategy repo
         if: env.STRATEGY_REPO != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.STRATEGY_REPO }}
           token: ${{ secrets.STRATEGY_REPO_TOKEN }}
           fetch-depth: 1
+          persist-credentials: true
 
       - name: Backup memory files
         if: env.STRATEGY_REPO != ''
@@ -104,11 +105,12 @@ jobs:
     steps:
       - name: Checkout strategy repo
         if: env.STRATEGY_REPO != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.STRATEGY_REPO }}
           token: ${{ secrets.STRATEGY_REPO_TOKEN }}
           fetch-depth: 100
+          persist-credentials: true
 
       - name: Checkout additional repos
         if: env.STRATEGY_REPO != ''

--- a/.github/workflows/notify-update.yml
+++ b/.github/workflows/notify-update.yml
@@ -16,7 +16,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # нужна полная история для git log
 

--- a/.github/workflows/post-release-audit.yml
+++ b/.github/workflows/post-release-audit.yml
@@ -30,7 +30,7 @@ jobs:
   create-audit-issue:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Determine version
         id: ver
         run: |
@@ -42,7 +42,7 @@ jobs:
             echo "version=$VER" >> $GITHUB_OUTPUT
           fi
       - name: Create or update audit reminder issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -15,7 +15,7 @@ jobs:
   release-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check CHANGELOG/manifest version sync
         run: |
           if [ ! -f "CHANGELOG.md" ] || [ ! -f "update-manifest.json" ]; then
@@ -63,7 +63,7 @@ jobs:
     env:
       SMOKE_GOVERNANCE_REPO: ${{ matrix.gov_repo }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y python3 jq
@@ -85,7 +85,7 @@ jobs:
   upgrade-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # full history для git log
       - name: Install dependencies
@@ -127,7 +127,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install ShellCheck
         run: sudo apt-get install -y shellcheck
@@ -149,7 +149,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # C1 fix (0.28.6): CI source-of-truth = local validator (setup/validate-template.sh).
       # Раньше CI имел собственный inline blacklist, который расходился с local — например,


### PR DESCRIPTION
Closes #141

- actions/checkout@v4 → v6 (9 occurrences, 4 workflow files)
- actions/github-script@v7 → v8 (1 occurrence, post-release-audit.yml)
- Add persist-credentials: true to cloud-scheduler.yml checkout steps

Verified:
- actions/checkout@v5 and v6 both use node24 runtime
- actions/github-script@v8 uses node24 (v9 is ESM-only, breaks inline require)
- cloud-scheduler.yml has workflow_dispatch trigger for smoke testing

Refs: peer-session 2026-06-01-24-fmt-quickfix-batch