### PR TITLE
fix(notify): run security check on main pushes

### DIFF
--- a/.github/workflows/notify-update.yml
+++ b/.github/workflows/notify-update.yml
@@ -9,9 +9,10 @@ on:
     - cron: '28 4 * * *'  # 7:28 MSK
   workflow_dispatch:       # ручной запуск для тестирования
   push:
-    branches: [main]        # найдено code review 13.08: без этого фильтра фичебранчи/worktree тоже триггерят уведомление о неревьюженном контенте
-    paths:
-      - 'CHANGELOG.md'     # WP-7 Ф62 п.4: триггер для срочного security-уведомления (job notify-security)
+    branches: [main]
+    # Не используем paths: GitHub создавал пустой failing-run до планирования
+    # job. Ненужные push завершаются успешно после проверки diff ниже, а
+    # webhook всё равно вызывается только для новых [security]-строк.
 
 permissions:
   contents: read

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -621,7 +621,7 @@
     },
     {
       "path": ".github/workflows/notify-update.yml",
-      "sha256": "b54bf64cf4ea8bf4940f192c6ecf608b0d535ef336a53123ac20b772f5ec9789"
+      "sha256": "bbd669fb6fcc6ee1a76576908e7ec1cba24b577d4dbdf6e281fb9026e6b5ed0e"
     },
     {
       "path": ".github/workflows/post-release-audit.yml",


### PR DESCRIPTION
## Что исправлено

`Notify Template Update` создавал красные push-запуски без единой запланированной задачи. Источник — фильтр `paths`, добавленный вместе со срочным security-маршрутом 13 августа; его появление совпало с началом ложных падений.

- запускаю проверку на каждом push в `main`, без хрупкого фильтра `paths`;
- отсутствие security-строк завершается успешно внутри задачи;
- webhook по-прежнему вызывается только для новых `[security]`-строк в основном репозитории;
- пересобрал `update-manifest.json`.

## Проверки

- `bash scripts/verify-manifest.sh`
- `python3 -m pytest -q scripts/tests` → 92 passed

Ручной dispatch не выполнялся: он мог бы отправить реальное уведомление подписчикам.
