### PR TITLE
fix(#165): server-calendar.sh invalid escape sequence SyntaxWarning

### DIFF
--- a/scripts/server-calendar.sh
+++ b/scripts/server-calendar.sh
@@ -341,7 +341,7 @@ if week_mode:
         print("| 🚦 | Время | Событие | Длит. | Тип |")
         print("|----|-------|---------|-------|-----|")
         for e in evs:
-            s = e["summary"].replace("|", "\\|")
+            s = e["summary"].replace("|", chr(92) + "|")
             t = "встреча" if e["type"] == "meeting" else "задача"
             print(f"| {e['status_emoji']} | {e['start_time']} | {s} | {e['duration']} | {t} |")
         print()
@@ -361,7 +361,7 @@ if meetings:
     print("| 🚦 | Время | Событие | Длит. | Связь с РП |")
     print("|----|-------|---------|-------|------------|")
     for e in meetings:
-        s = e["summary"].replace("|", "\\|")
+        s = e["summary"].replace("|", chr(92) + "|")
         print(f"| {e['status_emoji']} | {e['start_time']} | {s} | {e['duration']} | — |")
     print()
 else:
@@ -373,7 +373,7 @@ if tasks:
     print("| 🚦 | Время | Что | Длит. | Результат |")
     print("|----|-------|-----|-------|-----------|")
     for e in tasks:
-        s = e["summary"].replace("|", "\\|")
+        s = e["summary"].replace("|", chr(92) + "|")
         print(f"| {e['status_emoji']} | {e['start_time']} | {s} | {e['duration']} | — |")
     print()
 else:


### PR DESCRIPTION
## Проблема (#165)

`server-calendar.sh` экранирует `|` в ячейках markdown-таблицы через `.replace("|", "\\|")` внутри **unquoted** heredoc (`$PYTHON3 << PYEOF`). Оболочка схлопывает `\\` → `\` ещё до Python, поэтому Python 3.12 видит `"\|"` и пишет в stderr:

```
SyntaxWarning: invalid escape sequence '\|'
```

Это засоряет секцию «Календарь» в выводе.

## Фикс

`.replace("|", chr(92) + "|")` — даёт тот же `\|` на выходе, но без escape-последовательности в исходнике. Heredoc-safe: не требует менять delimiter на quoted (он интерполирует `${EVENTS_JSON}`). 3 вхождения (week / meetings / tasks). Поведение не меняется.

## Проверка

```
python3 -c '"a|b".replace("|", chr(92)+"|")'   # без warning, результат a\|b
```

Ветка от `main`, один файл.
