### PR TITLE
fix(notify): isolate security changelog delivery

### DIFF
--- a/.github/workflows/notify-security.yml
+++ b/.github/workflows/notify-security.yml
@@ -1,0 +1,68 @@
+name: Notify Security Changelog
+
+# WP-7 Ф62 п.4: срочная доставка новых [security]-строк CHANGELOG.
+# Отдельный workflow не смешивает push-маршрут с ежедневным дайджестом.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  notify-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Extract newly added security lines
+        id: extract
+        run: |
+          NEW_LINES=$(bash scripts/changelog-diff-lines.sh "${{ github.event.before }}" --security-only)
+
+          if [ -z "$NEW_LINES" ]; then
+            echo "has_security=false" >> "$GITHUB_OUTPUT"
+            echo "No new security-tagged CHANGELOG lines in this push"
+            exit 0
+          fi
+
+          echo "has_security=true" >> "$GITHUB_OUTPUT"
+          DELIM="SECURITY_EOF_$(date +%s%N | sha256sum | cut -c1-16)"
+          {
+            echo "lines<<$DELIM"
+            echo "$NEW_LINES"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send urgent security notification
+        if: steps.extract.outputs.has_security == 'true'
+        env:
+          BOT_WEBHOOK_URL: ${{ secrets.BOT_WEBHOOK_URL }}
+          TEMPLATE_WEBHOOK_SECRET: ${{ secrets.TEMPLATE_WEBHOOK_SECRET }}
+          SECURITY_LINES: ${{ steps.extract.outputs.lines }}
+        run: |
+          VERSION=$(grep -m1 '^## \[' CHANGELOG.md | sed 's/## //')
+          MESSAGE="🔒 СРОЧНО — обнаружены security-изменения:
+          $SECURITY_LINES"
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${BOT_WEBHOOK_URL}/api/template-update" \
+            -H "Content-Type: application/json" \
+            -H "X-Webhook-Secret: ${TEMPLATE_WEBHOOK_SECRET}" \
+            -d "$(jq -n \
+              --arg version "$VERSION" \
+              --arg changelog "$MESSAGE" \
+              --arg commit_count "1" \
+              '{version: $version, changelog: $changelog, commit_count: ($commit_count | tonumber)}')")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "Urgent security notification sent: $BODY"
+          else
+            echo "Urgent security notification failed (HTTP $HTTP_CODE): $BODY"
+            exit 1
+          fi

--- a/.github/workflows/notify-update.yml
+++ b/.github/workflows/notify-update.yml
@@ -8,11 +8,6 @@ on:
   schedule:
     - cron: '28 4 * * *'  # 7:28 MSK
   workflow_dispatch:       # ручной запуск для тестирования
-  push:
-    branches: [main]
-    # Не используем paths: GitHub создавал пустой failing-run до планирования
-    # job. Ненужные push завершаются успешно после проверки diff ниже, а
-    # webhook всё равно вызывается только для новых [security]-строк.
 
 permissions:
   contents: read
@@ -20,10 +15,7 @@ permissions:
 jobs:
   notify:
     runs-on: ubuntu-latest
-    # найдено code review 13.08: без ограничения по event_name дневной дайджест
-    # запускался бы на каждый push (после добавления push-триггера для
-    # notify-security) — дубль сообщения подписчикам на каждом security-пуше.
-    if: github.repository == 'TserenTserenov/FMT-exocortex-template' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    if: github.repository == 'TserenTserenov/FMT-exocortex-template'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -177,84 +169,5 @@ jobs:
             echo "✓ Bot webhook responded: $BODY"
           else
             echo "✗ Bot webhook failed (HTTP $HTTP_CODE): $BODY"
-            exit 1
-          fi
-
-  # WP-7 Ф62 п.4: срочное уведомление для [security]-пунктов CHANGELOG — поверх
-  # уже существующего дневного дайджеста (job notify выше), тот же webhook/бот,
-  # НЕ новый канал доставки (принцип SECURITY.md: rolling-release без LTS).
-  # DRR: decisions/2026-08/2026-08-10-wp-7-arhgeyt-changelog-klassifikaciya-bez-lts.md
-  notify-security:
-    runs-on: ubuntu-latest
-    steps:
-      # Не ставим фильтр на уровень job: GitHub создавал для push пустой
-      # failing-run ещё до планирования job. Роутинг ниже оставляет доставку
-      # строго в push основного репозитория, но даёт Actions наблюдаемый исход.
-      - name: Report notification route
-        run: |
-          echo "event=${{ github.event_name }}"
-          echo "repository=${{ github.repository }}"
-
-      - uses: actions/checkout@v6
-        if: github.repository == 'TserenTserenov/FMT-exocortex-template' && github.event_name == 'push'
-        with:
-          fetch-depth: 0  # нужна полная история для git diff по before..sha
-
-      - name: Extract newly added [security] lines
-        id: extract
-        if: github.repository == 'TserenTserenov/FMT-exocortex-template' && github.event_name == 'push'
-        run: |
-          # Общая логика извлечения/якорения — scripts/changelog-diff-lines.sh
-          # (выделена из дублей в этом файле и validate-template.yml, code
-          # review 13.08: голый grep был не заякорен на позицию бирки).
-          NEW_LINES=$(bash scripts/changelog-diff-lines.sh "${{ github.event.before }}" --security-only)
-
-          if [ -z "$NEW_LINES" ]; then
-            echo "has_security=false" >> "$GITHUB_OUTPUT"
-            echo "No new [security]-tagged CHANGELOG lines in this push"
-          else
-            echo "has_security=true" >> "$GITHUB_OUTPUT"
-            # найдено code review 13.08: статичный delimiter коллидирует, если
-            # текст CHANGELOG когда-нибудь совпадёт со строкой-разделителем —
-            # случайный delimiter на каждый прогон убирает этот класс бага.
-            DELIM="SECURITY_EOF_$(date +%s%N | sha256sum | cut -c1-16)"
-            {
-              echo "lines<<$DELIM"
-              echo "$NEW_LINES"
-              echo "$DELIM"
-            } >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Send urgent security notification
-        if: github.repository == 'TserenTserenov/FMT-exocortex-template' && github.event_name == 'push' && steps.extract.outputs.has_security == 'true'
-        env:
-          BOT_WEBHOOK_URL: ${{ secrets.BOT_WEBHOOK_URL }}
-          TEMPLATE_WEBHOOK_SECRET: ${{ secrets.TEMPLATE_WEBHOOK_SECRET }}
-          SECURITY_LINES: ${{ steps.extract.outputs.lines }}
-        run: |
-          # SECURITY_LINES передан через env:, не заинлайнен в run: — прямая
-          # интерполяция ${{ }} в тело скрипта была бы script injection
-          # (значение из CHANGELOG.md попадает в actions-context как текст
-          # ДО запуска shell, до всякого экранирования).
-          VERSION=$(grep -m1 '^## \[' CHANGELOG.md | sed 's/## //')
-          MESSAGE="🔒 СРОЧНО — обнаружены security-изменения:
-          $SECURITY_LINES"
-
-          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${BOT_WEBHOOK_URL}/api/template-update" \
-            -H "Content-Type: application/json" \
-            -H "X-Webhook-Secret: ${TEMPLATE_WEBHOOK_SECRET}" \
-            -d "$(jq -n \
-              --arg version "$VERSION" \
-              --arg changelog "$MESSAGE" \
-              --arg commit_count "1" \
-              '{version: $version, changelog: $changelog, commit_count: ($commit_count | tonumber)}')")
-
-          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-          BODY=$(echo "$RESPONSE" | sed '$d')
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            echo "✓ Urgent security notification sent: $BODY"
-          else
-            echo "✗ Urgent security notification failed (HTTP $HTTP_CODE): $BODY"
             exit 1
           fi

--- a/generate-manifest.sh
+++ b/generate-manifest.sh
@@ -103,6 +103,7 @@ FILES_EXCLUDE_EXACT=(
 # per-file include, same technique as setup/validate-template.sh below.
 GITHUB_EXPLICIT_INCLUDE=(
     ".github/workflows/cloud-scheduler.yml"
+    ".github/workflows/notify-security.yml"
     ".github/workflows/notify-update.yml"
     ".github/workflows/post-release-audit.yml"
 )

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -620,8 +620,12 @@
       "sha256": "9b61f9aa74d0abb0037fcf7ae8b867bb7d5b59b3c0a391ae2d89398edc3c3f33"
     },
     {
+      "path": ".github/workflows/notify-security.yml",
+      "sha256": "9ebf408d9c75c8e1a62b905339b869d476528bfccd52e99d44a50f1a3c73153b"
+    },
+    {
       "path": ".github/workflows/notify-update.yml",
-      "sha256": "bbd669fb6fcc6ee1a76576908e7ec1cba24b577d4dbdf6e281fb9026e6b5ed0e"
+      "sha256": "672316f4226d43912c77b9ad2b2a66c90e987f6939688e83a7bfd40859cb797f"
     },
     {
       "path": ".github/workflows/post-release-audit.yml",


### PR DESCRIPTION
## Что исправлено

`Notify Template Update` создавал красные push-запуски без единой запланированной задачи с момента, когда в ежедневный workflow добавили срочный security-маршрут. Два промежуточных исправления подтвердили, что локальная перестановка условий не устраняет дефект GitHub-планирования.

- возвращает дневной workflow к отдельным schedule/manual-триггерам;
- выделяет срочную проверку в самостоятельный `notify-security.yml` для каждого push в `main`;
- webhook вызывается только для новых `[security]`-строк;
- добавляет новый workflow в поставляемый манифест;
- пересобрал `update-manifest.json`.

## Проверки

- `bash scripts/verify-manifest.sh`
- `python3 -m pytest -q scripts/tests` → 92 passed

Ручной dispatch не выполнялся: он мог бы отправить реальное уведомление подписчикам. Слияние PR само создаст безопасный живой push-тест: в нём нет security-строк.
