### PR TITLE
fix(validate): allow marked governance literals in fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ scripts/sync-communication-style.yaml
 
 # Backup copies created by skill-promote.sh — local safety net, not for git
 .backups/
+
+# Python bytecode cache — build artifact, not for git
+__pycache__/
+*.pyc

--- a/scripts/tests/test_skill_promote.py
+++ b/scripts/tests/test_skill_promote.py
@@ -37,7 +37,7 @@ triggers:
 # {name}
 
 Этот скилл использует путь /Users/testuser/IWE/scripts/helper.sh
-и ссылается на репо DS-strategy.
+и ссылается на репо DS-strategy.  # validate-fmt-scripts: allow-governance-literal
 
 ```bash
 bash /Users/testuser/IWE/scripts/helper.sh

--- a/scripts/validate-fmt-scripts.sh
+++ b/scripts/validate-fmt-scripts.sh
@@ -80,6 +80,7 @@ if [[ "$MODE" != "settings-json" ]]; then
         #   - os.environ.get("GOVERNANCE_REPO", "DS-strategy")  (python fallback)
         #   - GOV_REPO_TMPL="DS-strategy"          (template identity literal)
         #   - VAR="DS-strategy" \                  (env override в команде, line cont)
+        #   - строка с маркером validate-fmt-scripts: allow-governance-literal (тестовая фикстура)
         # Запрещено: буквальное имя governance-репо вне fallback-паттерна в исполняемых строках
         # Комментарии (#) пропускаются — документация не влияет на поведение
         if grep -q "$AUTHOR_GOV_REPO" "$f" 2>/dev/null; then
@@ -90,6 +91,7 @@ if [[ "$MODE" != "settings-json" ]]; then
                 | grep -vE '^[0-9]*:[[:space:]]*[A-Z_]+_TMPL=' \
                 | grep -vE "os\.environ\.get\([^)]*,[[:space:]]*[\"']" \
                 | grep -vE '^[0-9]*:\s*[A-Z_][A-Z0-9_]*="[^"]*"[[:space:]]*[\\]$' \
+                | grep -v 'validate-fmt-scripts: allow-governance-literal' \
                 || true)
             if [[ -n "$bad_lines" ]]; then
                 echo "  ❌ $fname: '$AUTHOR_GOV_REPO' без env fallback в коде" >&2

--- a/seed/strategy/AGENTS.md
+++ b/seed/strategy/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/setup/smoke-test-fresh-install.sh
+++ b/setup/smoke-test-fresh-install.sh
@@ -155,26 +155,26 @@ bash "$TEMPLATE_DIR/setup/build-runtime.sh" --workspace "$TEST_WS" --env-file "$
 if grep -rq 'DS-pilot-strategy' "$TEST_WS/.iwe-runtime/roles/" 2>/dev/null; then
     pass "GOVERNANCE_REPO=DS-pilot-strategy подставлен в .iwe-runtime/"
 else
-    fail "GOVERNANCE_REPO не подставлен — хардкод DS-strategy остался (R6.1 regression)"
+    fail "GOVERNANCE_REPO не подставлен — хардкод DS-strategy остался (R6.1 regression)"  # validate-fmt-scripts: allow-governance-literal
 fi
 # Дополнительно: НЕ должно быть literal /DS-strategy/ в .iwe-runtime/ (если только не GOVERNANCE_REPO=DS-strategy).
 # Bash gotcha: `... | head -1 >/dev/null` всегда exit 0 даже на пустом stdin.
 # Используем grep -q . — true ТОЛЬКО если есть хоть один матч.
-LITERAL_HARDCODES=$(grep -rE '/DS-strategy[/"]' "$TEST_WS/.iwe-runtime/roles/" 2>/dev/null | grep -v ':#' || true)
+LITERAL_HARDCODES=$(grep -rE '/DS-strategy[/"]' "$TEST_WS/.iwe-runtime/roles/" 2>/dev/null | grep -v ':#' || true)  # validate-fmt-scripts: allow-governance-literal
 if [ -n "$LITERAL_HARDCODES" ]; then
-    fail "literal /DS-strategy/ остался в runtime (хардкод не убран): $LITERAL_HARDCODES"
+    fail "literal /DS-strategy/ остался в runtime (хардкод не убран): $LITERAL_HARDCODES"  # validate-fmt-scripts: allow-governance-literal
 else
-    pass "no literal /DS-strategy/ в runtime"
+    pass "no literal /DS-strategy/ в runtime"  # validate-fmt-scripts: allow-governance-literal
 fi
 
 # WP-293: расширение 6a — проверка template источников в roles/*/scripts/.
 # `dt-collect.sh` и аналоги не попадают в .iwe-runtime/ (используются напрямую cron'ом),
 # поэтому проверка только runtime-зоны выше пропускает hardcode'ы вроде dt-collect.sh:234.
-LITERAL_IN_TEMPLATE=$(grep -rE '/DS-strategy[/"]' "$TEMPLATE_DIR/roles/"*/scripts/ 2>/dev/null | grep -v ':#' || true)
+LITERAL_IN_TEMPLATE=$(grep -rE '/DS-strategy[/"]' "$TEMPLATE_DIR/roles/"*/scripts/ 2>/dev/null | grep -v ':#' || true)  # validate-fmt-scripts: allow-governance-literal
 if [ -n "$LITERAL_IN_TEMPLATE" ]; then
-    fail "literal /DS-strategy/ в template roles/*/scripts/ (use \$GOVERNANCE_DIR): $LITERAL_IN_TEMPLATE"
+    fail "literal /DS-strategy/ в template roles/*/scripts/ (use \$GOVERNANCE_DIR): $LITERAL_IN_TEMPLATE"  # validate-fmt-scripts: allow-governance-literal
 else
-    pass "no literal /DS-strategy/ в template roles/*/scripts/"
+    pass "no literal /DS-strategy/ в template roles/*/scripts/"  # validate-fmt-scripts: allow-governance-literal
 fi
 
 # === Test 6b: REMAINING placeholder check sanity (R6.2 regression guard) ===
@@ -274,7 +274,7 @@ print(mod.WORKSPACE)
 if echo "$PY_RESULT" | grep -q "DS-pilot-strategy"; then
     pass "Python script резолвит GOVERNANCE_REPO=DS-pilot-strategy"
 else
-    fail "Python script хардкод DS-strategy остался: $PY_RESULT"
+    fail "Python script хардкод DS-strategy остался: $PY_RESULT"  # validate-fmt-scripts: allow-governance-literal
 fi
 
 # === Test 6: install.sh С env проходит fail-fast check ===

--- a/setup/test-update-edge-cases.sh
+++ b/setup/test-update-edge-cases.sh
@@ -47,7 +47,7 @@ mkdir -p "$TEST_WS"
 
 # Build a minimal fake governance repo that update.sh can find
 setup_fake_governance() {
-    local gov="$TEST_WS/DS-strategy"
+    local gov="$TEST_WS/DS-strategy"  # validate-fmt-scripts: allow-governance-literal
     mkdir -p "$gov"
     git -C "$gov" init -q
     git -C "$gov" config user.email "test@test"
@@ -164,7 +164,7 @@ rm -f "$RUNTIME_DIR/orphan-test.plist" "$RUNTIME_DIR/clean-test.plist"
 # ============================================================
 echo "--- T3: conflict-marker stacking guard ---"
 
-gov3="$TEST_WS/DS-strategy-t3"
+gov3="$TEST_WS/DS-strategy-t3"  # validate-fmt-scripts: allow-governance-literal
 mkdir -p "$gov3"
 git -C "$gov3" init -q
 git -C "$gov3" config user.email "test@test"

--- a/templates/strategy-skeleton/AGENTS.md
+++ b/templates/strategy-skeleton/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Что исправлено

`validate-fmt-scripts.sh` теперь пропускает только явно помеченные тестовые фикстуры с литералом `DS-strategy`:

```bash
# validate-fmt-scripts: allow-governance-literal
```

Рабочий код без env-fallback по-прежнему блокируется. Это закрывает false positive, когда `DS-strategy` находится в тесте, который специально проверяет отсутствие hardcode-регрессии.

## История появления бага

Баг проявился на `/iwe-update` при безопасной синхронизации fork/PR-ветки с `upstream/main`: merge был разрешён, `setup/validate-template.sh` прошёл, но pre-commit остановил commit на `HOOK-PATH-CONVENTION`.

Причина составная:

1. `validate-fmt-scripts.sh` получил детектор голого `DS-strategy` без env-fallback 2026-05-22 (`95817fa`, TserenTserenov). Для рабочих скриптов это корректный gate.
2. 2026-06-04 (`a85cf57`, TserenTserenov) pre-commit стал передавать в `validate-fmt-scripts.sh --files` все staged `.sh/.py`, а не весь `scripts/`. Это полезно, но расширило зону проверки на `setup/*.sh` и `scripts/tests/*.py`, если они попали в staged merge.
3. В `setup/smoke-test-fresh-install.sh` старые test-regression строки с `DS-strategy` существуют с 2026-04-27 (`dd182cc`, TserenTserenov), но раньше не мешали.
4. В `scripts/tests/test_skill_promote.py` fixture с `DS-strategy` добавлен 2026-06-15 (`5e21531`, TserenTserenov).
5. В `setup/test-update-edge-cases.sh` новые fixtures с `DS-strategy` добавлены 2026-06-25 (`51cb56d`, TserenTserenov, co-authored Claude Sonnet 4.6).

Итог: detector правильный для production-кода, но у него не было способа отличить намеренную test fixture от настоящего hardcode.

## Почему не исключаем все тесты целиком

Полное исключение `test_*.py` / `setup/test-*.sh` сделало бы проверку слишком слабой: настоящий hardcode в тестовом скрипте мог бы пройти незамеченным.

Текущий PR требует явного маркера на каждой допустимой строке. Это оставляет gate строгим и делает исключение видимым в diff.

## Проверки

- `bash scripts/validate-fmt-scripts.sh --files scripts/tests/test_skill_promote.py setup/smoke-test-fresh-install.sh setup/test-update-edge-cases.sh` - passed
- Negative fixture without marker - blocked as expected
- Positive fixture with marker - passed
- `bash -n scripts/validate-fmt-scripts.sh setup/smoke-test-fresh-install.sh setup/test-update-edge-cases.sh` - passed
- `python3 -m py_compile scripts/tests/test_skill_promote.py` - passed
- `bash setup/validate-template.sh /home/natty/IWE/FMT-exocortex-template` - passed with existing warnings

Не запускалось: `pytest`, потому что в локальном окружении нет модуля `pytest`.
