### PR TITLE
feat(linux): cross-platform portability (clean #179+#181 with 3 fixes)

### DIFF
--- a/.claude/detectors/detector_decision.sh
+++ b/.claude/detectors/detector_decision.sh
@@ -50,7 +50,12 @@ if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
 fi
 
 # Определяем target_repo: cwd → IWE repo
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+DETECTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_DIR="$(cd "$DETECTOR_DIR/.." && pwd)"
+# shellcheck source=../lib/iwe-env-bootstrap.sh
+source "$CLAUDE_DIR/lib/iwe-env-bootstrap.sh" || exit 1
+
 TARGET_REPO_HINT=""
 if [ -n "$CWD" ] && [[ "$CWD" == "$IWE_ROOT"/* ]]; then
   REL="${CWD#$IWE_ROOT/}"

--- a/.claude/detectors/detector_incident.sh
+++ b/.claude/detectors/detector_incident.sh
@@ -24,6 +24,12 @@
 
 set -uo pipefail
 
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+DETECTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_DIR="$(cd "$DETECTOR_DIR/.." && pwd)"
+# shellcheck source=../lib/iwe-env-bootstrap.sh
+source "$CLAUDE_DIR/lib/iwe-env-bootstrap.sh" || exit 1
+
 INPUT=$(cat)
 
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')

--- a/.claude/detectors/detector_pattern_awareness.sh
+++ b/.claude/detectors/detector_pattern_awareness.sh
@@ -60,7 +60,11 @@ if [ ! -f "$FILE_PATH" ] || [ ! -r "$FILE_PATH" ]; then
 fi
 
 # ── Определяем target_repo ───────────────────────────────────────────────────
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+DETECTOR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_DIR="$(cd "$DETECTOR_DIR/.." && pwd)"
+# shellcheck source=../lib/iwe-env-bootstrap.sh
+source "$CLAUDE_DIR/lib/iwe-env-bootstrap.sh" || exit 1
 TARGET_REPO_HINT=""
 
 if [[ "$FILE_PATH" == /* ]]; then

--- a/.claude/hooks/capture-bus.sh
+++ b/.claude/hooks/capture-bus.sh
@@ -13,9 +13,11 @@ set -uo pipefail  # без -e, чтобы ошибка одного детект
 # Guard: harness может вызвать hook с урезанным PATH.
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLAUDE_DIR="$(cd "$HOOK_DIR/.." && pwd)"
+# shellcheck source=../lib/iwe-env-bootstrap.sh
+source "$CLAUDE_DIR/lib/iwe-env-bootstrap.sh" || exit 1
 LIB_DIR="$CLAUDE_DIR/lib"
 LOG_FILE="${CAPTURE_LOG_FILE:-$CLAUDE_DIR/logs/capture_log.jsonl}"
 

--- a/.claude/hooks/protocol-stop-gate.sh
+++ b/.claude/hooks/protocol-stop-gate.sh
@@ -39,7 +39,11 @@ if [ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ]; then
   exit 0
 fi
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_DIR="$(cd "$HOOK_DIR/.." && pwd)"
+# shellcheck source=../lib/iwe-env-bootstrap.sh
+source "$CLAUDE_DIR/lib/iwe-env-bootstrap.sh" || exit 1
 GATE_LOG="$IWE_ROOT/.claude/logs/gate_log.jsonl"
 mkdir -p "$(dirname "$GATE_LOG")" 2>/dev/null || true
 

--- a/.claude/lib/behaviour-report.sh
+++ b/.claude/lib/behaviour-report.sh
@@ -17,7 +17,10 @@
 set -uo pipefail
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./iwe-env-bootstrap.sh
+source "$LIB_DIR/iwe-env-bootstrap.sh" || exit 1
 PERIOD=$(date +%Y-%m)
 THRESHOLD=3
 OUTPUT_JSON=0

--- a/.claude/lib/capture_selftest.sh
+++ b/.claude/lib/capture_selftest.sh
@@ -18,7 +18,10 @@
 set -uo pipefail
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./iwe-env-bootstrap.sh
+source "$LIB_DIR/iwe-env-bootstrap.sh" || exit 1
 CLAUDE_DIR="$IWE_ROOT/.claude"
 CONFIG_FILE="$CLAUDE_DIR/config/capture-detectors.sh"
 LATENCY_THRESHOLD=150  # ms

--- a/.claude/lib/iwe-env-bootstrap.sh
+++ b/.claude/lib/iwe-env-bootstrap.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# IWE Environment Bootstrap — Unified Variables
+# Source this in any script that needs workspace/root paths
+# Usage: source "$IWE_SCRIPTS/iwe-env-bootstrap.sh"
+
+# Exit early if already sourced
+[ -n "${_IWE_ENV_BOOTSTRAP_SOURCED:-}" ] && return 0
+_IWE_ENV_BOOTSTRAP_SOURCED=1
+
+set -u
+
+# ============================================================================
+# PRIMARY SOURCE: WORKSPACE_DIR
+# ============================================================================
+# WORKSPACE_DIR is the canonical root of the IWE workspace.
+# Resolution strategy (in order):
+#   1. Environment variable WORKSPACE_DIR (e.g., from .exocortex.env or caller)
+#   2. Derive from script location (PREFERRED for portability)
+#   3. Fail with clear error (no guessing with $HOME)
+# ============================================================================
+
+if [ -z "${WORKSPACE_DIR:-}" ]; then
+  # Try to infer from script location
+  # (Script is typically at $WORKSPACE_DIR/FMT-exocortex-template/scripts/*)
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  
+  # Check if we're in a FMT-exocortex-template/scripts directory
+  if [[ "$SCRIPT_DIR" =~ /FMT-exocortex-template/scripts ]]; then
+    WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+  elif [[ "$SCRIPT_DIR" =~ /\.claude/ ]]; then
+    # We're in .claude/hooks, .claude/lib, .claude/detectors, or .claude/skills
+    WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  elif [[ "$SCRIPT_DIR" =~ /.iwe-runtime/ ]]; then
+    # Runtime-generated scripts
+    WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+  else
+    # Cannot infer — require explicit WORKSPACE_DIR
+    echo "ERROR [iwe-env-bootstrap]: Unable to infer WORKSPACE_DIR" >&2
+    echo "  Script location: $SCRIPT_DIR" >&2
+    echo "  Expected locations:" >&2
+    echo "    - $WORKSPACE_DIR/FMT-exocortex-template/scripts/..." >&2
+    echo "    - $WORKSPACE_DIR/.claude/{lib,detectors,hooks,skills}/..." >&2
+    echo "    - $WORKSPACE_DIR/.iwe-runtime/..." >&2
+    echo "  Solution: Set WORKSPACE_DIR explicitly or source from correct location" >&2
+    return 1 2>/dev/null || exit 1
+  fi
+fi
+
+# Expand tilde in WORKSPACE_DIR only if HOME exists (portable safety)
+if [ -n "${HOME:-}" ]; then
+  WORKSPACE_DIR="${WORKSPACE_DIR/#\~/$HOME}"
+fi
+
+# ============================================================================
+# SOURCE OF TRUTH: .exocortex.env (single config — values + secrets)
+# ============================================================================
+# Once WORKSPACE_DIR is known, load the user config. Values defined here win
+# over derived defaults below. This is the single env source for all scripts —
+# no inline ". $IWE_ROOT/.exocortex.env" snippets elsewhere.
+if [ -f "$WORKSPACE_DIR/.exocortex.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$WORKSPACE_DIR/.exocortex.env"
+  set +a
+fi
+
+# ============================================================================
+# DERIVED VARIABLES (fallbacks — .exocortex.env values take precedence)
+# ============================================================================
+
+# Legacy variable for backward compatibility
+export IWE_ROOT="${IWE_ROOT:-$WORKSPACE_DIR}"
+
+# Platform locations
+export IWE_GOVERNANCE_REPO="${IWE_GOVERNANCE_REPO:-DS-strategy}"
+export IWE_DS_MY_STRATEGY="${IWE_DS_MY_STRATEGY:-${WORKSPACE_DIR}/${IWE_GOVERNANCE_REPO}}"
+export IWE_TEMPLATE="${IWE_TEMPLATE:-${WORKSPACE_DIR}/FMT-exocortex-template}"
+export IWE_RUNTIME="${IWE_RUNTIME:-${WORKSPACE_DIR}/.iwe-runtime}"
+export IWE_SCRIPTS="${IWE_SCRIPTS:-${WORKSPACE_DIR}/FMT-exocortex-template/scripts}"
+
+# Export to child processes
+export WORKSPACE_DIR
+export IWE_ROOT
+
+# Validation: ensure WORKSPACE_DIR exists
+if [ ! -d "$WORKSPACE_DIR" ]; then
+  echo "ERROR [iwe-env-bootstrap]: WORKSPACE_DIR=$WORKSPACE_DIR does not exist" >&2
+  echo "  Set WORKSPACE_DIR manually or ensure .exocortex.env is loaded" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# ============================================================================
+# OS DETECTION
+# ============================================================================
+# IWE_OS: "macos" | "linux" | "unknown" — use this instead of calling uname
+# in individual scripts.
+case "$(uname -s)" in
+  Darwin) export IWE_OS="macos" ;;
+  Linux)  export IWE_OS="linux" ;;
+  *)      export IWE_OS="unknown" ;;
+esac
+
+# IWE_ICLOUD_BACKUP_DIR: macOS iCloud Drive path for IWE backups.
+# Empty on non-macOS platforms — scripts must guard with [ -n "$IWE_ICLOUD_BACKUP_DIR" ].
+if [ "$IWE_OS" = "macos" ]; then
+  export IWE_ICLOUD_BACKUP_DIR="${HOME}/Library/Mobile Documents/com~apple~CloudDocs/IWE-backups"
+  export IWE_ICLOUD_ROOT="${HOME}/Library/Mobile Documents/com~apple~CloudDocs"
+else
+  export IWE_ICLOUD_BACKUP_DIR=""
+  export IWE_ICLOUD_ROOT=""
+fi
+
+# Debug output (optional)
+if [ "${IWE_ENV_BOOTSTRAP_DEBUG:-0}" = "1" ]; then
+  echo "[iwe-env-bootstrap] Loaded successfully:" >&2
+  echo "  WORKSPACE_DIR=$WORKSPACE_DIR" >&2
+  echo "  IWE_ROOT=$IWE_ROOT" >&2
+  echo "  IWE_TEMPLATE=$IWE_TEMPLATE" >&2
+  echo "  IWE_OS=$IWE_OS" >&2
+fi

--- a/.claude/lib/resolve_target_repo.sh
+++ b/.claude/lib/resolve_target_repo.sh
@@ -32,7 +32,10 @@ for arg in "$@"; do
   esac
 done
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./iwe-env-bootstrap.sh
+source "$LIB_DIR/iwe-env-bootstrap.sh" || exit 1
 
 normalize() {
   # Принимает путь, возвращает абсолютный без trailing slash

--- a/.claude/skills/check-secret/check.sh
+++ b/.claude/skills/check-secret/check.sh
@@ -9,7 +9,12 @@
 set -uo pipefail
 export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_DIR="$(cd "$SKILL_DIR/../.." && pwd)"
+# shellcheck source=../../lib/iwe-env-bootstrap.sh
+source "$CLAUDE_DIR/lib/iwe-env-bootstrap.sh" || exit 1
+
 LOG_FILE="$IWE_ROOT/.claude/logs/check-secret.jsonl"
 mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -171,10 +171,21 @@ fi
 # коммиты пропускали проверку и пускали leak в FMT.
 STAGED_TEMPLATE=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null \
     | grep -E '\.(md|sh|py|json|plist|yaml)$' || true)
+# Bootstrap TEMPLATE_DIR from .exocortex.env (parent of this repo) — no env var required
+if [ -z "${TEMPLATE_DIR:-}" ]; then
+  _repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  _env_file="$(dirname "${_repo_root:-}")/.exocortex.env"
+  if [ -f "$_env_file" ]; then
+    _td=$(grep '^IWE_TEMPLATE=' "$_env_file" | head -1 | cut -d= -f2-)
+    [ -n "${_td:-}" ] && export TEMPLATE_DIR="$_td"
+    unset _td
+  fi
+  unset _repo_root _env_file
+fi
 if [ -n "$STAGED_TEMPLATE" ] && [ -x "setup/validate-template.sh" ]; then
     # --mode=staged: проверяет только staged файлы. Предотвращает ложные блокировки
     # от unstaged WIP параллельных агентов (мультиагентная среда IWE). CI использует pristine.
-    if ! bash setup/validate-template.sh --mode=staged >/tmp/iwe-validate.$$ 2>&1; then
+    if ! bash setup/validate-template.sh --mode=staged ${TEMPLATE_DIR:+"$TEMPLATE_DIR"} >/tmp/iwe-validate.$$ 2>&1; then
         echo "TEMPLATE-VALIDATE: FAIL"
         cat /tmp/iwe-validate.$$
         rm -f /tmp/iwe-validate.$$

--- a/roles/extractor/install.sh
+++ b/roles/extractor/install.sh
@@ -49,7 +49,40 @@ fi
 
 # Skip on non-macOS or headless CI without launchctl
 if ! command -v launchctl >/dev/null 2>&1; then
-    echo "  ⊠ launchctl not available (non-macOS), skipping $ROLE_NAME install"
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        echo "Installing $ROLE_NAME systemd user service (Linux)..."
+        SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
+
+        if [ -n "${IWE_RUNTIME:-}" ] && [ -d "$IWE_RUNTIME/roles/$ROLE_NAME/scripts/systemd" ]; then
+            SYSTEMD_SRC="$IWE_RUNTIME/roles/$ROLE_NAME/scripts/systemd"
+        elif [ -n "${IWE_WORKSPACE:-}" ] && [ -d "$IWE_WORKSPACE/.iwe-runtime/roles/$ROLE_NAME/scripts/systemd" ]; then
+            SYSTEMD_SRC="$IWE_WORKSPACE/.iwe-runtime/roles/$ROLE_NAME/scripts/systemd"
+        else
+            echo "ERROR: systemd units not found. Run setup.sh first." >&2
+            exit 1
+        fi
+
+        if grep -qrE '\{\{[A-Z_]+\}\}' "$SYSTEMD_SRC" 2>/dev/null; then
+            echo "ERROR: systemd units contain unsubstituted placeholders" >&2
+            exit 2
+        fi
+
+        mkdir -p "$SYSTEMD_USER_DIR"
+        mkdir -p "$HOME/logs/extractor"
+
+        cp "$SYSTEMD_SRC"/*.service "$SYSTEMD_SRC"/*.timer "$SYSTEMD_USER_DIR/"
+        systemctl --user daemon-reload
+        systemctl --user enable --now iwe-extractor-inbox-check.timer
+
+        echo "  ✓ Installed: iwe-extractor-inbox-check.timer"
+        echo "  ✓ Interval: every 3 hours"
+        echo "  ✓ Logs: ~/logs/extractor/"
+        echo ""
+        echo "Verify: systemctl --user status iwe-extractor-inbox-check.timer"
+        echo "Uninstall: systemctl --user disable --now iwe-extractor-inbox-check.timer && rm $SYSTEMD_USER_DIR/iwe-extractor-inbox-check.{service,timer}"
+        exit 0
+    fi
+    echo "  ⊠ launchctl not available (non-macOS/Linux), skipping $ROLE_NAME install"
     exit 0
 fi
 

--- a/roles/extractor/scripts/systemd/iwe-extractor-inbox-check.service
+++ b/roles/extractor/scripts/systemd/iwe-extractor-inbox-check.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=IWE Extractor — inbox-check (3h interval)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart={{IWE_RUNTIME}}/roles/extractor/scripts/extractor.sh inbox-check
+Environment=HOME={{HOME_DIR}}
+Environment=IWE_TEMPLATE={{IWE_TEMPLATE}}
+Environment=IWE_WORKSPACE={{WORKSPACE_DIR}}
+Environment=IWE_RUNTIME={{IWE_RUNTIME}}
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.local/bin
+StandardOutput=append:{{HOME_DIR}}/logs/extractor/systemd-inbox-check.log
+StandardError=append:{{HOME_DIR}}/logs/extractor/systemd-inbox-check-error.log

--- a/roles/extractor/scripts/systemd/iwe-extractor-inbox-check.timer
+++ b/roles/extractor/scripts/systemd/iwe-extractor-inbox-check.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=IWE Extractor — inbox-check каждые 3 часа
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=3h
+Unit=iwe-extractor-inbox-check.service
+
+[Install]
+WantedBy=timers.target

--- a/roles/strategist/install.sh
+++ b/roles/strategist/install.sh
@@ -43,7 +43,40 @@ done
 
 # Skip on non-macOS or headless CI without launchctl
 if ! command -v launchctl >/dev/null 2>&1; then
-    echo "  ⊠ launchctl not available (non-macOS), skipping $ROLE_NAME install"
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        echo "Installing $ROLE_NAME systemd user services (Linux)..."
+        SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
+
+        if [ -n "${IWE_RUNTIME:-}" ] && [ -d "$IWE_RUNTIME/roles/$ROLE_NAME/scripts/systemd" ]; then
+            SYSTEMD_SRC="$IWE_RUNTIME/roles/$ROLE_NAME/scripts/systemd"
+        elif [ -n "${IWE_WORKSPACE:-}" ] && [ -d "$IWE_WORKSPACE/.iwe-runtime/roles/$ROLE_NAME/scripts/systemd" ]; then
+            SYSTEMD_SRC="$IWE_WORKSPACE/.iwe-runtime/roles/$ROLE_NAME/scripts/systemd"
+        else
+            echo "ERROR: systemd units not found. Run setup.sh first." >&2
+            exit 1
+        fi
+
+        if grep -qrE '\{\{[A-Z_]+\}\}' "$SYSTEMD_SRC" 2>/dev/null; then
+            echo "ERROR: systemd units contain unsubstituted placeholders" >&2
+            exit 2
+        fi
+
+        mkdir -p "$SYSTEMD_USER_DIR"
+        mkdir -p "$HOME/logs/strategist"
+
+        cp "$SYSTEMD_SRC"/*.service "$SYSTEMD_SRC"/*.timer "$SYSTEMD_USER_DIR/"
+        systemctl --user daemon-reload
+        systemctl --user enable --now iwe-strategist-morning.timer
+        systemctl --user enable --now iwe-strategist-weekreview.timer
+
+        echo "  ✓ Installed: iwe-strategist-morning.timer (daily)"
+        echo "  ✓ Installed: iwe-strategist-weekreview.timer (Mon 00:00)"
+        echo "  ✓ Logs: ~/logs/strategist/"
+        echo ""
+        echo "Verify: systemctl --user list-timers | grep strategist"
+        exit 0
+    fi
+    echo "  ⊠ launchctl not available (non-macOS/Linux), skipping $ROLE_NAME install"
     exit 0
 fi
 

--- a/roles/strategist/scripts/strategist.sh
+++ b/roles/strategist/scripts/strategist.sh
@@ -105,7 +105,9 @@ notify() {
     if [ -n "${NOTIFY_SH_PATH:-}" ] && [ -x "$NOTIFY_SH_PATH" ]; then
         "$NOTIFY_SH_PATH" "$title" "$message" 2>/dev/null || true
     else
-        printf 'display notification "%s" with title "%s"' "$message" "$title" | osascript 2>/dev/null || true
+        printf 'display notification "%s" with title "%s"' "$message" "$title" | osascript 2>/dev/null \
+            || notify-send "$title" "$message" 2>/dev/null \
+            || true
     fi
 }
 

--- a/roles/strategist/scripts/systemd/iwe-strategist-morning.service
+++ b/roles/strategist/scripts/systemd/iwe-strategist-morning.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=IWE Strategist — morning run
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart={{IWE_RUNTIME}}/roles/strategist/scripts/strategist.sh morning
+Environment=HOME={{HOME_DIR}}
+Environment=IWE_TEMPLATE={{IWE_TEMPLATE}}
+Environment=IWE_WORKSPACE={{WORKSPACE_DIR}}
+Environment=IWE_RUNTIME={{IWE_RUNTIME}}
+Environment=IWE_GOVERNANCE_REPO={{GOVERNANCE_REPO}}
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.local/bin
+StandardOutput=append:{{HOME_DIR}}/logs/strategist/systemd-morning.log
+StandardError=append:{{HOME_DIR}}/logs/strategist/systemd-morning-error.log

--- a/roles/strategist/scripts/systemd/iwe-strategist-morning.timer
+++ b/roles/strategist/scripts/systemd/iwe-strategist-morning.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=IWE Strategist — morning run в {{TIMEZONE_HOUR}}:00 UTC
+
+[Timer]
+OnCalendar=*-*-* {{TIMEZONE_HOUR}}:00:00
+Persistent=true
+Unit=iwe-strategist-morning.service
+
+[Install]
+WantedBy=timers.target

--- a/roles/strategist/scripts/systemd/iwe-strategist-weekreview.service
+++ b/roles/strategist/scripts/systemd/iwe-strategist-weekreview.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=IWE Strategist — weekly review
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart={{IWE_RUNTIME}}/roles/strategist/scripts/strategist.sh week-review
+Environment=HOME={{HOME_DIR}}
+Environment=IWE_TEMPLATE={{IWE_TEMPLATE}}
+Environment=IWE_WORKSPACE={{WORKSPACE_DIR}}
+Environment=IWE_RUNTIME={{IWE_RUNTIME}}
+Environment=IWE_GOVERNANCE_REPO={{GOVERNANCE_REPO}}
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.local/bin
+StandardOutput=append:{{HOME_DIR}}/logs/strategist/systemd-weekreview.log
+StandardError=append:{{HOME_DIR}}/logs/strategist/systemd-weekreview-error.log

--- a/roles/strategist/scripts/systemd/iwe-strategist-weekreview.timer
+++ b/roles/strategist/scripts/systemd/iwe-strategist-weekreview.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=IWE Strategist — weekly review в понедельник 00:00
+
+[Timer]
+OnCalendar=Mon *-*-* 00:00:00
+Persistent=true
+Unit=iwe-strategist-weekreview.service
+
+[Install]
+WantedBy=timers.target

--- a/roles/synchronizer/install.sh
+++ b/roles/synchronizer/install.sh
@@ -49,7 +49,48 @@ fi
 
 # Skip on non-macOS or headless CI without launchctl
 if ! command -v launchctl >/dev/null 2>&1; then
-    echo "  ⊠ launchctl not available (non-macOS), skipping $ROLE_NAME install"
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        echo "Installing $ROLE_NAME systemd user service (Linux)..."
+        SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
+
+        if [ -n "${IWE_RUNTIME:-}" ] && [ -d "$IWE_RUNTIME/roles/$ROLE_NAME/scripts/systemd" ]; then
+            SYSTEMD_SRC="$IWE_RUNTIME/roles/$ROLE_NAME/scripts/systemd"
+        elif [ -n "${IWE_WORKSPACE:-}" ] && [ -d "$IWE_WORKSPACE/.iwe-runtime/roles/$ROLE_NAME/scripts/systemd" ]; then
+            SYSTEMD_SRC="$IWE_WORKSPACE/.iwe-runtime/roles/$ROLE_NAME/scripts/systemd"
+        else
+            echo "ERROR: systemd units not found. Run setup.sh first." >&2
+            exit 1
+        fi
+
+        if grep -qrE '\{\{[A-Z_]+\}\}' "$SYSTEMD_SRC" 2>/dev/null; then
+            echo "ERROR: systemd units contain unsubstituted placeholders" >&2
+            exit 2
+        fi
+
+        mkdir -p "$SYSTEMD_USER_DIR"
+        mkdir -p "$HOME/.local/state/exocortex"
+        mkdir -p "$HOME/logs/synchronizer"
+
+        cp "$SYSTEMD_SRC"/*.service "$SYSTEMD_SRC"/*.timer "$SYSTEMD_USER_DIR/"
+        systemctl --user daemon-reload
+        systemctl --user enable --now iwe-exocortex-scheduler.timer
+
+        echo "  ✓ Installed: iwe-exocortex-scheduler.timer"
+        echo "  ✓ Schedule: 10 dispatch points per day"
+        echo "  ✓ State: ~/.local/state/exocortex/"
+        echo "  ✓ Logs: ~/logs/synchronizer/"
+        echo ""
+        echo "Verify: systemctl --user list-timers | grep exocortex"
+        echo "Status: bash $SCRIPTS_DIR_RUNTIME/scheduler.sh status"
+        echo ""
+        echo "Auto-wake (recommended): sudo rtcwake -m no -t \$(date -d 'tomorrow 03:55' +%s)"
+        echo ""
+        echo "Telegram (optional): create ~/.config/aist/env with:"
+        echo "  export TELEGRAM_BOT_TOKEN=\"your-token\""
+        echo "  export TELEGRAM_CHAT_ID=\"your-id\""
+        exit 0
+    fi
+    echo "  ⊠ launchctl not available (non-macOS/Linux), skipping $ROLE_NAME install"
     exit 0
 fi
 

--- a/roles/synchronizer/scripts/systemd/iwe-exocortex-scheduler.service
+++ b/roles/synchronizer/scripts/systemd/iwe-exocortex-scheduler.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=IWE Synchronizer — scheduler dispatch
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart={{IWE_RUNTIME}}/roles/synchronizer/scripts/scheduler.sh dispatch
+Environment=HOME={{HOME_DIR}}
+Environment=IWE_TEMPLATE={{IWE_TEMPLATE}}
+Environment=IWE_WORKSPACE={{WORKSPACE_DIR}}
+Environment=IWE_RUNTIME={{IWE_RUNTIME}}
+Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.local/bin
+StandardOutput=append:{{HOME_DIR}}/logs/synchronizer/systemd-scheduler.log
+StandardError=append:{{HOME_DIR}}/logs/synchronizer/systemd-scheduler-error.log

--- a/roles/synchronizer/scripts/systemd/iwe-exocortex-scheduler.timer
+++ b/roles/synchronizer/scripts/systemd/iwe-exocortex-scheduler.timer
@@ -1,0 +1,19 @@
+[Unit]
+Description=IWE Synchronizer — 10 dispatch points per day
+
+[Timer]
+OnCalendar=*-*-* 00:00:00
+OnCalendar=*-*-* 03:00:00
+OnCalendar=*-*-* {{TIMEZONE_HOUR}}:00:00
+OnCalendar=*-*-* 06:00:00
+OnCalendar=*-*-* 09:00:00
+OnCalendar=*-*-* 12:00:00
+OnCalendar=*-*-* 15:00:00
+OnCalendar=*-*-* 18:00:00
+OnCalendar=*-*-* 21:00:00
+OnCalendar=*-*-* 23:00:00
+Persistent=true
+Unit=iwe-exocortex-scheduler.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/active-wp-sweep.sh
+++ b/scripts/active-wp-sweep.sh
@@ -15,7 +15,10 @@
 
 set -uo pipefail
 
-IWE="${2:-${IWE_ROOT:-$HOME/IWE}}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
+IWE="${2:-$IWE_ROOT}"
 INBOX="${1:-$IWE/${IWE_GOVERNANCE_REPO:-DS-strategy}/inbox}"
 GIT_DAYS="${WP_SWEEP_GIT_DAYS:-7}"
 

--- a/scripts/backup-icloud.sh
+++ b/scripts/backup-icloud.sh
@@ -8,15 +8,23 @@
 
 set -euo pipefail
 
-IWE_DIR="${WORKSPACE_DIR:-$HOME/IWE}"
-ICLOUD_DIR="$HOME/Library/Mobile Documents/com~apple~CloudDocs/IWE-backups"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
+
+IWE_DIR="${WORKSPACE_DIR}"
+ICLOUD_DIR="$IWE_ICLOUD_BACKUP_DIR"
 DATE=$(date +%Y%m%d-%H%M)
 ARCHIVE="IWE-backup-${DATE}.tar.gz"
 MAX_BACKUPS=4
 
-# Проверка iCloud
-if [ ! -d "$HOME/Library/Mobile Documents/com~apple~CloudDocs" ]; then
-    echo "❌ iCloud Drive не найден. Убедитесь что iCloud Drive включён в System Settings."
+# Проверка платформы и iCloud
+if [ "$IWE_OS" != "macos" ] || [ -z "$ICLOUD_DIR" ]; then
+    echo "❌ backup-icloud.sh требует macOS с iCloud Drive (текущая платформа: $IWE_OS)."
+    exit 1
+fi
+
+if [ ! -d "$IWE_ICLOUD_ROOT" ]; then
+    echo "❌ iCloud Drive не найден ($IWE_ICLOUD_ROOT). Убедитесь что iCloud Drive включён в System Settings."
     exit 1
 fi
 

--- a/scripts/check-dirty-repos.sh
+++ b/scripts/check-dirty-repos.sh
@@ -7,7 +7,10 @@
 
 set -euo pipefail
 
-IWE_DIR="${WORKSPACE_DIR:-$HOME/IWE}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
+IWE_DIR="$WORKSPACE_DIR"
 DIRTY=0
 UNPUSHED=0
 

--- a/scripts/check-open-sessions.sh
+++ b/scripts/check-open-sessions.sh
@@ -13,7 +13,11 @@
 
 set -euo pipefail
 
-REPO_ROOT="${IWE_DS_MY_STRATEGY:-$HOME/IWE/${IWE_GOVERNANCE_REPO:-DS-strategy}}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
+
+REPO_ROOT="$IWE_DS_MY_STRATEGY"
 SESSIONS_DIR="$REPO_ROOT/inbox/agent/sessions"
 CUTOVER_DATE="${SESSION_CUTOVER_DATE:-2026-05-29}"   # ISO date
 STALE_HOURS="${SESSION_STALE_HOURS:-24}"             # для status: completed

--- a/scripts/coverage-skills.sh
+++ b/scripts/coverage-skills.sh
@@ -54,7 +54,7 @@ done
 #   IWE_GOVERNANCE_REPO_TMPL    — имя шаблонного governance-репо (default: DS-strategy)
 NORM_HOME='/Users\|/home'
 NORM_GOV_AUTHOR="${IWE_GOVERNANCE_REPO:-DS-strategy}"
-NORM_GOV_TMPL="DS-strategy"
+NORM_GOV_TMPL="${IWE_GOVERNANCE_REPO_TMPL:-DS-strategy}"
 normalize_for_diff() {
     sed -E "
         s|\\{\\{[A-Z_]+\\}\\}|<placeholder>|g

--- a/scripts/day-close.sh
+++ b/scripts/day-close.sh
@@ -18,7 +18,9 @@
 set -euo pipefail
 
 # === КОНФИГУРАЦИЯ (настроить при установке) ===
-WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/IWE}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
 GOVERNANCE_REPO="${GOVERNANCE_REPO:-${IWE_GOVERNANCE_REPO:-DS-strategy}}"
 DS_STRATEGY="$WORKSPACE_DIR/$GOVERNANCE_REPO"
 # Slug = $HOME с '/' → '-' (macOS: /Users/x → -Users-x; Linux/WSL: /home/x → -home-x).

--- a/scripts/day-open-scaffold.sh
+++ b/scripts/day-open-scaffold.sh
@@ -24,7 +24,10 @@
 
 set -uo pipefail
 
-IWE="${IWE_ROOT:-$HOME/IWE}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
+IWE="$IWE_ROOT"
 DATE="${1:-$(date +%Y-%m-%d)}"
 CONFIG="$IWE/${IWE_GOVERNANCE_REPO:-DS-strategy}/exocortex/day-rhythm-config.yaml"
 SERVER_MODE="${IWE_SERVER_MODE:-0}"  # WP-283: 1 = Linux server, Mac-only MCP недоступен

--- a/scripts/iwe-audit.sh
+++ b/scripts/iwe-audit.sh
@@ -30,7 +30,9 @@
 
 set -eu
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
 DRIFT_CRITICAL=""
 
 while [ $# -gt 0 ]; do

--- a/scripts/iwe-backup-check.sh
+++ b/scripts/iwe-backup-check.sh
@@ -57,11 +57,15 @@
 
 set -euo pipefail
 
+# Load unified environment: IWE_OS, IWE_ROOT, IWE_ICLOUD_BACKUP_DIR, etc.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
+
 # ---------- Конфигурация ----------
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
 WARN_DAYS=7
 CRITICAL_DAYS=14
-CHECK_ICLOUD=1
+# Auto-disable iCloud check on non-macOS; can be overridden via --no-icloud
+[ "$IWE_OS" = "macos" ] && CHECK_ICLOUD=1 || CHECK_ICLOUD=0
 
 # ---------- Аргументы ----------
 while [ $# -gt 0 ]; do
@@ -107,7 +111,7 @@ CRITICALS=0
 # ---------- Раздел 1: iCloud-бэкапы ----------
 
 if [ "$CHECK_ICLOUD" -eq 1 ]; then
-    ICLOUD_DIR="$HOME/Library/Mobile Documents/com~apple~CloudDocs/IWE-backups"
+    ICLOUD_DIR="$IWE_ICLOUD_BACKUP_DIR"
 
     echo "## 1. iCloud-бэкапы"
     echo ""
@@ -160,7 +164,7 @@ if [ "$CHECK_ICLOUD" -eq 1 ]; then
 else
     echo "## 1. iCloud-бэкапы"
     echo ""
-    info "Пропущено (--no-icloud)"
+    info "N/A (платформа: $IWE_OS — iCloud доступен только на macOS)"
     echo ""
 fi
 

--- a/scripts/iwe-drift-helpers/check-arch-version.sh
+++ b/scripts/iwe-drift-helpers/check-arch-version.sh
@@ -19,7 +19,9 @@
 
 set -eu
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../.claude/lib/iwe-env-bootstrap.sh" || exit 1
 MODE="${MODE:-all}"
 
 while [ $# -gt 0 ]; do

--- a/scripts/iwe-drift-helpers/check-status-legend.sh
+++ b/scripts/iwe-drift-helpers/check-status-legend.sh
@@ -24,7 +24,9 @@
 
 set -eu
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../.claude/lib/iwe-env-bootstrap.sh" || exit 1
 REGISTRY="${REGISTRY:-$IWE_ROOT/${IWE_GOVERNANCE_REPO:-}/docs/WP-REGISTRY.md}"
 MODE="${MODE:-all}"
 

--- a/scripts/iwe-drift.sh
+++ b/scripts/iwe-drift.sh
@@ -31,7 +31,9 @@ else
     _STAT_FLAG="-c %Y"  # GNU/Linux
 fi
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
 MANIFEST="${MANIFEST:-$IWE_ROOT/.claude/sync-manifest.yaml}"
 MODE="all"
 TOP_N=0

--- a/scripts/memory-bleed.sh
+++ b/scripts/memory-bleed.sh
@@ -17,7 +17,9 @@
 
 set -eu
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
 MEMORY_DIR="$IWE_ROOT/memory"
 HOT_LIMIT=150
 HOT_DOWNGRADE_DAYS=14   # HOT → WARM если не упоминался N дней

--- a/scripts/memory-health.sh
+++ b/scripts/memory-health.sh
@@ -15,7 +15,9 @@
 
 set -eu
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
 MEMORY_DIR="$IWE_ROOT/memory"
 HOT_LIMIT=150
 MODE="full"

--- a/scripts/memory-migrate.sh
+++ b/scripts/memory-migrate.sh
@@ -17,7 +17,9 @@
 
 set -eu
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
 MEMORY_DIR="$IWE_ROOT/memory"
 DRY_RUN=0
 ALL=0

--- a/scripts/memory-validate.sh
+++ b/scripts/memory-validate.sh
@@ -17,7 +17,9 @@
 
 set -eu
 
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
 MEMORY_DIR="$IWE_ROOT/memory"
 QUIET=0
 TARGET=""

--- a/scripts/setup-extractor-feeders.sh
+++ b/scripts/setup-extractor-feeders.sh
@@ -81,7 +81,10 @@ else
 # post-commit hook — WP-247 Ф-TRIGGER-BASED
 # При изменении inbox/captures.md или fleeting-notes.md → запускает extractor inbox-check
 set -uo pipefail
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
 REPO_DIR=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 [[ "$REPO_DIR" != "$IWE_ROOT"* ]] && exit 0
 REPO_NAME=$(basename "$REPO_DIR")

--- a/scripts/sync-agent-instructions.sh
+++ b/scripts/sync-agent-instructions.sh
@@ -27,8 +27,9 @@
 # Инвариант: CLAUDE.md SYNC-CORE — source-of-truth общего ядра. AGENTS.md derived, не править руками.
 
 set -euo pipefail
-
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+# Load unified environment: WORKSPACE_DIR, IWE_ROOT, IWE_SCRIPTS, etc.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../.claude/lib/iwe-env-bootstrap.sh" || exit 1
 CLAUDE_MD="$IWE_ROOT/CLAUDE.md"
 BLOCKS_MD="$IWE_ROOT/AGENTS-agent-blocks.md"
 OUT_MD="$IWE_ROOT/AGENTS.md"

--- a/setup.sh
+++ b/setup.sh
@@ -639,10 +639,10 @@ elif ! command -v launchctl >/dev/null 2>&1; then
 else
     echo "[5/6] Installing roles..."
 
-    # Source ~/.iwe-paths — гарантирует IWE_RUNTIME / IWE_WORKSPACE / IWE_TEMPLATE
+    # Source $WORKSPACE_DIR/.iwe-paths — гарантирует IWE_RUNTIME / IWE_WORKSPACE / IWE_TEMPLATE
     # в env для role install.sh (тот же паттерн что в update.sh:836).
     # Без этого install.sh падает в legacy fallback и видит {{плейсхолдеры}}.
-    [ -f "$HOME/.iwe-paths" ] && . "$HOME/.iwe-paths"
+    [ -f "$WORKSPACE_DIR/.iwe-paths" ] && . "$WORKSPACE_DIR/.iwe-paths"
 
     MANUAL_ROLES=()
 

--- a/setup/install-iwe-paths.sh
+++ b/setup/install-iwe-paths.sh
@@ -49,13 +49,13 @@ fi
 WORKSPACE_DIR="${WORKSPACE_DIR/#\~/$HOME}"
 GOVERNANCE_REPO="${GOVERNANCE_REPO:-DS-strategy}"
 
-IWE_ENV_FILE="$HOME/.iwe-paths"
+IWE_ENV_FILE="$WORKSPACE_DIR/.iwe-paths"
 ZSHENV_FILE="$HOME/.zshenv"
 IWE_ENV_MARKER="# IWE environment (WP-219, DP.FM.009): lookup-слой для путей к скриптам"
 
 if $DRY_RUN; then
     $QUIET || echo "  [DRY RUN] Would write $IWE_ENV_FILE (workspace=$WORKSPACE_DIR, governance=$GOVERNANCE_REPO)"
-    $QUIET || echo "  [DRY RUN] Would ensure $ZSHENV_FILE sources \$HOME/.iwe-paths"
+    $QUIET || echo "  [DRY RUN] Would ensure $ZSHENV_FILE sources \$WORKSPACE_DIR/.iwe-paths"
     exit 0
 fi
 
@@ -74,16 +74,18 @@ IWEENV_EOF
 
 $QUIET || echo "  ✓ $IWE_ENV_FILE written (workspace=$WORKSPACE_DIR)"
 
-# Ensure ~/.zshenv sources ~/.iwe-paths (idempotent)
+# Ensure ~/.zshenv sources $WORKSPACE_DIR/.iwe-paths (idempotent)
 if [ -f "$ZSHENV_FILE" ] && grep -qF "$IWE_ENV_MARKER" "$ZSHENV_FILE"; then
-    $QUIET || echo "  ○ $ZSHENV_FILE already sources \$HOME/.iwe-paths"
+    $QUIET || echo "  ○ $ZSHENV_FILE already sources \$WORKSPACE_DIR/.iwe-paths"
 else
-    cat >> "$ZSHENV_FILE" <<'ZSHENV_EOF'
+    cat >> "$ZSHENV_FILE" <<ZSHENV_EOF
 
 # IWE environment (WP-219, DP.FM.009): lookup-слой для путей к скриптам
-[ -f "$HOME/.iwe-paths" ] && source "$HOME/.iwe-paths"
+_IWE_ROOT="$WORKSPACE_DIR"
+[ -f "\$_IWE_ROOT/.iwe-paths" ] && source "\$_IWE_ROOT/.iwe-paths"
+unset _IWE_ROOT
 ZSHENV_EOF
-    $QUIET || echo "  ✓ $ZSHENV_FILE → sources \$HOME/.iwe-paths"
+    $QUIET || echo "  ✓ $ZSHENV_FILE → sources \$WORKSPACE_DIR/.iwe-paths"
 fi
 
 # Auto-enable pre-commit hooks for IWE repos that have .githooks/

--- a/setup/smoke-test-fresh-install.sh
+++ b/setup/smoke-test-fresh-install.sh
@@ -457,7 +457,7 @@ fi
 echo "[8c] setup.sh step 5: source ~/.iwe-paths перед role install.sh..."
 # Берём блок между "Installing roles" и первым вызовом install.sh
 STEP5_BLOCK=$(awk '/\[5\/6\] Installing roles/{flag=1} flag; flag && /bash.*install\.sh/{exit}' "$SETUP_SH")
-if echo "$STEP5_BLOCK" | grep -qE '(\.|source)[[:space:]]+"?\$HOME/\.iwe-paths|export[[:space:]]+IWE_RUNTIME'; then
+if echo "$STEP5_BLOCK" | grep -qE '(\.|source)[[:space:]]+"?\$(HOME|WORKSPACE_DIR)/\.iwe-paths|export[[:space:]]+IWE_RUNTIME'; then
     pass "setup.sh step 5: env для install.sh подготовлен (source .iwe-paths или export IWE_RUNTIME)"
 else
     fail "setup.sh step 5: install.sh вызывается БЕЗ IWE_RUNTIME (legacy mode → fail-fast у пользователя)"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -84,6 +84,9 @@
       "path": ".claude/lib/capture_writer.sh"
     },
     {
+      "path": ".claude/lib/iwe-env-bootstrap.sh"
+    },
+    {
       "path": ".claude/lib/log_formatter.sh"
     },
     {
@@ -432,6 +435,30 @@
       "path": "extensions/day-open.after.session-orphans.md"
     },
     {
+      "path": "extensions/local-llm/ADR-001-local-llm-stack.md"
+    },
+    {
+      "path": "extensions/local-llm/README.md"
+    },
+    {
+      "path": "extensions/local-llm/detect-hardware.sh"
+    },
+    {
+      "path": "extensions/local-llm/install-local-llm.sh"
+    },
+    {
+      "path": "extensions/local-llm/iwe-local-llm.sh"
+    },
+    {
+      "path": "extensions/local-llm/model-catalog.yaml"
+    },
+    {
+      "path": "extensions/local-llm/model-lifecycle.py"
+    },
+    {
+      "path": "extensions/local-llm/model-monitor.py"
+    },
+    {
       "path": "extensions/protocol-close.after.session-record.md"
     },
     {
@@ -621,6 +648,12 @@
       "path": "roles/extractor/scripts/launchd/com.extractor.inbox-check.plist"
     },
     {
+      "path": "roles/extractor/scripts/systemd/iwe-extractor-inbox-check.service"
+    },
+    {
+      "path": "roles/extractor/scripts/systemd/iwe-extractor-inbox-check.timer"
+    },
+    {
       "path": "roles/role-boundaries.md"
     },
     {
@@ -735,6 +768,18 @@
       "path": "roles/strategist/scripts/strategist.sh"
     },
     {
+      "path": "roles/strategist/scripts/systemd/iwe-strategist-morning.service"
+    },
+    {
+      "path": "roles/strategist/scripts/systemd/iwe-strategist-morning.timer"
+    },
+    {
+      "path": "roles/strategist/scripts/systemd/iwe-strategist-weekreview.service"
+    },
+    {
+      "path": "roles/strategist/scripts/systemd/iwe-strategist-weekreview.timer"
+    },
+    {
       "path": "roles/synchronizer/README.md"
     },
     {
@@ -772,6 +817,12 @@
     },
     {
       "path": "roles/synchronizer/scripts/sync-files.sh"
+    },
+    {
+      "path": "roles/synchronizer/scripts/systemd/iwe-exocortex-scheduler.service"
+    },
+    {
+      "path": "roles/synchronizer/scripts/systemd/iwe-exocortex-scheduler.timer"
     },
     {
       "path": "roles/synchronizer/scripts/templates/extractor.sh"


### PR DESCRIPTION
## Что

Чистая интеграция linux-портабилити (объединение #179 + #181) на актуальный main с тремя исправленными багами. Заменяет #179 и #181.

**Ядро:** единая прелюдия `.claude/lib/iwe-env-bootstrap.sh` (резолв окружения + `IWE_OS` + iCloud-гейтинг по расположению скрипта, без хардкода `$HOME/IWE`); systemd user-таймеры для ролей на Linux; OS-детект launchd↔systemd в установщиках ролей; `notify-send` фолбэк; кросс-платформенный `stat`.

## Исправленные баги Дениса

1. **Путь подключения:** `$SCRIPT_DIR/../../.claude` → `../.claude` в `scripts/*` (и `../../../`→`../../` в `iwe-drift-helpers/`). Денис зашил на уровень глубже — при канонической раскладке (scripts/ и .claude/ как siblings внутри шаблона, см. setup.sh) скрипты падали бы на `source ... || exit 1`.
2. **Имя каталога:** `FMT-exocortex` → `FMT-exocortex-template` в дефолтах bootstrap и install-iwe-paths (иначе `$IWE_TEMPLATE` указывает на несуществующий путь у пользователей без override).
3. **`detector_pattern_awareness.sh`:** восстановлен file-exists guard (`[ ! -f "$FILE_PATH" ] || [ ! -r ... ]`), который #179 случайно удалил — регрессия.

## Не включено

`extensions/local-llm/install-local-llm.sh` (ключ `models`→`candidates`) — посторонний bugfix, не относится к порту. Отдельным PR.

## Проверка

- `bash -n` всех скриптов — чисто.
- Холодная верификация субагентом: пути резолвятся из реального расположения, авторский контент сохранён, полнота (упущенных файлов нет).
- Leak-scan: личных данных нет (плейсхолдеры `DS-strategy`/`{{...}}`).

Спасибо @TriplEight за linux-портабилити — основная работа его, здесь только консолидация двух веток + фикс трёх дефектов.