### PR TITLE
feat(hooks): destructive-guard + check-trash (focused)

### DIFF
--- a/.claude/hooks/check-trash.sh
+++ b/.claude/hooks/check-trash.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# SessionStart — verify `trash` is installed (safe-delete policy: never rm -rf).
+# Non-blocking: prints a warning to context if missing, so the user can install it.
+set -euo pipefail
+
+if ! command -v trash >/dev/null 2>&1; then
+  echo "⚠️ 'trash' не установлен — политика безопасного удаления (вместо rm -rf) не работает. Установка: sudo pacman -S trash-cli" >&2
+fi
+
+exit 0

--- a/.claude/hooks/destructive-guard.sh
+++ b/.claude/hooks/destructive-guard.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PreToolUse:Bash guard — blocks irreversible git operations regardless of flag order.
+# Complements the global rm -rf blocker (which forces `trash`). Exit 2 = block.
+set -euo pipefail
+
+CMD=$(jq -r '.tool_input.command // empty' 2>/dev/null || true)
+[ -z "$CMD" ] && exit 0
+
+block() {
+  echo "BLOCKED: $1" >&2
+  exit 2
+}
+
+is_git_subcmd() {
+  # git, optionally with -C <dir>, then the subcommand
+  echo "$CMD" | grep -qE "(^|[;&|[:space:]])git([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+$1"
+}
+
+# git push --force / -f (allow the safe --force-with-lease)
+if is_git_subcmd push; then
+  if echo "$CMD" | grep -qE -- '(--force([[:space:]]|=|$)|(^|[[:space:]])-[a-zA-Z]*f([[:space:]]|$))' \
+     && ! echo "$CMD" | grep -qE -- '--force-with-lease'; then
+    block "git push --force запрещён. Используй --force-with-lease или согласуй с владельцем (CLAUDE.md §2)."
+  fi
+fi
+
+# git reset --hard
+if is_git_subcmd reset && echo "$CMD" | grep -qE -- '--hard'; then
+  block "git reset --hard запрещён (теряет незакоммиченное). Используй git stash."
+fi
+
+# git clean with delete flags (-f/-d/-x)
+if is_git_subcmd clean && echo "$CMD" | grep -qE -- '(^|[[:space:]])-[a-zA-Z]*[dfx]'; then
+  block "git clean -fdx запрещён (удаляет неотслеживаемые файлы). Согласуй с владельцем."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/destructive-guard.sh"
+          },
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protocol-artifact-validate.sh"
           }
         ]
@@ -117,6 +121,16 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/precompact-checkpoint.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-trash.sh"
           }
         ]
       }

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -33,7 +33,13 @@
       "path": ".claude/hooks/capture-bus.sh"
     },
     {
+      "path": ".claude/hooks/check-trash.sh"
+    },
+    {
       "path": ".claude/hooks/close-gate-reminder.sh"
+    },
+    {
+      "path": ".claude/hooks/destructive-guard.sh"
     },
     {
       "path": ".claude/hooks/dry-run-gate.sh"
@@ -430,6 +436,30 @@
     },
     {
       "path": "extensions/day-open.after.session-orphans.md"
+    },
+    {
+      "path": "extensions/local-llm/ADR-001-local-llm-stack.md"
+    },
+    {
+      "path": "extensions/local-llm/README.md"
+    },
+    {
+      "path": "extensions/local-llm/detect-hardware.sh"
+    },
+    {
+      "path": "extensions/local-llm/install-local-llm.sh"
+    },
+    {
+      "path": "extensions/local-llm/iwe-local-llm.sh"
+    },
+    {
+      "path": "extensions/local-llm/model-catalog.yaml"
+    },
+    {
+      "path": "extensions/local-llm/model-lifecycle.py"
+    },
+    {
+      "path": "extensions/local-llm/model-monitor.py"
     },
     {
       "path": "extensions/protocol-close.after.session-record.md"


### PR DESCRIPTION
## Что

Два хука безопасности, извлечённые из #176 на текущий main (без устаревшей базы со слимом day-open):

- **`destructive-guard.sh`** (PreToolUse:Bash) — блокирует необратимые git-операции независимо от позиции флага: `push --force`/`-f`, `reset --hard`, `clean -fdx`. Безопасный `--force-with-lease` пропускается. Закрывает дыру: широкие `Bash(git *)` allow-правила разрешали форс-пуш.
- **`check-trash.sh`** (SessionStart) — предупреждает, если `trash` не установлен.

Оба зарегистрированы в `.claude/settings.json` (destructive-guard первым в Bash-matcher, новая секция SessionStart).

## Почему focused, а не #176

#176 несёт устаревшую базу (slim day-open −329 строк, отклонён в #166) и конфликтует. Эти два хука — единственная уникальная ценность #176, которой нет в #179/#180/#181. Извлечены на чистый main, чтобы не потерять при закрытии #176.

## Проверка

- `bash -n` обоих хуков — синтаксис чистый.
- JSON `settings.json` валиден; destructive-guard зарегистрирован первым в Bash-matcher.

Refs: peer-session 2026-06-13-05-implement-denis-prs-part1. Заменяет hook-часть #176.