### PR TITLE
feat(day-close): pre-collect deterministic facts for Haiku verifier

### DIFF
--- a/.claude/skills/day-close/SKILL.md
+++ b/.claude/skills/day-close/SKILL.md
@@ -252,8 +252,23 @@ SCRIPT="$HOME/IWE/.claude/scripts/rule-classifier.py"
 
 ### 12. Верификация (Haiku R23)
 
-Запустить sub-agent Haiku в роли R23 Верификатор (context isolation).
-Передать: (1) чеклист Day Close, (2) черновик итогов, (3) список обновлённых файлов.
+**12a. Собрать факты (основной агент — ДО вызова Haiku):**
+```bash
+DAYPLAN="current/DayPlan $(date +%Y-%m-%d).md"
+WEEKREPORT=$(ls current/WeekReport*.md 2>/dev/null | tail -1)
+# postcondition 9a: итоги дня записаны
+grep -c "Итоги дня" "$DAYPLAN" 2>/dev/null || echo "0"
+# postcondition 9b: WeekReport обновлён сегодня
+grep -c "$(date +%Y-%m-%d)" "$WEEKREPORT" 2>/dev/null || echo "0"
+# коммит сегодня есть
+git log --oneline --since="$(date +%Y-%m-%d) 00:00" | wc -l | tr -d ' '
+# DayPlan заархивирован
+ls "archive/day-plans/DayPlan $(date +%Y-%m-%d).md" 2>/dev/null && echo "archived" || echo "NOT archived"
+```
+
+**12b. Вызвать sub-agent Haiku (context isolation) с фактами:**
+Передать Haiku: (1) чеклист Day Close, (2) факты из шага 12a, (3) список обновлённых файлов.
+Haiku оценивает по **фактам**, не догадывается о состоянии файлов.
 По ❌ — исправить до показа пользователю.
 
 ---


### PR DESCRIPTION
## Что

Day Close, новый шаг **12a**: основной агент собирает postcondition-факты **до** вызова sub-agent Haiku R23 (верификатор чеклиста):

- итоги дня записаны в DayPlan (grep),
- WeekReport обновлён сегодня,
- есть коммит за сегодня,
- DayPlan заархивирован.

## Зачем

Раньше Haiku-верификатор «догадывался» о состоянии вслепую. SOTA-практика верификации: давать проверяющему **детерминированные факты на входе**, а не заставлять его выводить их самому. Снижает ложные вердикты чеклист-проверки.

## Примечание

Часть оптимизации протоколов (WP-10). Изменение самодостаточное — только добавляет шаг сбора фактов в `day-close/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
