### PR TITLE
fix(notify): #169 уведомления DayPlan — шаблоны из .iwe-runtime + UTF-8

### DIFF
--- a/roles/synchronizer/scripts/notify.sh
+++ b/roles/synchronizer/scripts/notify.sh
@@ -12,8 +12,26 @@
 
 set -e
 
+# #169: эмодзи (🚦🔴🟡🟢⚫) из DayPlan ломают python3 (json.dumps/html.escape) при локали C/POSIX
+# — UnicodeEncodeError: surrogates not allowed. Форсим UTF-8 для всех python3 в процессе,
+# включая sourced-шаблон (escape_html, urllib.quote).
+export PYTHONUTF8=1
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-TEMPLATES_DIR="${TEMPLATES_DIR:-$SCRIPT_DIR/templates}"
+
+# #169: scheduler.sh зовёт notify.sh из FMT (read-only), а FMT-шаблоны держат неразрешённые
+# {{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}} → путь к DayPlan не резолвится, сообщение пустое.
+# Берём шаблоны из .iwe-runtime, куда build-runtime.sh подставил реальные пути
+# (runtime-overlay.yaml: templates/*.sh в списке substituted). Якорь: IWE_RUNTIME → IWE_WORKSPACE → $HOME/IWE.
+RUNTIME_TEMPLATES="${IWE_RUNTIME:-${IWE_WORKSPACE:-$HOME/IWE}/.iwe-runtime}/roles/synchronizer/scripts/templates"
+if [ -z "${TEMPLATES_DIR:-}" ]; then
+    if [ -d "$RUNTIME_TEMPLATES" ]; then
+        TEMPLATES_DIR="$RUNTIME_TEMPLATES"
+    else
+        TEMPLATES_DIR="$SCRIPT_DIR/templates"
+        echo "WARN: notify.sh fell back to FMT templates (.iwe-runtime not built?). Run setup/build-runtime.sh." >&2
+    fi
+fi
 ENV_FILE="$HOME/.config/aist/env"
 
 AVAILABLE=$(ls "$TEMPLATES_DIR"/*.sh 2>/dev/null | xargs -I{} basename {} .sh | tr '\n' '|' | sed 's/|$//')

--- a/roles/synchronizer/scripts/scheduler.sh
+++ b/roles/synchronizer/scripts/scheduler.sh
@@ -55,7 +55,9 @@ if [ -z "${IWE_TEMPLATE:-}" ]; then
     echo "[$(date '+%H:%M:%S')] WARN: \$IWE_TEMPLATE не задана, scheduler использует fallback $HOME/IWE/FMT-exocortex-template. source ~/.zshenv?" >&2
 fi
 ROLES_DIR="$ROLES_DIR_RUNTIME"  # backward-compat alias для downstream-логики
-# notify.sh — read-only, не substituted
+# notify.sh — read-only, не substituted (берётся из FMT, не из .iwe-runtime).
+# Поэтому notify.sh САМ резолвит шаблоны из .iwe-runtime (см. #169): иначе его
+# $SCRIPT_DIR/templates указывает на FMT-копии с неразрешёнными {{WORKSPACE_DIR}}.
 if [ -n "${IWE_TEMPLATE:-}" ] && [ -f "$IWE_TEMPLATE/roles/synchronizer/scripts/notify.sh" ]; then
     NOTIFY_SH="$IWE_TEMPLATE/roles/synchronizer/scripts/notify.sh"
 elif [ -f "$HOME/IWE/FMT-exocortex-template/roles/synchronizer/scripts/notify.sh" ]; then


### PR DESCRIPTION
## Что

Telegram-уведомления DayPlan не доходили 2+ недели. Две связанные причины в `roles/synchronizer/scripts/notify.sh`:

1. **Путь шаблонов.** scheduler.sh намеренно зовёт notify.sh из FMT (read-only), а notify.sh грузил шаблоны из `$SCRIPT_DIR/templates` = FMT-копии с **неразрешёнными** `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}` → путь к DayPlan не резолвился → пустое сообщение → «skip». Фикс: резолвить `TEMPLATES_DIR` из `.iwe-runtime`, куда `build-runtime.sh` подставил реальные пути (`runtime-overlay.yaml`: templates в списке substituted). Якорь `IWE_RUNTIME → IWE_WORKSPACE → $HOME/IWE`; при отсутствии рантайма — fallback на FMT + WARN в stderr.
2. **Кодировка эмодзи.** `python3` (`json.dumps`/`html.escape`) падал `UnicodeEncodeError: surrogates not allowed` на эмодзи DayPlan (🚦🔴🟡🟢⚫) при локали C/POSIX (WSL2 репортёра). Фикс: `export PYTHONUTF8=1` (PEP 540) — наследуется и python3-вызовами в sourced-шаблоне.

Плюс комментарий в `scheduler.sh`: почему notify.sh read-only и сам резолвит `.iwe-runtime` (против повторной регрессии).

## Проверка

- Smoke: с `PYTHONUTF8=1` эмодзи через `json.dumps` под `LC_ALL=C` проходят; резолв `TEMPLATES_DIR` берёт `.iwe-runtime` при наличии, иначе fallback + WARN; `bash -n` обоих файлов OK.
- Холодное независимое ревью: 0 блокеров (наследование PYTHONUTF8 в подпроцессы подтверждено, контракт внешнего override сохранён, кросс-платформенность чиста).
- **Оговорка:** отказ кодировки воспроизводится на Linux/WSL (старый Python под C-локалью), не на macOS (Python 3.14 — UTF-8 mode по умолчанию). Репортёр подтвердил баг на WSL2; фикс — канонический UTF-8-режим, работает на любой платформе.

`Closes #169`. Источник: peer-сессия Claude (писатель) + Kimi (напарник), консенсус достигнут. Слияние — по решению владельца.

🤖 Generated with [Claude Code](https://claude.com/claude-code)