### PR TITLE
fix(wp485): repair-pass bash 3.2, WP archive dup, Unicode cap, /extend catalog

### DIFF
--- a/.claude/hooks/inject-code-style.sh
+++ b/.claude/hooks/inject-code-style.sh
@@ -106,9 +106,15 @@ CONTEXT="## 🔧 Инженерный стиль кода IWE (L0 база + L1 
 
 $FRAGMENT"
 
-# Хард-кап: обрезка по последнему полному предложению до HARD_CAP символов
-# (защита от молчаливой ампутации правила на лимите PreToolUse, консенсус Kimi)
-CTX_LEN=$(printf '%s' "$CONTEXT" | wc -c | tr -d ' ')
+# Хард-кап: считаем и обрезаем в Unicode-символах. `wc -c` считал байты,
+# тогда как Python ниже срезает символы: на кириллице это давало ложное
+# превышение капа и добавляло маркер обрезки к уже допустимому контексту.
+# (За пределами этого блока CUR_BYTES намеренно остаётся байтовым счётчиком:
+# это отдельный порог роста transcript для переинъекции.)
+if ! CTX_LEN=$(printf '%s' "$CONTEXT" | python3 -c 'import sys; print(len(sys.stdin.read()))'); then
+  echo '{}'
+  exit 0
+fi
 if [ "$CTX_LEN" -gt "$HARD_CAP" ]; then
   echo "inject-code-style: context $CTX_LEN > cap $HARD_CAP — обрезаю по предложению" >&2
   CONTEXT=$(CTX="$CONTEXT" CAP="$HARD_CAP" python3 - <<'PY'

--- a/.claude/skills/extend/SKILL.md
+++ b/.claude/skills/extend/SKILL.md
@@ -47,6 +47,13 @@ cat {{WORKSPACE_DIR}}/params.yaml 2>/dev/null
 | `week-close` | `before` | `extensions/week-close.before.md` | Перед ротацией уроков |
 | `week-close` | `after` | `extensions/week-close.after.md` | После аудита memory |
 | `protocol-open` | `after` | `extensions/protocol-open.after.md` | После ритуала согласования |
+| `protocol-open` | `sync` | `extensions/protocol-open.sync.md` | Переопределяет поведение синхронизации на шаге 3b |
+| `day-open` | `checks` | `extensions/day-open.checks.md` | Перед commit, после подготовки DayPlan |
+| `day-close` | `before` | `extensions/day-close.before.md` | Перед первыми шагами закрытия дня |
+| `month-close` | `before` | `extensions/month-close.before.md` | Перед первыми шагами закрытия месяца |
+| `month-close` | `after` | `extensions/month-close.after.md` | После итогов месяца, перед верификацией |
+| `strategy-session` | `before` | `extensions/strategy-session.before.md` | Перед началом стратегической сессии |
+| `strategy-session` | `after` | `extensions/strategy-session.after.md` | После итогов стратегической сессии |
 
 **Несколько файлов одного hook** — загружаются в алфавитном порядке.
 Пример: `day-close.after.md` + `day-close.after.health.md` — оба выполнятся.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ Refs: WP-NNN
 - `/extend`: каталог включает все 16 реально вызываемых точек расширения, в том числе проверки day-open, month-close и strategy-session (#436).
 - `AGENTS-agent-blocks.md` снова входит в поставку; манифест пересобран по актуальному дереву (#437).
 - CI-workflow ночного аудита явно помечен как недоставляемый, поэтому собственный валидатор манифеста больше не отвергает релиз (#423).
+- Seed-копия `day-open-pipeline.sh` синхронизирована с каноническим скриптом, поэтому новая установка не получает отставший конвейер (#427).
 - `cdb7c29` fix(day-open): reap stale .git/HEAD.lock before commit + clearer race-guard message (WP-484 Ф95)
 - [behavior] `978d382` fix(update): --apply-settings-merge работает и на повторном прогоне
 - [security] `4a934aa` fix(security): defaultMode=default вместо acceptEdits + fail-closed extensions-gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,12 @@ Refs: WP-NNN
 
 ### Fixed
 
+- `create-wp.sh` больше не создаёт pending-архив, а `close-wp.sh` закрывает `WP-009` по bare ID `9` без второго контекстного файла (#425, #431).
+- `update.sh`: repair-pass снова работает в системном Bash 3.2 macOS; один ремонт закрывает #433 и #438 без потери диагностик.
+- `inject-code-style.sh`: ограничение контекста считает и обрезает Unicode-символы в одной единице, поэтому кириллица не вызывает ложную обрезку (#435).
+- `/extend`: каталог включает все 16 реально вызываемых точек расширения, в том числе проверки day-open, month-close и strategy-session (#436).
+- `AGENTS-agent-blocks.md` снова входит в поставку; манифест пересобран по актуальному дереву (#437).
+- CI-workflow ночного аудита явно помечен как недоставляемый, поэтому собственный валидатор манифеста больше не отвергает релиз (#423).
 - `cdb7c29` fix(day-open): reap stale .git/HEAD.lock before commit + clearer race-guard message (WP-484 Ф95)
 - [behavior] `978d382` fix(update): --apply-settings-merge работает и на повторном прогоне
 - [security] `4a934aa` fix(security): defaultMode=default вместо acceptEdits + fail-closed extensions-gate

--- a/generate-manifest.sh
+++ b/generate-manifest.sh
@@ -72,7 +72,6 @@ EXCLUDED_SCRIPTS=(
 EXCLUDED_EXACT=(
     "promotion-status.yaml"
     "scripts/guide-kit-sync-state.yaml"         # provenance vendored-копии guide-kit/ — нужен CI drift-check, не пользователям
-    "AGENTS-agent-blocks.md"
     "${EXCLUDED_SCRIPTS[@]}"
 )
 
@@ -107,6 +106,9 @@ GITHUB_EXPLICIT_INCLUDE=(
     ".github/workflows/notify-update.yml"
     ".github/workflows/post-release-audit.yml"
 )
+GITHUB_CI_ONLY_EXCLUDE=(
+    ".github/workflows/nightly-template-audit.yml"
+)
 SETUP_EXPLICIT_INCLUDE=(
     "setup/build-runtime.sh"
     "setup/install-iwe-paths.sh"
@@ -132,6 +134,7 @@ SCRIPT_CONTRACT_EXPLICIT_INCLUDE=(
     "scripts/tests/test_create_wp_contract.sh"
     "scripts/tests/test_capture_bus_contract.sh"
     "scripts/tests/test_critical_alert_contract.sh"
+    "scripts/tests/test_create_wp_number_padding.py"
     "scripts/tests/validate_manifest_coverage.sh"
     "scripts/tests/lib/capture_fixture.sh"
     "scripts/tests/lib/seed_strategy_fixture.sh"
@@ -165,6 +168,13 @@ while IFS= read -r rel; do
         "${GITHUB_EXPLICIT_INCLUDE[@]}" \
         "${SCRIPT_CONTRACT_EXPLICIT_INCLUDE[@]}"; then
         FILES+=("$rel")
+        continue
+    fi
+    # .github/ is normally outside the delivery manifest.  Keep every tracked
+    # workflow explicitly classified, otherwise manifest-coverage correctly
+    # reports a silent delivery gap (#423).
+    if is_explicit_include "$rel" "${GITHUB_CI_ONLY_EXCLUDE[@]}"; then
+        EXCLUDED_PATHS+=("$rel")
         continue
     fi
     skip=false

--- a/generate-manifest.sh
+++ b/generate-manifest.sh
@@ -135,6 +135,7 @@ SCRIPT_CONTRACT_EXPLICIT_INCLUDE=(
     "scripts/tests/test_capture_bus_contract.sh"
     "scripts/tests/test_critical_alert_contract.sh"
     "scripts/tests/test_create_wp_number_padding.py"
+    "scripts/tests/test_create_wp_weekplan_writer.py"
     "scripts/tests/validate_manifest_coverage.sh"
     "scripts/tests/lib/capture_fixture.sh"
     "scripts/tests/lib/seed_strategy_fixture.sh"

--- a/scripts/close-wp.sh
+++ b/scripts/close-wp.sh
@@ -35,6 +35,25 @@ if [[ -z "$WP_NUM" ]]; then
   exit 1
 fi
 
+# Public files use the canonical three-digit ID (WP-009), while the registry
+# stores the bare number (9).  Normalise the CLI once so closing a freshly
+# created card does not create a second WP-9 archive or miss WP-009.md.
+if ! WP_NUM=$(python3 - "$WP_NUM" <<'PY'
+import re
+import sys
+
+raw = sys.argv[1]
+match = re.fullmatch(r"(?:WP-)?(\d+)", raw)
+if not match:
+    raise SystemExit(1)
+print(int(match.group(1)))
+PY
+); then
+  echo "Некорректный номер РП: используйте число или WP-N" >&2
+  exit 1
+fi
+WP_ID=$(printf '%03d' "$WP_NUM")
+
 TODAY=$(date +%Y-%m-%d)
 
 # --- Шаг 1: зачеркнуть строку в REGISTRY ---
@@ -128,7 +147,15 @@ with open(registry_path, "r", encoding="utf-8") as f:
 print("context")
 PYEOF2
 )
-CONTEXT_FILE="$ARCHIVE_DIR/WP-${WP_NUM}-${SLUG}.md"
+CANONICAL_CONTEXT_FILE="$ARCHIVE_DIR/WP-${WP_ID}-${SLUG}.md"
+LEGACY_CONTEXT_FILE=$(find "$ARCHIVE_DIR" -maxdepth 1 -type f -name "WP-${WP_NUM}-*.md" -print 2>/dev/null | sort | head -1)
+if [[ -f "$CANONICAL_CONTEXT_FILE" ]]; then
+  CONTEXT_FILE="$CANONICAL_CONTEXT_FILE"
+elif [[ -n "$LEGACY_CONTEXT_FILE" ]]; then
+  CONTEXT_FILE="$LEGACY_CONTEXT_FILE"
+else
+  CONTEXT_FILE="$CANONICAL_CONTEXT_FILE"
+fi
 if [[ -f "$CONTEXT_FILE" ]]; then
   echo "   ℹ️  Файл уже существует (повторный запуск close-wp.sh?), дописываю в него"
 else
@@ -200,9 +227,9 @@ else
 fi
 
 # --- Шаг 3: обновить статус в inbox/WP-NNN*.md ---
-echo "3/3 Обновляю inbox/WP-${WP_NUM}..."
+echo "3/3 Обновляю inbox/WP-${WP_ID}..."
 
-CANONICAL_INBOX_FILE="$STRATEGY/inbox/WP-${WP_NUM}/WP-${WP_NUM}.md"
+CANONICAL_INBOX_FILE="$STRATEGY/inbox/WP-${WP_ID}/WP-${WP_ID}.md"
 if [[ -f "$CANONICAL_INBOX_FILE" ]]; then
   INBOX_FILE="$CANONICAL_INBOX_FILE"
 else
@@ -229,10 +256,10 @@ with open(path, "w", encoding="utf-8") as f:
 print(f"   ✅ inbox: status=done, closed_date={today}")
 PYEOF4
 else
-  echo "   ⚠️  inbox/WP-${WP_NUM}*.md не найден — обновить вручную"
+  echo "   ⚠️  inbox/WP-${WP_ID}*.md не найден — обновить вручную"
 fi
 
 echo ""
-echo "✅ WP-${WP_NUM} закрыт"
+echo "✅ WP-${WP_ID} закрыт"
 echo "   Контекст: $(basename "${CONTEXT_FILE}")"
 echo "   Следующий шаг: git add + commit оба файла"

--- a/scripts/create-wp.sh
+++ b/scripts/create-wp.sh
@@ -269,11 +269,10 @@ print(result)
 fi
 
 # Inbox convention (WP-434): every WP is a folder inbox/WP-N/ with main file WP-N.md.
-# Slug is dropped from the filename (lives in title: frontmatter); archive stub keeps it.
+# Slug lives in the title/frontmatter.  Архив появляется только при закрытии:
+# предварительный stub конфликтовал с close-wp.sh и мог затереть контекст.
 WP_DIR="$INBOX/WP-${WP_ID}"
 WP_FILE="$WP_DIR/WP-${WP_ID}.md"
-ARCHIVE_DIR="$STRATEGY/archive/wp-contexts"
-ARCHIVE_STUB="$ARCHIVE_DIR/WP-${WP_ID}-${SLUG}.md"
 mkdir -p "$WP_DIR"
 
 echo "🚀 Создаю WP-${WP_ID}: $TITLE"
@@ -304,7 +303,6 @@ WEEKPLAN_SNAPSHOT="$SNAPSHOT_DIR/weekplan.snapshot"
 rollback_wp_creation() {
   echo "↩️  Откат: WP-${WP_ID} не создан целиком, отменяю частичные записи" >&2
   rm -rf "$WP_DIR"
-  rm -f "$ARCHIVE_STUB"
   if [[ -f "$REGISTRY_SNAPSHOT" ]]; then
     cp "$REGISTRY_SNAPSHOT" "$REGISTRY"
   else
@@ -336,7 +334,7 @@ fi
 
 # --- Шаг 1: context file ---
 echo ""
-echo "1/6 context file..."
+echo "1/5 context file..."
 
 # state_transition goes into frontmatter only when provided (gate off on
 # installs without the axes registry); hypothesis always present, "—" = no bet.
@@ -409,31 +407,8 @@ if [[ "$HYPOTHESIS_RELATION" == "unclassified" ]]; then
   echo "   ⚠️  Связь с гипотезой не определена: до начала РП выберите tests/enables/responds/researches/operational" >&2
 fi
 
-# --- Шаг 2: archive stub ---
-echo "2/6 archive stub..."
-
-mkdir -p "$ARCHIVE_DIR"
-if ! cat > "$ARCHIVE_STUB" <<ARCHEOF
----
-wp: ${WP_NUM}
-title: "${TITLE}"
-created: ${TODAY}
-status: pending
----
-
-# WP-${WP_ID}: ${TITLE} — §Закрытие
-
-*(заполняется при закрытии РП)*
-ARCHEOF
-then
-  echo "❌ Не удалось записать archive stub: $ARCHIVE_STUB" >&2
-  rollback_wp_creation
-  exit 1
-fi
-echo "   ✅ $ARCHIVE_STUB"
-
-# --- Шаг 3: WP-REGISTRY.md ---
-echo "3/6 WP-REGISTRY.md..."
+# --- Шаг 2: WP-REGISTRY.md ---
+echo "2/5 WP-REGISTRY.md..."
 
 if ! python3 - "$REGISTRY" "$WP_NUM" "$PRIORITY" "$TITLE" "$REPO" "$BUDGET" "$GOV_REPO" "$STAKE_CELL" "$WP_ID" <<'PYEOF'
 import sys
@@ -556,8 +531,8 @@ if ! grep -qE "\| \*?\*?(WP-)?${WP_NUM}\*?\*? \|" "$REGISTRY"; then
   exit 1
 fi
 
-# --- Шаг 4: WeekPlan ---
-echo "4/6 WeekPlan..."
+# --- Шаг 3: WeekPlan ---
+echo "3/5 WeekPlan..."
 
 # WEEKPLAN уже найден выше (снимок для отката, issue WP-507 про формат имени файла
 # применён там же) — здесь используется тот же путь, не ищем повторно.
@@ -621,8 +596,8 @@ else
   echo "   ⚠️  WeekPlan не найден в current/ — добавить вручную" >&2
 fi
 
-# --- Шаг 5: Strategy.md (только если --result задан и бюджет ≥3h) ---
-echo "5/6 Strategy.md..."
+# --- Шаг 4: Strategy.md (только если --result задан и бюджет ≥3h) ---
+echo "4/5 Strategy.md..."
 
 BUDGET_H=$(echo "$BUDGET" | sed 's/[^0-9]//g')
 if [[ -n "$RESULT" && "${BUDGET_H:-0}" -ge 3 ]]; then
@@ -662,8 +637,8 @@ else
   echo "   ℹ️  РП <3h — маппинг в Strategy.md не требуется"
 fi
 
-# --- Шаг 6: active-wp.md ---
-echo "6/6 active-wp.md..."
+# --- Шаг 5: active-wp.md ---
+echo "5/5 active-wp.md..."
 
 BUILD_ACTIVE_WP=""
 if [[ -f "$STRATEGY/scripts/build-active-wp.py" ]]; then
@@ -697,6 +672,6 @@ fi
 echo ""
 echo "✅ WP-${WP_ID} создан: $TITLE"
 echo "   context: inbox/WP-${WP_ID}/WP-${WP_ID}.md"
-echo "   archive: archive/wp-contexts/WP-${WP_ID}-${SLUG}.md"
+echo "   archive: будет создан close-wp.sh при закрытии РП"
 echo "   Следующий шаг: заполнить «Проблема», «Артефакт», «Фазы» в context file"
 echo "   Не забыть: issue во внешнем трекере (если подключён)"

--- a/scripts/tests/test_create_wp_number_padding.py
+++ b/scripts/tests/test_create_wp_number_padding.py
@@ -62,9 +62,8 @@ def test_next_wp_number_padded_in_paths_and_headers(tmp_path):
     assert "# WP-009: Тестовый РП" in content, "заголовок H1 должен быть дополнен нулями"
     assert "wp: 9" in content, "frontmatter wp: остаётся чистым числом, без паддинга"
 
-    archive_stub = strategy / "archive" / "wp-contexts" / "WP-009-testovyj-rp.md"
-    assert archive_stub.is_file(), f"archive stub не найден: {sorted((strategy / 'archive' / 'wp-contexts').iterdir())}"
-    assert "wp: 9" in archive_stub.read_text(encoding="utf-8")
+    archive_dir = strategy / "archive" / "wp-contexts"
+    assert not list(archive_dir.iterdir()), "архив создаётся только при закрытии РП, без pending stub"
 
 
 def test_registry_number_column_stays_bare(tmp_path):

--- a/scripts/tests/test_create_wp_weekplan_writer.py
+++ b/scripts/tests/test_create_wp_weekplan_writer.py
@@ -13,8 +13,12 @@
    файл: печатает предупреждение в stderr, содержимое файла не меняется.
 
 Тест выполняет python-блок ИЗ РЕАЛЬНОГО create-wp.sh (извлекается по
-heredoc-маркерам между «# --- Шаг 4: WeekPlan ---» и следующим PYEOF),
+heredoc-маркерам между «# --- Шаг 3: WeekPlan ---» и следующим PYEOF),
 не копию логики — иначе тест проверял бы дубликат, не продакшен-код.
+
+Номер шага в маркере (issue #485: удалён archive stub, Шаг 4 стал Шагом 3)
+следует за нумерацией в create-wp.sh — при очередном сдвиге шагов поправить
+и здесь.
 """
 
 import re
@@ -26,9 +30,9 @@ CREATE_WP = Path(__file__).parent.parent / "create-wp.sh"
 
 
 def _extract_weekplan_writer() -> str:
-    """Достаёт python-heredoc шага 4 (WeekPlan writer) из create-wp.sh."""
+    """Достаёт python-heredoc шага 3 (WeekPlan writer) из create-wp.sh."""
     text = CREATE_WP.read_text(encoding="utf-8")
-    marker = "# --- Шаг 4: WeekPlan ---"
+    marker = "# --- Шаг 3: WeekPlan ---"
     start = text.index(marker)
     heredoc_start = text.index("<<'PYEOF'\n", start) + len("<<'PYEOF'\n")
     heredoc_end = text.index("\nPYEOF", heredoc_start)

--- a/scripts/tests/test_create_wp_weekplan_writer.py
+++ b/scripts/tests/test_create_wp_weekplan_writer.py
@@ -13,12 +13,8 @@
    файл: печатает предупреждение в stderr, содержимое файла не меняется.
 
 Тест выполняет python-блок ИЗ РЕАЛЬНОГО create-wp.sh (извлекается по
-heredoc-маркерам между «# --- Шаг 3: WeekPlan ---» и следующим PYEOF),
+семантическому маркеру секции WeekPlan и следующему PYEOF),
 не копию логики — иначе тест проверял бы дубликат, не продакшен-код.
-
-Номер шага в маркере (issue #485: удалён archive stub, Шаг 4 стал Шагом 3)
-следует за нумерацией в create-wp.sh — при очередном сдвиге шагов поправить
-и здесь.
 """
 
 import re
@@ -30,10 +26,11 @@ CREATE_WP = Path(__file__).parent.parent / "create-wp.sh"
 
 
 def _extract_weekplan_writer() -> str:
-    """Достаёт python-heredoc шага 3 (WeekPlan writer) из create-wp.sh."""
+    """Достаёт WeekPlan-writer без привязки к порядковому номеру шага."""
     text = CREATE_WP.read_text(encoding="utf-8")
-    marker = "# --- Шаг 3: WeekPlan ---"
-    start = text.index(marker)
+    marker = re.search(r"^# --- Шаг \d+: WeekPlan ---$", text, flags=re.MULTILINE)
+    assert marker, "В create-wp.sh отсутствует секция WeekPlan"
+    start = marker.end()
     heredoc_start = text.index("<<'PYEOF'\n", start) + len("<<'PYEOF'\n")
     heredoc_end = text.index("\nPYEOF", heredoc_start)
     return text[heredoc_start:heredoc_end]

--- a/scripts/tests/test_issues_413_418.py
+++ b/scripts/tests/test_issues_413_418.py
@@ -213,6 +213,34 @@ def test_close_wp_updates_canonical_folder_card(tmp_path: Path):
     assert "closed_date:" in content
 
 
+def test_close_wp_uses_padded_card_and_single_archive_for_bare_number(tmp_path: Path):
+    governance = tmp_path / "DS-strategy"
+    (governance / "docs").mkdir(parents=True)
+    card = governance / "inbox" / "WP-009" / "WP-009.md"
+    card.parent.mkdir(parents=True)
+    (governance / "docs" / "WP-REGISTRY.md").write_text(
+        "| # | P | Название | Ст |\n|---|---|---|---|\n| 9 | P1 | Проверка архива | 🔄 |\n",
+        encoding="utf-8",
+    )
+    card.write_text("---\nstatus: in_progress\ncreated: 2026-08-01\n---\n", encoding="utf-8")
+    env = {**os.environ, "IWE_ROOT": str(tmp_path), "IWE_GOVERNANCE_REPO": "DS-strategy"}
+
+    for _ in range(2):
+        result = subprocess.run(
+            ["bash", str(CLOSE_WP), "--wp", "9", "--summary", "готово"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    assert "status: done" in card.read_text(encoding="utf-8")
+    archives = list((governance / "archive" / "wp-contexts").glob("WP-009-*.md"))
+    assert len(archives) == 1
+    assert not list((governance / "archive" / "wp-contexts").glob("WP-9-*.md"))
+
+
 @pytest.mark.skipif(not shutil.which("jq"), reason="destructive guard requires jq")
 def test_destructive_guard_ignores_quoted_git_argument_and_allows_no_loss_reset(tmp_path: Path):
     subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)

--- a/seed/strategy/scripts/day-open-pipeline.sh
+++ b/seed/strategy/scripts/day-open-pipeline.sh
@@ -264,6 +264,27 @@ case "$LLM_PROXY_URL" in
   *) PROXY_IS_LOCAL=false ;;
 esac
 
+# --- Helper: reap a stale .git/HEAD.lock left by a crashed prior git process ---
+# WP-484 Ф95 (15.08): a run that dies mid-commit (any abort() after `git add`)
+# leaves this lock behind — nothing swept it, so it blocked every commit until
+# a human found it manually. Only ever removes a lock whose holder is provably
+# dead (no live git process at all); a live git process (this run's own, or a
+# genuinely concurrent one) is left untouched, matching the same PID-liveness
+# principle session-guard.sh already uses for semaphores.
+reap_stale_git_lock() {
+  local lock="$DS_STRATEGY/.git/HEAD.lock"
+  [ -f "$lock" ] || return 0
+  # Match on this repo's own path, not a bare `git` process name — the server
+  # runs unrelated git activity for other repos/users constantly, and a
+  # name-only match would find those and never reap anything.
+  if pgrep -f "git.*$DS_STRATEGY" >/dev/null 2>&1; then
+    echo "  git lock present but a git process for this repo is running — leaving it (may be legitimate)"
+    return 0
+  fi
+  echo "  stale git lock found, no live git process for this repo — removing: $lock"
+  rm -f "$lock"
+}
+
 # --- Helper: abort with notification + proxy cleanup ---
 abort() {
   local reason="$1"
@@ -426,7 +447,7 @@ if [ "$FORCE" != "true" ]; then
       DC_DONE=$(cd "$DS_STRATEGY" && git log HEAD origin/main --format="" --name-only -- "$YDAY_DAYPLAN" 2>/dev/null | head -1)
       if [ -z "$DC_DONE" ] && [ -n "$YDAY_COMMITS" ]; then
         echo "  Day Close for $YDAY not done yet (no archived DayPlan) — deferring Day Open (will regenerate after close)."
-        tg_notify "⏸ Day Open $DATE отложен: Day Close за $YDAY ещё не сделан. Пересоберётся после закрытия (или запусти с --force)."
+        tg_notify "⏸ Day Open $DATE отложен: закрытие $YDAY ещё не долетело до сервера (гонка расписаний, не поломка). Пересоберётся автоматически после закрытия (или запусти с --force)."
         # Ф32 п.11 (WP-484, 31.07): deferred ≠ done — exit 7, scheduler retries next tick.
         exit 7
       fi
@@ -871,10 +892,15 @@ fi
 # session open on the same machine at the same time.
 SG_AGENT="day-open-pipeline"
 if [ "$PROBE" != "true" ]; then
+  # WP-484 F91: explicit --slug keeps note-file resolution unambiguous when the
+  # agent has 2+ open semaphores (a stale housekeeping semaphore used to make
+  # both note-file calls fail in one run); the slug is fixed by the `open
+  # --housekeeping day-open` call above. --owner-pid from the author copy is NOT
+  # ported: this parser swallows unknown flags and misparses the PID as positional.
   bash "$IWE/scripts/session-guard.sh" open --housekeeping day-open --agent "$SG_AGENT" 2>/dev/null || true
-  bash "$IWE/scripts/session-guard.sh" note-file "$DAYPLAN_PATH" --agent "$SG_AGENT"
+  bash "$IWE/scripts/session-guard.sh" note-file "$DAYPLAN_PATH" --agent "$SG_AGENT" --slug day-open
   for f in "${ARCHIVED_PATHS[@]+"${ARCHIVED_PATHS[@]}"}"; do
-    bash "$IWE/scripts/session-guard.sh" note-file "$ARCHIVE_DIR/$(basename "$f")" --agent "$SG_AGENT"
+    bash "$IWE/scripts/session-guard.sh" note-file "$ARCHIVE_DIR/$(basename "$f")" --agent "$SG_AGENT" --slug day-open
   done
 fi
 
@@ -901,6 +927,7 @@ if [ "$PROBE" = "true" ]; then
 else
 echo "=== 6. Commit + Push ==="
 cd "$DS_STRATEGY" || abort "Cannot cd to repo"
+reap_stale_git_lock
 
 git add "$DAYPLAN_PATH"
 for f in "${ARCHIVE_TARGETS[@]+"${ARCHIVE_TARGETS[@]}"}"; do

--- a/setup/test-update-edge-cases.sh
+++ b/setup/test-update-edge-cases.sh
@@ -1992,6 +1992,73 @@ else
 fi
 
 # ============================================================
+# T34: code-style cap uses the same Unicode unit for count and slice (#435)
+# ============================================================
+echo ""
+echo "--- T34: code-style Unicode cap contract (#435) ---"
+T34_BASE="$TEST_WS/t34-base.json"
+T34_CAPPED="$TEST_WS/t34-capped.json"
+T34_PAYLOAD="{\"session_id\":\"t34-base\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$T16_PROJ/t16-fixture.py\"}}"
+if printf '%s' "$T34_PAYLOAD" | HOME="$T16_HOME" CLAUDE_PROJECT_DIR="$T16_PROJ" \
+    IWE_GOVERNANCE_REPO="DS-strategy" bash "$TEMPLATE_DIR/.claude/hooks/inject-code-style.sh" > "$T34_BASE" 2>/dev/null; then
+    T34_CHARS=$(python3 -c "import json; print(len(json.load(open('$T34_BASE'))['hookSpecificOutput']['additionalContext']))")
+    T34_BYTES=$(python3 -c "import json; print(len(json.load(open('$T34_BASE'))['hookSpecificOutput']['additionalContext'].encode()))")
+    T34_PAYLOAD="{\"session_id\":\"t34-capped\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$T16_PROJ/t16-fixture.py\"}}"
+    if [ "$T34_BYTES" -gt "$T34_CHARS" ] && \
+       printf '%s' "$T34_PAYLOAD" | HOME="$T16_HOME" CLAUDE_PROJECT_DIR="$T16_PROJ" \
+          IWE_GOVERNANCE_REPO="DS-strategy" CODE_STYLE_INJECT_CAP="$T34_CHARS" \
+          bash "$TEMPLATE_DIR/.claude/hooks/inject-code-style.sh" > "$T34_CAPPED" 2>/dev/null && \
+       python3 - "$T34_BASE" "$T34_CAPPED" <<'PY'
+import json
+import sys
+
+baseline = json.load(open(sys.argv[1], encoding="utf-8"))["hookSpecificOutput"]["additionalContext"]
+capped = json.load(open(sys.argv[2], encoding="utf-8"))["hookSpecificOutput"]["additionalContext"]
+raise SystemExit(0 if baseline == capped and "[…обрезано до лимита" not in capped else 1)
+PY
+    then
+        pass "T34: Cyrillic context at its character cap is not falsely truncated by bytes"
+    else
+        fail "T34: code-style cap count and slice diverge on Cyrillic"
+    fi
+else
+    fail "T34: inject-code-style did not produce a baseline context"
+fi
+
+# ============================================================
+# T35: /extend lists every extension point that a protocol invokes (#436)
+# ============================================================
+echo ""
+echo "--- T35: /extend catalog matches protocol extension points (#436) ---"
+if python3 - "$TEMPLATE_DIR" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1])
+call_re = re.compile(r"load-extensions\.sh\s+([a-z-]+)\s+(before|after|checks|sync)")
+row_re = re.compile(r"^\| `([^`]+)` \| `([^`]+)` \| `extensions/", re.MULTILINE)
+
+sources = [root / "memory/protocol-close.md", root / "memory/protocol-open.md"]
+sources.extend(path for path in (root / ".claude/skills").rglob("*.md") if path != root / ".claude/skills/extend/SKILL.md")
+called = {
+    match.groups()
+    for path in sources
+    for match in call_re.finditer(path.read_text(encoding="utf-8"))
+}
+catalog = set(row_re.findall((root / ".claude/skills/extend/SKILL.md").read_text(encoding="utf-8")))
+if len(called) != 16 or catalog != called:
+    missing = sorted(called - catalog)
+    extra = sorted(catalog - called)
+    raise SystemExit(f"called={len(called)} catalog={len(catalog)} missing={missing} extra={extra}")
+PY
+then
+    pass "T35: /extend lists all 16 invoked extension points"
+else
+    fail "T35: /extend catalog differs from invoked extension points"
+fi
+
+# ============================================================
 # Summary
 # ============================================================
 echo ""

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2296,6 +2296,10 @@
       "sha256": "926603ebb29d83b7e3db5e0998182e1cc8c8b756820e3b99950d24071cbb093a"
     },
     {
+      "path": "scripts/tests/test_create_wp_weekplan_writer.py",
+      "sha256": "126dabff6e7e72c7564e2d0acfdf0449eca9adf06e76010f1175c9b02fe70fc8"
+    },
+    {
       "path": "scripts/tests/test_critical_alert_contract.sh",
       "sha256": "ef00075dd25cc016c0d21d4605dcb9444c62493a08f90c44c92b60eb8fec2547"
     },
@@ -2447,7 +2451,6 @@
     "scripts/tests/conftest.py",
     "scripts/tests/test_agent_dashboard.py",
     "scripts/tests/test_copy_to_aisystant.py",
-    "scripts/tests/test_create_wp_weekplan_writer.py",
     "scripts/tests/test_day_close_prepare.py",
     "scripts/tests/test_delivery_content.py",
     "scripts/tests/test_delivery_formal.py",

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2421,7 +2421,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "0bb7299434f63420b665f24ea50c127778776694f11da0c7a8e6c6fce77936ed"
+      "sha256": "2043034ec78a47aebe5085ebcf66963ebcac48cc722c6df5a93713c4b36b0512"
     }
   ],
   "excluded_paths": [

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -649,7 +649,7 @@
     },
     {
       "path": "CHANGELOG.md",
-      "sha256": "c8e942c53010e431b0fad3e14862752a27afe553576dce5179171b88040467bb"
+      "sha256": "d8e24e39b4e7e27acf348000b1cd9ea6bef4c21e055503d299d31501fc425133"
     },
     {
       "path": "CLAUDE.md",

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -73,7 +73,7 @@
     },
     {
       "path": ".claude/hooks/inject-code-style.sh",
-      "sha256": "99d028f6f863e4e35c505cce427e6a874a549025e0c00a9b4bb0d13871a0a90e"
+      "sha256": "085b2d7d9dba02576ece94d92c63c051358ff5e29e205c824f5be5fa51452060"
     },
     {
       "path": ".claude/hooks/inject-communication-style.sh",
@@ -365,7 +365,7 @@
     },
     {
       "path": ".claude/skills/extend/SKILL.md",
-      "sha256": "d5f4cbc7a7883f1f03a33f5fd982c3941527de2359a4784fa60e2ddd168ac912"
+      "sha256": "c2c867c9d385e0025bd9e281d87d6da2eb3d85fa5bcffa021c3ed5cc42fe0def"
     },
     {
       "path": ".claude/skills/fpf/SKILL.md",
@@ -640,12 +640,16 @@
       "sha256": "13c0512dafbb06fe34b0efb34311874114188121d3c0609d514775b9a5c5398c"
     },
     {
+      "path": "AGENTS-agent-blocks.md",
+      "sha256": "609c4037e9d70ea4a30c75d83626e48041e3b4746c3a217ba868a83bc6897738"
+    },
+    {
       "path": "AGENTS.md",
       "sha256": "7a94fb8ac1cb077412d7facfa0c08655e99a79503efbea3056ea586d5cd92652"
     },
     {
       "path": "CHANGELOG.md",
-      "sha256": "959ac8c843f683265ec54613cd621c01862fc2b9bde629519ddac4b2d21c26e4"
+      "sha256": "c8e942c53010e431b0fad3e14862752a27afe553576dce5179171b88040467bb"
     },
     {
       "path": "CLAUDE.md",
@@ -1253,7 +1257,7 @@
     },
     {
       "path": "memory/communication-style-base.md",
-      "sha256": "8c553c4558a403256ff585ed4760ce43b26c304526d63e3e25c79dec572d3590"
+      "sha256": "9775eda3c479f6149434469f7f925cfabb6925e5b0e410227c0070142f455f4f"
     },
     {
       "path": "memory/communication-style-downstream-template.md",
@@ -1877,7 +1881,7 @@
     },
     {
       "path": "scripts/close-wp.sh",
-      "sha256": "57ac198f937530a9a692cf9baf98729006ae5576e628d2c19323dce6ef11dcac"
+      "sha256": "1708ba2d92f31e0770ceff9847ddfd1012776f28302134704e1fd91caa02ba92"
     },
     {
       "path": "scripts/codex-peer-adapter.sh",
@@ -1909,7 +1913,7 @@
     },
     {
       "path": "scripts/create-wp.sh",
-      "sha256": "53e54c4fb7fdd08691404527012e50c71210ca3f1637cc3f79a07773263ce0ac"
+      "sha256": "d915d9acaea07dfd2be43266d2136b1cae6fe9589987ea7c877277888a4cd551"
     },
     {
       "path": "scripts/day-close-lock.sh",
@@ -1937,7 +1941,7 @@
     },
     {
       "path": "scripts/day-open-pipeline.sh",
-      "sha256": "c615ba6e9ae7a24cc080a50756f52e799c5c4bc612e3b01948b34f9f77d14d7d"
+      "sha256": "cbd5b60230db40e2f0c24c88a5f5dc2cf26725ad0a7de0dd47b683441e87ecfc"
     },
     {
       "path": "scripts/day-open-preflight.sh",
@@ -2280,6 +2284,10 @@
       "sha256": "2265e5dda20c17e17ea66d2c870fa0f97e3a053f741239fe61beaa785f944a58"
     },
     {
+      "path": "scripts/tests/test_create_wp_number_padding.py",
+      "sha256": "fc5c500573c067fb1e6882834d2e0a1d7cd287446f9df5c9b49c1b404362e201"
+    },
+    {
       "path": "scripts/tests/test_create_wp_registry_coherence.sh",
       "sha256": "852828b4b741b9922fd0a72b5089214a3ee1663874d7950976ed8115958adb69"
     },
@@ -2313,7 +2321,7 @@
     },
     {
       "path": "scripts/tests/test_issues_413_418.py",
-      "sha256": "deccd502f68f06f7d95c8382e5daf25bb0ce62bd5df2ac3e9729f91c4a7f7d4e"
+      "sha256": "23a1581ea39df97ebda73ae5faea1b24b1c331ee3cd0ff8daa16a46669a83b7e"
     },
     {
       "path": "scripts/tests/test_session_guard_hypothesis_gate.sh",
@@ -2413,11 +2421,11 @@
     },
     {
       "path": "update.sh",
-      "sha256": "b05c02ebecbdaa245ad513556048c7135d7fd6add4a9c25662982f8ad394fbd4"
+      "sha256": "0bb7299434f63420b665f24ea50c127778776694f11da0c7a8e6c6fce77936ed"
     }
   ],
   "excluded_paths": [
-    "AGENTS-agent-blocks.md",
+    ".github/workflows/nightly-template-audit.yml",
     "docs/developer/README.md",
     "docs/developer/card-template.md",
     "docs/developer/code-style.md",
@@ -2439,7 +2447,6 @@
     "scripts/tests/conftest.py",
     "scripts/tests/test_agent_dashboard.py",
     "scripts/tests/test_copy_to_aisystant.py",
-    "scripts/tests/test_create_wp_number_padding.py",
     "scripts/tests/test_create_wp_weekplan_writer.py",
     "scripts/tests/test_day_close_prepare.py",
     "scripts/tests/test_delivery_content.py",

--- a/update.sh
+++ b/update.sh
@@ -786,6 +786,7 @@ repair_pass() {
     # recognizes the closing `)` of a process substitution.  Keep the manifest
     # reader in ordinary temporary files: its diagnostics stay visible and the
     # repair pass remains available on the oldest supported shell.
+    local repair_paths repair_errors
     repair_paths=$(mktemp "${TMPDIR:-/tmp}/iwe-repair-paths.XXXXXX") || {
         echo "  ⚠ repair_pass: не удалось создать временный список" >&2
         return 0

--- a/update.sh
+++ b/update.sh
@@ -782,6 +782,39 @@ fi
 # REPAIRED — глобальный счётчик, читается вызывающим кодом после возврата.
 repair_pass() {
     REPAIRED=0
+    # Bash 3.2 (macOS) parses the apostrophe in the comment below before it
+    # recognizes the closing `)` of a process substitution.  Keep the manifest
+    # reader in ordinary temporary files: its diagnostics stay visible and the
+    # repair pass remains available on the oldest supported shell.
+    repair_paths=$(mktemp "${TMPDIR:-/tmp}/iwe-repair-paths.XXXXXX") || {
+        echo "  ⚠ repair_pass: не удалось создать временный список" >&2
+        return 0
+    }
+    repair_errors=$(mktemp "${TMPDIR:-/tmp}/iwe-repair-errors.XXXXXX") || {
+        rm -f "$repair_paths"
+        echo "  ⚠ repair_pass: не удалось создать файл диагностики" >&2
+        return 0
+    }
+
+    if py_available; then
+        if ! $PY_BIN -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+for entry in data.get('files', []):
+    print(entry['path'] + '|')
+" "$MANIFEST" > "$repair_paths" 2> "$repair_errors"; then
+            sed 's/^/  ⚠ repair_pass: /' "$repair_errors" >&2
+            rm -f "$repair_paths" "$repair_errors"
+            report_owner_user_memory_drift
+            return 0
+        fi
+    else
+        echo "  ⚠ repair_pass: python недоступен — сверка runtime-файлов пропущена" >&2
+    fi
+
+    [ -s "$repair_errors" ] && sed 's/^/  ⚠ repair_pass: /' "$repair_errors" >&2
+
     while IFS='|' read -r fpath _; do
         [ -z "$fpath" ] && continue
         [ ! -f "$SCRIPT_DIR/$fpath" ] && continue
@@ -855,26 +888,8 @@ repair_pass() {
                 fi
                 ;;
         esac
-    done < <(
-        # issue #402: path via argv, not interpolated — see FILES_MATCH above for why.
-        # stderr is NOT suppressed here on purpose: the old `2>/dev/null` made a
-        # broken interpreter (or, before this fix, an embedded path native Python
-        # couldn't resolve) return zero rows with no diagnostic — "nothing to
-        # repair" looked identical to a real clean pass. A visible ⚠ beats silence;
-        # stderr is routed through a prefixer so it doesn't get read as a file row
-        # by the `while IFS='|' read` loop above (which only sees this fd's stdout).
-        if py_available; then
-            $PY_BIN -c "
-import json, sys
-with open(sys.argv[1]) as f:
-    data = json.load(f)
-for entry in data.get('files', []):
-    print(entry['path'] + '|')
-" "$MANIFEST" 2> >(sed 's/^/  ⚠ repair_pass: /' >&2)
-        else
-            echo "  ⚠ repair_pass: python недоступен — сверка runtime-файлов пропущена" >&2
-        fi
-    )
+    done < "$repair_paths"
+    rm -f "$repair_paths" "$repair_errors"
     if [ "$REPAIRED" -gt 0 ]; then
         echo "  ✓ $REPAIRED runtime-файлов восстановлено"
     fi


### PR DESCRIPTION
## Summary

Closes seven template defects in РП-485:

- `update.sh` repair-pass now works in macOS Bash 3.2; one repair closes #433 and #438.
- `create-wp.sh` no longer creates a pending archive stub, while `close-wp.sh` normalizes bare IDs and avoids a second archive. Fixes #425, #431.
- `inject-code-style.sh` counts and slices the hard cap in Unicode characters. Fixes #435.
- `/extend` lists all 16 invoked extension points. Fixes #436.
- `AGENTS-agent-blocks.md` is delivered again. Fixes #437.
- The nightly CI workflow is explicitly classified as non-deliverable, so the template validator accepts a clean release. Fixes #423.
- `seed/strategy/scripts/day-open-pipeline.sh` is synchronized with its canonical script. Fixes #427.

## Regression coverage

- WeekPlan-writer extraction is independent of the numbered create-wp step.
- `repair_paths` and `repair_errors` are local to `repair_pass()`.

## Verification

- `python3 -m pytest scripts/tests/` — 91 passed
- `bash setup/test-update-edge-cases.sh` — 123 PASS, 0 FAIL
- `bash scripts/check-seed-drift.sh` — 7 snapshots synchronized
- `bash scripts/tests/validate_manifest_coverage.sh` — all test files covered
