### PR TITLE
fix: scope install-path guard to update diff

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -387,6 +387,11 @@ jobs:
       - name: Run update.sh edge-case regression tests (T1-T17)
         run: bash setup/test-update-edge-cases.sh
 
+      # PR #385: cloud install paths may occur legitimately in old tracked text;
+      # only additions made by the current updater run are publication blockers.
+      - name: Test staged install-path guard
+        run: bash scripts/tests/test_update_install_path_guard.sh
+
       # issue #310/#323: хук-страж, не зарегистрированный ни в одном событии, не
       # срабатывает никогда — и «не сработал» неотличимо от «нарушений не было».
       - name: Check every hook is actually wired (orphan-hook guard)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # IWE — Intellectual Work Environment
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.36.3-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.38.1-blue.svg)](CHANGELOG.md)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(Git%20Bash)-lightgrey.svg)]()
 [![EN sync](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/TserenTserenov/FMT-exocortex-template/en-draft/badge-data.json)](https://github.com/TserenTserenov/FMT-exocortex-template/tree/en-draft)
 

--- a/scripts/tests/test_update_install_path_guard.sh
+++ b/scripts/tests/test_update_install_path_guard.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Load only the guard under test; sourcing update.sh would execute the updater.
+eval "$(awk '
+  /^validate_no_install_values_in_staged_additions\(\)/ { capture=1 }
+  capture { print }
+  capture && /^}/ { exit }
+' "$ROOT/update.sh")"
+declare -F validate_no_install_values_in_staged_additions >/dev/null
+
+SCRIPT_DIR="$TMP/template"
+WORKSPACE_DIR="$TMP/workspace"
+mkdir -p "$SCRIPT_DIR" "$WORKSPACE_DIR"
+git -C "$SCRIPT_DIR" init -q
+git -C "$SCRIPT_DIR" config user.email test@example.invalid
+git -C "$SCRIPT_DIR" config user.name 'Install path guard test'
+
+cat >"$WORKSPACE_DIR/.exocortex.env" <<EOF
+WORKSPACE_DIR=$WORKSPACE_DIR
+HOME_DIR=/root
+CLAUDE_PATH=/root/.claude
+IWE_TEMPLATE=$SCRIPT_DIR
+IWE_RUNTIME=$WORKSPACE_DIR/.iwe-runtime
+EOF
+
+# Existing tracked install-like values are outside the updater's responsibility.
+# An unrelated staged addition must not be blocked by historical container docs.
+cat >"$SCRIPT_DIR/existing.md" <<'EOF'
+The container user has HOME=/root and stores Claude config in /root/.claude.
+EOF
+git -C "$SCRIPT_DIR" add existing.md
+git -C "$SCRIPT_DIR" commit -qm baseline
+printf 'Safe update line.\n' >>"$SCRIPT_DIR/existing.md"
+git -C "$SCRIPT_DIR" add existing.md
+APPLIED_PATHS=(existing.md)
+validate_no_install_values_in_staged_additions
+
+# A value newly introduced by the updater must still block the commit.
+printf 'Leaked workspace: %s\n' "$WORKSPACE_DIR" >"$SCRIPT_DIR/leak.md"
+git -C "$SCRIPT_DIR" add leak.md
+APPLIED_PATHS=(existing.md)
+validate_no_install_values_in_staged_additions
+
+# Once the leaking path belongs to this updater run, the guard must reject it.
+APPLIED_PATHS=(existing.md leak.md)
+if validate_no_install_values_in_staged_additions 2>"$TMP/guard.err"; then
+    echo 'guard accepted a newly added install value' >&2
+    exit 1
+fi
+grep -Fq 'install-value WORKSPACE_DIR' "$TMP/guard.err"
+if grep -Fq -- "$WORKSPACE_DIR" "$TMP/guard.err"; then
+    echo 'guard disclosed the install value in diagnostics' >&2
+    exit 1
+fi
+
+# Deleting a leaked value makes the tree safer and must not be rejected.
+git -C "$SCRIPT_DIR" reset -q HEAD -- .
+git -C "$SCRIPT_DIR" checkout -q -- .
+printf 'legacy %s\nkeep\n' "$WORKSPACE_DIR" >"$SCRIPT_DIR/remove-leak.md"
+git -C "$SCRIPT_DIR" add remove-leak.md
+git -C "$SCRIPT_DIR" commit -qm 'add legacy fixture'
+grep -v 'legacy' "$SCRIPT_DIR/remove-leak.md" >"$TMP/cleaned"
+mv "$TMP/cleaned" "$SCRIPT_DIR/remove-leak.md"
+git -C "$SCRIPT_DIR" add remove-leak.md
+APPLIED_PATHS=(remove-leak.md)
+validate_no_install_values_in_staged_additions
+
+echo 'PASS: install-path guard checks only staged additions'

--- a/scripts/tests/test_update_install_path_guard.sh
+++ b/scripts/tests/test_update_install_path_guard.sh
@@ -53,8 +53,25 @@ if validate_no_install_values_in_staged_additions 2>"$TMP/guard.err"; then
     exit 1
 fi
 grep -Fq 'install-value WORKSPACE_DIR' "$TMP/guard.err"
+grep -Fq 'leak.md' "$TMP/guard.err"
 if grep -Fq -- "$WORKSPACE_DIR" "$TMP/guard.err"; then
     echo 'guard disclosed the install value in diagnostics' >&2
+    exit 1
+fi
+
+# Content beginning with "++ " appears as "+++ " in a patch. It must not be
+# mistaken for the file header; a spaced filename also exercises path handling.
+printf '++ %s/no-newline' "$WORKSPACE_DIR" >"$SCRIPT_DIR/prefix leak.md"
+git -C "$SCRIPT_DIR" add 'prefix leak.md'
+APPLIED_PATHS=(leak.md 'prefix leak.md')
+if validate_no_install_values_in_staged_additions 2>"$TMP/prefix-guard.err"; then
+    echo 'guard accepted header-like content containing an install value' >&2
+    exit 1
+fi
+grep -Fq 'leak.md' "$TMP/prefix-guard.err"
+grep -Fq 'prefix leak.md' "$TMP/prefix-guard.err"
+if grep -Fq -- "$WORKSPACE_DIR" "$TMP/prefix-guard.err"; then
+    echo 'guard disclosed the header-like install value in diagnostics' >&2
     exit 1
 fi
 

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2317,7 +2317,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "6516582fe731c8da57a04ec9721f03cadfc2ab7e7fa8d28eded4b20f432a8eb5"
+      "sha256": "2765c32744e76a4c6702e9aa6325c09dc1411b446da9ef23f662cceaf7d7a754"
     }
   ],
   "excluded_paths": [
@@ -2354,6 +2354,7 @@
     "scripts/tests/test_skill_promote.py",
     "scripts/tests/test_translate_delta.py",
     "scripts/tests/test_translate_parse.py",
+    "scripts/tests/test_update_install_path_guard.sh",
     "scripts/translate.py",
     "scripts/verify-template-integrity.sh",
     "sessions/2026-06/2026-06-17-01-kimi-setup/00-writer.md",

--- a/update.sh
+++ b/update.sh
@@ -1737,24 +1737,39 @@ if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "$BRANCH" ]; then
 fi
 
 validate_no_install_values_in_staged_additions() {
-    local env_file="$WORKSPACE_DIR/.exocortex.env" key value hit failed=0 staged_additions
+    local env_file="$WORKSPACE_DIR/.exocortex.env" key value failed=0 fpath staged_additions i
+    local -a install_keys=() install_values=()
     [ -f "$env_file" ] || return 0
     [ "${#APPLIED_PATHS[@]}" -gt 0 ] || return 0
 
-    # Guard the material introduced by this update, not every historical line in
-    # the repository. Common cloud values such as /root legitimately occur in
-    # container documentation and used to make every update fail. Diff headers
-    # are excluded so an install value in a path cannot create a false positive.
-    staged_additions=$(git -C "$SCRIPT_DIR" diff --cached --no-color --unified=0 -- "${APPLIED_PATHS[@]}" |
-        sed -n '/^+++ /d; /^+/s/^+//p')
     for key in WORKSPACE_DIR HOME_DIR CLAUDE_PATH IWE_TEMPLATE IWE_RUNTIME; do
         value=$(grep -E "^${key}=" "$env_file" 2>/dev/null | head -1 | cut -d= -f2- | sed -E 's/^"//; s/"$//; s/^'"'"'//; s/'"'"'$//')
         [ -n "$value" ] || continue
-        hit=$(printf '%s\n' "$staged_additions" | grep -F -- "$value" || true)
-        if [ -n "$hit" ]; then
-            echo "  ✗ install-value $key найден в добавленных строках обновления" >&2
-            failed=1
-        fi
+        install_keys+=("$key")
+        install_values+=("$value")
+    done
+
+    # Guard only the lines introduced in files handled by this update. Parse
+    # additions inside @@ hunks instead of filtering +++ headers by prefix:
+    # content beginning with "++ " also appears as "+++ " in a patch.
+    # Iterating paths separately keeps the diagnostic filename authoritative
+    # without parsing quoted/renamed diff headers or disclosing the matched value.
+    for fpath in "${APPLIED_PATHS[@]}"; do
+        staged_additions=$(git -C "$SCRIPT_DIR" diff --cached --no-color --no-ext-diff --no-textconv --unified=0 -- "$fpath" |
+            awk '
+                /^diff --git / { in_hunk=0; next }
+                /^@@ / { in_hunk=1; next }
+                in_hunk && /^\+/ { print substr($0, 2) }
+            ')
+        [ -n "$staged_additions" ] || continue
+
+        for i in "${!install_keys[@]}"; do
+            if grep -Fq -- "${install_values[$i]}" <<<"$staged_additions"; then
+                echo "  ✗ install-value ${install_keys[$i]} найден в добавленных строках обновления:" >&2
+                printf '    %s\n' "$fpath" >&2
+                failed=1
+            fi
+        done
     done
     [ "$failed" -eq 0 ]
 }

--- a/update.sh
+++ b/update.sh
@@ -1736,16 +1736,23 @@ if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "$BRANCH" ]; then
     fi
 fi
 
-validate_no_install_values_in_tracked_files() {
-    local env_file="$WORKSPACE_DIR/.exocortex.env" key value hit failed=0
+validate_no_install_values_in_staged_additions() {
+    local env_file="$WORKSPACE_DIR/.exocortex.env" key value hit failed=0 staged_additions
     [ -f "$env_file" ] || return 0
+    [ "${#APPLIED_PATHS[@]}" -gt 0 ] || return 0
+
+    # Guard the material introduced by this update, not every historical line in
+    # the repository. Common cloud values such as /root legitimately occur in
+    # container documentation and used to make every update fail. Diff headers
+    # are excluded so an install value in a path cannot create a false positive.
+    staged_additions=$(git -C "$SCRIPT_DIR" diff --cached --no-color --unified=0 -- "${APPLIED_PATHS[@]}" |
+        sed -n '/^+++ /d; /^+/s/^+//p')
     for key in WORKSPACE_DIR HOME_DIR CLAUDE_PATH IWE_TEMPLATE IWE_RUNTIME; do
         value=$(grep -E "^${key}=" "$env_file" 2>/dev/null | head -1 | cut -d= -f2- | sed -E 's/^"//; s/"$//; s/^'"'"'//; s/'"'"'$//')
         [ -n "$value" ] || continue
-        hit=$(git -C "$SCRIPT_DIR" grep -l -F -- "$value" -- ':(exclude).exocortex.env' 2>/dev/null || true)
+        hit=$(printf '%s\n' "$staged_additions" | grep -F -- "$value" || true)
         if [ -n "$hit" ]; then
-            echo "  ✗ install-value $key найден в tracked-файлах:" >&2
-            printf '    %s\n' "$hit" >&2
+            echo "  ✗ install-value $key найден в добавленных строках обновления" >&2
             failed=1
         fi
     done
@@ -1759,7 +1766,7 @@ if ! $SKIP_COMMIT; then
         for fpath in "${APPLIED_PATHS[@]}"; do
             git -C "$SCRIPT_DIR" add -- "$fpath" 2>/dev/null || true
         done
-        if ! validate_no_install_values_in_tracked_files; then
+        if ! validate_no_install_values_in_staged_additions; then
             echo "  ОШИБКА: автокоммит остановлен, чтобы не опубликовать install paths." >&2
             exit 1
         fi


### PR DESCRIPTION
## Summary

- scope the install-path publication guard to added staged lines from files
  applied by the current updater run;
- preserve blocking for newly introduced machine-specific paths without
  reporting their values;
- add regression coverage for historical cloud paths, unrelated staged files,
  newly introduced leaks, and leak removal.

## Problem

Cloud installations commonly use values such as `/root`, `/root/.claude`, and
`/workspace/IWE`. The previous repository-wide literal scan treated any
historical tracked occurrence as a new leak and blocked every automatic update
commit.

## Safety

The guard still rejects an install value when the current updater run
introduces it in an added line. It ignores unchanged history, unrelated staged
files, and deleted lines.

## Testing

- `bash -n update.sh scripts/tests/test_update_install_path_guard.sh`
- `bash scripts/tests/test_update_install_path_guard.sh`
- `python3 scripts/tests/test_manifest_coverage_local.py`
- `git diff --cached --check`
- staged diff secret-signature scan