### PR TITLE
fix(strategist): exit 0 on concurrent-run skip (scheduler marks done)

### DIFF
--- a/roles/strategist/scripts/strategist.sh
+++ b/roles/strategist/scripts/strategist.sh
@@ -237,8 +237,8 @@ acquire_lock() {
         local pid
         pid=$(cat "$lockdir/pid" 2>/dev/null)
         if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-            log "SKIP: $scenario already running (PID $pid)"
-            exit 2  # non-zero → scheduler won't mark_done
+            log "SKIP: $scenario already running (PID $pid) — exiting 0 so scheduler marks done"
+            exit 0  # task is being handled by concurrent process → treat as success
         else
             log "WARN: removing stale lock (PID $pid no longer exists): $lockdir"
             rm -rf "$lockdir"


### PR DESCRIPTION
## Что

`acquire_lock()` в strategist.sh: при обнаружении уже запущенного сценария было `exit 2`, стало `exit 0`.

## Зачем

`exit 2` (non-zero) → scheduler НЕ помечает задачу `done` → ложный WARN и/или повторный запуск. Но «сценарий уже выполняется параллельным процессом» — это нормальный исход, а не сбой. `exit 0` → scheduler корректно помечает done, без ложной тревоги.

Согласуется с различением «Терминальный fail ≠ Transient fail» (scheduler.sh): concurrent-run = не терминальная ошибка.

