### PR TITLE
fix(hook): DayPlan-валидатор обходится связкой `git add && git commit`

### DIFF
--- a/.claude/hooks/protocol-artifact-validate.sh
+++ b/.claude/hooks/protocol-artifact-validate.sh
@@ -39,6 +39,53 @@ GOV_PATH="$WORKSPACE/$GOV_REPO"
 # на любой коммит файла `day-close/SKILL.md` или сообщения с «day-close».
 # Принцип: «hook trigger = artifact (staged file), не TOOL_INPUT текст» (memory/hooks-design.md).
 STAGED=$(cd "$GOV_PATH" 2>/dev/null && git diff --cached --name-only 2>/dev/null || echo "")
+
+# bug-2026-07-24 fix: индекс читается ДО запуска команды, поэтому связка
+# `git add X && git commit` проходила без валидации — на момент проверки индекс
+# ещё пуст, и хук выходил на строке ниже. Дополняем фактический индекс путями,
+# которые команда собирается застейджить сама.
+#
+# Принцип WP-273 не нарушается: парсится не весь текст команды, а ТОЛЬКО
+# сегменты, начинающиеся с `git add`. Сообщение коммита с упоминанием DayPlan
+# false positive не даёт, потому что сегмент `git commit -m ...` не парсится.
+extract_git_add_paths() {
+  local segments seg args toks tok out=""
+  # Разбиваем команду на сегменты по разделителям — валидируем только `git add`.
+  # awk, а не `sed 's/&&/\n/g'`: BSD sed (macOS) вставил бы литерал «n».
+  segments=$(printf '%s\n' "$TOOL_INPUT" | awk '{gsub(/&&|\|\||;|\|/, "\n"); print}')
+  while IFS= read -r seg; do
+    echo "$seg" | grep -qE '(^|[[:space:]])git[[:space:]]+add([[:space:]]|$)' || continue
+    args=${seg#*git}
+    args=${args#*add}
+    # xargs разбирает кавычки по-шелловски — пути с пробелами не рвутся.
+    toks=$(printf '%s' "$args" | xargs -n1 2>/dev/null) || toks=""
+    while IFS= read -r tok; do
+      [ -z "$tok" ] && continue
+      case "$tok" in
+        # Массовый стейджинг (запрещён CLAUDE.md, но дыру не оставляем):
+        # берём изменённые артефакты из рабочего дерева.
+        .|-A|--all|-u|--update)
+          # -uall: без него неотслеживаемый каталог схлопывается в `current/`
+          # и новый DayPlan не виден.
+          out="$out$(cd "$GOV_PATH" 2>/dev/null && git status --porcelain -uall 2>/dev/null \
+            | sed -e 's/^...//' -e 's/^.* -> //' -e 's/^"//' -e 's/"$//')"$'\n'
+          continue
+          ;;
+        -*) continue ;;
+      esac
+      tok=${tok#./}
+      # Абсолютный или вложенный путь -> repo-relative.
+      case "$tok" in
+        */current/*) tok="current/${tok#*/current/}" ;;
+      esac
+      out="$out$tok"$'\n'
+    done <<< "$toks"
+  done <<< "$segments"
+  printf '%s' "$out"
+}
+
+STAGED=$(printf '%s\n%s\n' "$STAGED" "$(extract_git_add_paths)" | sed '/^$/d' | sort -u)
+
 if ! echo "$STAGED" | grep -qE '^current/DayPlan.*\.md$|^current/WeekPlan.*\.md$'; then
   echo '{}'
   exit 0

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -78,6 +78,8 @@ jobs:
         run: bash setup/smoke-test-fresh-install.sh
       - name: Run detector regression fixtures (regex gap guard)
         run: bash setup/test-detectors.sh
+      - name: Run DayPlan-validator hook regression (trigger gap guard)
+        run: bash setup/test-hook-dayplan-validator.sh
 
   # Upgrade-flow regression test (0.29.18).
   # Корень бага (0.29.13): template-sync перезаписал FMT файлы — smoke-test fresh

--- a/setup/test-hook-dayplan-validator.sh
+++ b/setup/test-hook-dayplan-validator.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# test-hook-dayplan-validator.sh — регрессионный тест для
+# .claude/hooks/protocol-artifact-validate.sh
+#
+# Назначение: ловить регрессию триггера. Хук — PreToolUse на Bash, и он читает
+# `git diff --cached` ДО того, как команда выполнится. Если `git add` находится
+# внутри той же команды, что и `git commit` (`git add X && git commit -m ...`),
+# то на момент проверки индекс ещё пуст — раньше хук выходил с `{}` и коммит
+# проходил без валидации. Тест фиксирует, что обе формы коммита валидируются
+# и что при этом не появилось ложных срабатываний по тексту команды (WP-273).
+#
+# Usage:
+#   bash setup/test-hook-dayplan-validator.sh
+#
+# Exit:
+#   0 — все проверки прошли
+#   1 — есть провалы (или не найден хук / jq)
+
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+HOOK="$REPO_ROOT/.claude/hooks/protocol-artifact-validate.sh"
+[ -f "$HOOK" ] || { echo "SKIP: хук не найден: $HOOK"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq не установлен"; exit 0; }
+
+FIXTURE=$(mktemp -d)
+trap 'rm -rf "$FIXTURE"' EXIT
+mkdir -p "$FIXTURE/GOV/current"
+git -C "$FIXTURE/GOV" init -q
+
+# DayPlan, заведомо не проходящий check 4 (нет слова «mandatory»),
+# но валидный по всем остальным проверкам.
+cat > "$FIXTURE/GOV/current/DayPlan 2026-07-24.md" <<'EOF'
+# Day Plan
+<summary><b>План на сегодня</b></summary>
+| # | РП | h |
+|---|-----|---|
+| 1 | Пример | 5 |
+**Бюджет дня:** ~7.5h РП всего / ~7.5h физ / мультипликатор ~1.0x
+<summary><b>Календарь</b></summary>
+нет событий
+строка два
+строка три
+<summary><b>IWE за ночь</b></summary>
+ок
+<summary><b>Разбор заметок</b></summary>
+пусто
+<summary><b>Итоги вчера</b></summary>
+carry-over: нет
+EOF
+
+export IWE_WORKSPACE="$FIXTURE" IWE_GOVERNANCE_REPO="GOV"
+FAILED=0
+
+run_case() {
+  local name="$1" cmd="$2" expect="$3" out verdict
+  out=$(jq -n --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}' | bash "$HOOK")
+  case "$out" in
+    *'"decision": "block"'*) verdict="BLOCK" ;;
+    '{}')                    verdict="PASS-THROUGH" ;;
+    *additionalContext*)     verdict="VALIDATED-OK" ;;
+    *)                       verdict="UNKNOWN" ;;
+  esac
+  if [ "$verdict" = "$expect" ]; then
+    echo "  ok   $name -> $verdict"
+  else
+    echo "  FAIL $name -> $verdict (ожидалось $expect)"
+    echo "       вывод: $out"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+echo "== Невалидный DayPlan: связка add+commit обязана блокироваться =="
+run_case "add+commit одной командой, путь в кавычках" \
+  'cd ~/x && git add "current/DayPlan 2026-07-24.md" && git commit -m "test"' BLOCK
+run_case "add+commit, абсолютный путь" \
+  "git add '$FIXTURE/GOV/current/DayPlan 2026-07-24.md' && git commit -m x" BLOCK
+run_case "git add . && commit (массовый стейджинг)" \
+  'git add . && git commit -m x' BLOCK
+run_case "add+commit через точку с запятой" \
+  'git add "current/DayPlan 2026-07-24.md"; git commit -m x' BLOCK
+
+echo "== Отсутствие ложных срабатываний (принцип WP-273) =="
+run_case "commit без add, индекс пуст" \
+  'git commit -m "правил current/DayPlan 2026-07-24.md"' PASS-THROUGH
+run_case "сообщение упоминает DayPlan, стейджится другой файл" \
+  'git add README.md && git commit -m "см. current/DayPlan 2026-07-24.md"' PASS-THROUGH
+run_case "git add без commit" \
+  'git add "current/DayPlan 2026-07-24.md"' PASS-THROUGH
+run_case "посторонняя команда" 'ls -la' PASS-THROUGH
+
+echo "== Валидный DayPlan проходит =="
+printf '\n**Mandatory check:** обязательных РП нет.\n' >> "$FIXTURE/GOV/current/DayPlan 2026-07-24.md"
+run_case "add+commit одной командой, валидный DayPlan" \
+  'git add "current/DayPlan 2026-07-24.md" && git commit -m x' VALIDATED-OK
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+  echo "OK: все 9 проверок прошли."
+else
+  echo "FAIL: провалено проверок: $FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## Что изменилось и почему

`.claude/hooks/protocol-artifact-validate.sh` — PreToolUse-хук на Bash. Он читает `git diff --cached` **до** того, как перехваченная команда выполнится. Если `git add` находится внутри той же команды, что и `git commit`:

```bash
git add "current/DayPlan 2026-07-24.md" && git commit -m "Day Open"
```

то на момент проверки индекс ещё пуст, `$STAGED` не содержит DayPlan, и хук выходит на строке 42 с `{}`. Коммит проходит без валидации.

Обнаружено на живой установке: три коммита подряд трогали один и тот же DayPlan, в котором отсутствовало слово «mandatory» (check 4). Два, где `git add` и `git commit` были в одной команде, прошли молча. Третий, где `git add` был отдельным вызовом, — заблокирован. Файл во всех трёх случаях был идентичен по этому признаку.

То есть защита сейчас работает только когда staging и commit разнесены по разным вызовам инструмента — фактически случайно.

## Решение

`$STAGED` = фактический индекс ∪ пути из `git add` в самой команде.

Принцип WP-273 («trigger = artifact, не текст команды») сохранён: разбирается **не весь** текст команды, а только сегменты, начинающиеся с `git add`. Сегмент `git commit -m "…"` не парсится, поэтому сообщение коммита с упоминанием DayPlan ложного срабатывания не даёт — это отдельно закрыто тестом.

Детали реализации:

- сегментация по `&&`, `||`, `;`, `|` через **awk**, а не `sed 's/&&/\n/g'` — BSD sed на macOS вставил бы литерал «n»;
- токены через `xargs -n1` — разбирает кавычки по-шелловски, пути с пробелами (`"DayPlan 2026-07-24.md"`) не рвутся;
- абсолютные и вложенные пути нормализуются к repo-relative по сегменту `current/`;
- массовый стейджинг (`.`, `-A`, `-u`) — дыру не оставляем: подтягиваются изменённые артефакты из `git status --porcelain -uall`. Флаг `-uall` обязателен, иначе неотслеживаемый каталог схлопывается в `current/` и новый DayPlan не виден (на этом первая версия фикса и провалила тест).

## Как проверено

Новый `setup/test-hook-dayplan-validator.sh` — 9 проверок на временном фикстур-репо (`mktemp -d`, чистится по trap):

- 4 варианта, где невалидный DayPlan **обязан** блокироваться: путь в кавычках, абсолютный путь, `git add .`, разделитель `;`;
- 4 проверки на отсутствие ложных срабатываний: commit без add при пустом индексе, commit-сообщение с упоминанием DayPlan при стейджинге другого файла, `git add` без commit, посторонняя команда;
- 1 проверка, что валидный DayPlan проходит и отдаёт `additionalContext`.

Все зелёные. Тест подключён в `validate-template.yml` рядом с `test-detectors.sh`. Дополнительно прогнал на реальной установке: DayPlan и WeekPlan валидируются, посторонний файл проходит насквозь.

Платформенных конструкций из списка `check-platform-compat.sh` (`date -v`, `sed -i ''`, `stat -f`, `readlink -f`, `grep -P`) не добавлено.

## Один нюанс отдельно от этого PR

Check 4 (`grep -qi "mandatory"`, строка ~114) требует слова «mandatory» безусловно, даже когда `mandatory_daily_wps` в `day-rhythm-config.yaml` не сконфигурированы, — а ни `templates.md`, ни `day-open-scaffold.sh` его не эмитят. То есть после этого PR валидатор начнёт честно блокировать DayPlan, которые раньше проскакивали. У себя закрыли строкой «Mandatory check: …» в шаблоне DayPlan, но, возможно, проверку стоит сделать условной. Сознательно не трогал — одна тема на PR.
