### PR TITLE
fix: treat cancelled WPs as terminal (#405)

### DIFF
--- a/scripts/iwe-drift-helpers/check-status-legend.sh
+++ b/scripts/iwe-drift-helpers/check-status-legend.sh
@@ -7,9 +7,9 @@
 #   I1. **Legend completeness:** все статус-эмодзи, встречающиеся в таблице WP-REGISTRY.md,
 #       задокументированы в легенде вверху файла. Новый эмодзи без записи в легенде → DRIFT.
 #   I2. **Format compliance — active id:** строки с plain id `| <num> |` имеют active статус
-#       (НЕ из терминального множества {✅, 📦, ↗️}).
+#       (НЕ из терминального множества {✅, 📦, ↗️, ❌}).
 #   I3. **Format compliance — terminal id:** строки с crossed id `| ~~<num>~~ |` имеют
-#       терминальный статус из {✅, 📦, ↗️}.
+#       терминальный статус из {✅, 📦, ↗️, ❌}.
 #
 # I2 + I3 — invariant id-format ↔ status (см. .claude/rules/formatting.md «Таблицы с РП»).
 # Сломан = расхождение row-format и status, что ломает счётчики (linear-sync.sh, day-close.sh).
@@ -32,7 +32,7 @@ MODE="${MODE:-all}"
 
 # Терминальные статусы — закрытие РП. Источник: легенда WP-REGISTRY.md.
 # Изменение этого списка = архитектурное решение об эволюции lifecycle РП.
-TERMINAL_STATUSES=("✅" "📦" "↗️")
+TERMINAL_STATUSES=("✅" "📦" "↗️" "❌")
 
 while [ $# -gt 0 ]; do
     case "$1" in

--- a/scripts/tests/test_issues_413_418.py
+++ b/scripts/tests/test_issues_413_418.py
@@ -89,6 +89,36 @@ def test_status_legend_accepts_skeleton_legend_format(tmp_path: Path):
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_status_legend_accepts_cancelled_wp_as_terminal(tmp_path: Path):
+    registry = tmp_path / "WP-REGISTRY.md"
+    registry.write_text(
+        "\n".join(
+            (
+                "| Статус | Расшифровка |",
+                "|---|---|",
+                "| 🔄 | in_progress |",
+                "| ❌ | cancelled |",
+                "",
+                "| # | Название | Ст |",
+                "|---|---|---|",
+                "| ~~405~~ | Отменённая работа | ❌ |",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["bash", str(STATUS_LEGEND), "--registry", str(registry), "--critical-only"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "format-compliance OK: 1" in result.stdout
+
+
 def test_day_open_uses_priority_draft_from_template_contract(tmp_path: Path):
     governance = tmp_path / "DS-strategy"
     drafts = governance / "drafts"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2021,7 +2021,7 @@
     },
     {
       "path": "scripts/iwe-drift-helpers/check-status-legend.sh",
-      "sha256": "3a20ed7301bc59312aa47e2bd2a1942a1864f983cc02efcbed8c1a02f3c5da9b"
+      "sha256": "4b025b18accb86c1bba5cf6d9284e6ccfe4ca58b32881cb5979b7d49260078f6"
     },
     {
       "path": "scripts/iwe-drift.sh",
@@ -2297,7 +2297,7 @@
     },
     {
       "path": "scripts/tests/test_issues_413_418.py",
-      "sha256": "11c81d661b3b1bfe98f7cd33a70429f7aeb3fd2909ca13fec6f731eafbc9ebd5"
+      "sha256": "deccd502f68f06f7d95c8382e5daf25bb0ce62bd5df2ac3e9729f91c4a7f7d4e"
     },
     {
       "path": "scripts/tests/test_session_guard_hypothesis_gate.sh",


### PR DESCRIPTION
Closes #405.\n\nAdds ❌ to the terminal WP statuses and covers a cancelled, crossed-out registry entry with a regression test. Regenerates the delivery manifest.\n\nVerified:\n- pytest -q scripts/tests/test_issues_413_418.py\n- IWE_TEMPLATE="/private/tmp/wp7-f67-fmt-fix" bash scripts/tests/validate_manifest_coverage.sh\n- bash setup/validate-template.sh