### PR TITLE
fix(backup): #172 cloud перестаёт затирать exocortex/CLAUDE.md

### DIFF
--- a/.github/workflows/cloud-scheduler.yml
+++ b/.github/workflows/cloud-scheduler.yml
@@ -2,7 +2,7 @@ name: IWE Cloud Scheduler (базовый)
 
 # Облачный планировщик IWE — базовый уровень (без LLM).
 # Выполняет задачи, которые не требуют Claude API:
-# - Backup memory/ и CLAUDE.md в exocortex/
+# - Backup memory/ в exocortex/ (CLAUDE.md — НЕ здесь, см. #172: корневой CLAUDE.md бэкапит day-close.sh локально)
 # - Health check ночной автоматики
 #
 # Для пользователей шаблона FMT-exocortex-template.
@@ -71,11 +71,12 @@ jobs:
             echo "✓ Memory files backed up"
           fi
 
-          # Копируем CLAUDE.md из корня workspace если есть
-          if [ -f "CLAUDE.md" ]; then
-            cp "CLAUDE.md" "$BACKUP_DIR/CLAUDE.md"
-            echo "✓ CLAUDE.md backed up"
-          fi
+          # CLAUDE.md НЕ копируется из облака (#172). Слот exocortex/CLAUDE.md семантически =
+          # бэкап КОРНЕВОГО CLAUDE.md рабочей папки: restore-from-exocortex.sh разворачивает его
+          # в $WORKSPACE_DIR/CLAUDE.md. Облако клонирует только STRATEGY_REPO и физически не видит
+          # корневой CLAUDE.md (в слоёной топологии он не лежит ни в одном репо), а CLAUDE.md самого
+          # STRATEGY_REPO уже под git в этом же репо. Корневой бэкапит day-close.sh локально —
+          # это единственно возможное место. Не возвращать копирование сюда (затрёт локальный бэкап).
 
           # Проверяем, есть ли изменения
           if git diff --quiet -- "$BACKUP_DIR/"; then


### PR DESCRIPTION
## Что

`cloud-scheduler.yml` (GitHub Action, 04:00 UTC) копировал CLAUDE.md **governance-репо** в `exocortex/CLAUDE.md` и каждое утро затирал локальный бэкап day-close.

## Находка глубже коллизии

Слот `exocortex/CLAUDE.md` семантически = бэкап **корневого** CLAUDE.md рабочей папки: `restore-from-exocortex.sh:88-90` разворачивает его в `$WORKSPACE_DIR/CLAUDE.md` (корень). Значит облако клало туда **не тот файл** — в слоёной топологии (корневой CLAUDE.md ≠ governance) restore развернул бы governance-контент в корень.

## Решение (вариант B)

cloud-scheduler **перестаёт** копировать CLAUDE.md:
- он видит только governance CLAUDE.md (checkout = STRATEGY_REPO) — неверный файл для этого слота;
- governance CLAUDE.md и так под git в самом STRATEGY_REPO;
- корневой CLAUDE.md облако физически не достанет (не лежит ни в одном репо) — его бэкапит `day-close.sh` локально, это единственно возможное место.

Добавлен комментарий-инвариант, чтобы шаг не вернули как «баг». `day-close.sh` / `restore-from-exocortex.sh` / `AGENTS.md` не тронуты.

## Проверка

- YAML валиден, job `backup-memory` цел (memory-бэкап + commit/push сохранены).
- Холодное независимое ревью: 0 блокеров; аргумент restore-семантики подтверждён по коду; регрессии для канонического юзера нет (его бэкап делает day-close локально).

`Closes #172`. Источник: peer-сессия Claude + Kimi, консенсус. Слияние — по решению владельца.

🤖 Generated with [Claude Code](https://claude.com/claude-code)