### PR TITLE
fix(#366): резолв claude из нативного инсталлера (~/.local/bin) + fail-fast в скриптах ролей

### DIFF
--- a/roles/extractor/scripts/extractor.sh
+++ b/roles/extractor/scripts/extractor.sh
@@ -47,10 +47,16 @@ if [ -n "${CLAUDE_CLI_PATH:-}" ]; then
     CLAUDE_PATH="$CLAUDE_CLI_PATH"
 elif command -v claude &>/dev/null; then
     CLAUDE_PATH="$(command -v claude)"
+elif [ -x "$HOME/.local/bin/claude" ]; then
+    CLAUDE_PATH="$HOME/.local/bin/claude"  # нативный инсталлер (curl -fsSL claude.ai/install.sh)
 elif [ -x "$HOME/.npm-global/bin/claude" ]; then
     CLAUDE_PATH="$HOME/.npm-global/bin/claude"
 else
     CLAUDE_PATH="{{CLAUDE_PATH}}"  # fallback: build-runtime должен был подставить
+fi
+if [ ! -x "$CLAUDE_PATH" ]; then
+    echo "[$(date '+%H:%M:%S')] ERROR: claude CLI не найден ни по одному пути (CLAUDE_CLI_PATH/PATH/~/.local/bin/~/.npm-global/фолбэк='$CLAUDE_PATH'). Задайте CLAUDE_CLI_PATH в plist." >&2
+    exit 127
 fi
 ENV_FILE="$HOME/.config/aist/env"
 

--- a/roles/extractor/scripts/launchd/com.extractor.inbox-check.plist
+++ b/roles/extractor/scripts/launchd/com.extractor.inbox-check.plist
@@ -23,7 +23,7 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <string>{{HOME_DIR}}/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
         <key>HOME</key>
         <string>{{HOME_DIR}}</string>
         <key>IWE_TEMPLATE</key>

--- a/roles/strategist/scripts/launchd/com.strategist.morning.plist
+++ b/roles/strategist/scripts/launchd/com.strategist.morning.plist
@@ -28,7 +28,7 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <string>{{HOME_DIR}}/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
         <key>HOME</key>
         <string>{{HOME_DIR}}</string>
         <key>IWE_TEMPLATE</key>

--- a/roles/strategist/scripts/launchd/com.strategist.weekreview.plist
+++ b/roles/strategist/scripts/launchd/com.strategist.weekreview.plist
@@ -30,7 +30,7 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <string>{{HOME_DIR}}/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
         <key>HOME</key>
         <string>{{HOME_DIR}}</string>
         <key>IWE_TEMPLATE</key>

--- a/roles/strategist/scripts/strategist.sh
+++ b/roles/strategist/scripts/strategist.sh
@@ -46,10 +46,16 @@ if [ -n "${CLAUDE_CLI_PATH:-}" ]; then
     CLAUDE_PATH="$CLAUDE_CLI_PATH"
 elif command -v claude &>/dev/null; then
     CLAUDE_PATH="$(command -v claude)"
+elif [ -x "$HOME/.local/bin/claude" ]; then
+    CLAUDE_PATH="$HOME/.local/bin/claude"  # нативный инсталлер (curl -fsSL claude.ai/install.sh)
 elif [ -x "$HOME/.npm-global/bin/claude" ]; then
     CLAUDE_PATH="$HOME/.npm-global/bin/claude"
 else
     CLAUDE_PATH="{{CLAUDE_PATH}}"  # fallback: build-runtime должен был подставить
+fi
+if [ ! -x "$CLAUDE_PATH" ]; then
+    echo "[$(date '+%H:%M:%S')] ERROR: claude CLI не найден ни по одному пути (CLAUDE_CLI_PATH/PATH/~/.local/bin/~/.npm-global/фолбэк='$CLAUDE_PATH'). Задайте CLAUDE_CLI_PATH в plist." >&2
+    exit 127
 fi
 CLAUDE_TIMEOUT=1800  # 30 мин — защита от зависания Claude CLI
 

--- a/roles/synchronizer/scripts/launchd/com.exocortex.scheduler.plist
+++ b/roles/synchronizer/scripts/launchd/com.exocortex.scheduler.plist
@@ -46,7 +46,7 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <string>{{HOME_DIR}}/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
         <key>HOME</key>
         <string>{{HOME_DIR}}</string>
         <key>IWE_TEMPLATE</key>


### PR DESCRIPTION
Closes #366.

Claude Code из нативного инсталлера живёт в `~/.local/bin/claude` — этот путь не знали ни цепочки резолва в скриптах ролей, ни PATH в plist-шаблонах. В окружении launchd все кандидаты промахивались, скрипт exec'ал несуществующий фолбэк, и все ночные сценарии умирали с загадочным `rc=2` до вызова модели (у нас — пять недель, см. issue).

## Изменения (16 строк, 6 файлов)

1. **Цепочки резолва** (`strategist.sh`, `extractor.sh`): кандидат `$HOME/.local/bin/claude` после `command -v`, до `~/.npm-global`.
2. **PATH четырёх plist-шаблонов** (morning, weekreview, scheduler, extractor): `{{HOME_DIR}}/.local/bin` первым элементом.
3. **Fail-fast:** после резолва — проверка `[ -x "$CLAUDE_PATH" ]`; при провале понятная ошибка «claude CLI не найден… Задайте CLAUDE_CLI_PATH в plist» и код 127 вместо `exec failed: No such file or directory at -e line 5` с кодом 2, который маскировался под ошибку CLI.

## Тесты (живая установка: macOS, native installer, claude 2.1.223)

| Сценарий | До | После |
|---|---|---|
| Окружение launchd без `CLAUDE_CLI_PATH`, PATH без `~/.local/bin` | фолбэк на несуществующий путь → rc=2 | резолв в `~/.local/bin/claude`, `--version` работает |
| `command -v claude` под PATH из правленого шаблона (плейсхолдер подставлен) | не находился | находится |
| claude отсутствует везде (fake HOME) | тихий exec fail, rc=2 | внятная ошибка, rc=127 |

`bash -n` на обоих скриптах чист. Замечания `plutil -lint` на morning/scheduler существуют и до патча (плейсхолдер `{{TIMEZONE_HOUR}}` в `<integer>`) — не регрессия.

Патч идентичен приложенному в #366; ветка собрана от `origin/main` (v0.38.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
