### PR TITLE
fix(notify): keep security route observable

### DIFF
--- a/.github/workflows/notify-update.yml
+++ b/.github/workflows/notify-update.yml
@@ -185,14 +185,23 @@ jobs:
   # DRR: decisions/2026-08/2026-08-10-wp-7-arhgeyt-changelog-klassifikaciya-bez-lts.md
   notify-security:
     runs-on: ubuntu-latest
-    if: github.repository == 'TserenTserenov/FMT-exocortex-template' && github.event_name == 'push'
     steps:
+      # Не ставим фильтр на уровень job: GitHub создавал для push пустой
+      # failing-run ещё до планирования job. Роутинг ниже оставляет доставку
+      # строго в push основного репозитория, но даёт Actions наблюдаемый исход.
+      - name: Report notification route
+        run: |
+          echo "event=${{ github.event_name }}"
+          echo "repository=${{ github.repository }}"
+
       - uses: actions/checkout@v6
+        if: github.repository == 'TserenTserenov/FMT-exocortex-template' && github.event_name == 'push'
         with:
           fetch-depth: 0  # нужна полная история для git diff по before..sha
 
       - name: Extract newly added [security] lines
         id: extract
+        if: github.repository == 'TserenTserenov/FMT-exocortex-template' && github.event_name == 'push'
         run: |
           # Общая логика извлечения/якорения — scripts/changelog-diff-lines.sh
           # (выделена из дублей в этом файле и validate-template.yml, code
@@ -216,7 +225,7 @@ jobs:
           fi
 
       - name: Send urgent security notification
-        if: steps.extract.outputs.has_security == 'true'
+        if: github.repository == 'TserenTserenov/FMT-exocortex-template' && github.event_name == 'push' && steps.extract.outputs.has_security == 'true'
         env:
           BOT_WEBHOOK_URL: ${{ secrets.BOT_WEBHOOK_URL }}
           TEMPLATE_WEBHOOK_SECRET: ${{ secrets.TEMPLATE_WEBHOOK_SECRET }}

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -621,7 +621,7 @@
     },
     {
       "path": ".github/workflows/notify-update.yml",
-      "sha256": "7a31dd64679fe304d06ad116ccfb9b2765a0a6271d4211deab854749e792b436"
+      "sha256": "b54bf64cf4ea8bf4940f192c6ecf608b0d535ef336a53123ac20b772f5ec9789"
     },
     {
       "path": ".github/workflows/post-release-audit.yml",


### PR DESCRIPTION
## Что исправлено

`Notify Template Update` создавал красные push-запуски без единой запланированной задачи; из-за этого срочный маршрут `[security]` не выполнялся даже при изменении `CHANGELOG.md`.

- перенёс фильтрацию push/репозитория с уровня job на шаги;
- добавил наблюдаемый шаг маршрутизации, чтобы GitHub фиксировал реальный исход запуска;
- сохранил отправку webhook только для новых `[security]`-строк в push основного репозитория;
- пересобрал `update-manifest.json`.

## Проверки

- `bash scripts/verify-manifest.sh`
- `python3 -m pytest -q scripts/tests` → 92 passed

Ручной dispatch не выполнялся: он мог бы отправить реальное уведомление подписчикам.
