### PR TITLE
feat(WP-529 Ф3): fail-closed release receipt для критичных CI-проверок

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -517,6 +517,13 @@ jobs:
       - name: Test staged install-path guard
         run: bash scripts/tests/test_update_install_path_guard.sh
 
+      # WP-529 Ф3: release-receipt.sh (the release-receipt job below) must
+      # fail closed — success/skipped on every mandatory check to publish,
+      # anything else blocks. Tested here the same way every other guard in
+      # this job is: run against synthetic scenarios, not just imported.
+      - name: Test release-receipt fail-closed logic
+        run: bash scripts/tests/test_release_receipt.sh
+
       # issue #310/#323: хук-страж, не зарегистрированный ни в одном событии, не
       # срабатывает никогда — и «не сработал» неотличимо от «нарушений не было».
       - name: Check every hook is actually wired (orphan-hook guard)
@@ -543,3 +550,47 @@ jobs:
           else
             echo "PASS: All placeholders are valid"
           fi
+
+  # WP-529 Ф3: single fail-closed receipt for this commit, built from the
+  # results of THIS workflow run (needs.<job>.result — same trigger, same
+  # SHA), not from querying job status elsewhere. `if: always()` so a
+  # failure upstream still produces a receipt recording that failure,
+  # instead of the receipt job itself being skipped and leaving no artifact
+  # to show why the commit isn't publishable. integration-contract-macos is
+  # included even though it only runs on pull_request/schedule (see its own
+  # `if:` above) — on a plain push its result is "skipped", which
+  # release-receipt.sh already treats as pass; on the triggers where it DOES
+  # run, this receipt actually gates on it instead of silently ignoring it.
+  release-receipt:
+    needs:
+      - release-sync
+      - integration-contract-ubuntu
+      - integration-contract-macos
+      - shellcheck
+      - platform-compat
+      - validate
+      - upgrade-test
+      - guide-kit-drift
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # release-receipt.sh needs full update-manifest.json history to resolve base_sha
+      - name: Build release receipt
+        env:
+          RESULT_RELEASE_SYNC: ${{ needs.release-sync.result }}
+          RESULT_INTEGRATION_CONTRACT_UBUNTU: ${{ needs.integration-contract-ubuntu.result }}
+          RESULT_INTEGRATION_CONTRACT_MACOS: ${{ needs.integration-contract-macos.result }}
+          RESULT_SHELLCHECK: ${{ needs.shellcheck.result }}
+          RESULT_PLATFORM_COMPAT: ${{ needs.platform-compat.result }}
+          RESULT_VALIDATE: ${{ needs.validate.result }}
+          RESULT_UPGRADE_TEST: ${{ needs.upgrade-test.result }}
+          RESULT_GUIDE_KIT_DRIFT: ${{ needs.guide-kit-drift.result }}
+        run: bash scripts/release-receipt.sh
+      - name: Upload release receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-receipt
+          path: release-receipt.json

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ __pycache__/
 # В репозитории живёт только образец params.yaml.example; рабочий файл создаётся
 # при установке и никогда не приезжает из git.
 /params.yaml
+
+# WP-529 Ф3: release-receipt.sh output — generated per-run in CI (uploaded as
+# an artifact, not committed) and by any local dry-run of the script.
+/release-receipt.json

--- a/scripts/release-receipt.sh
+++ b/scripts/release-receipt.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# release-receipt.sh — WP-529 Ф3 fail-closed release receipt.
+#
+# Aggregates the mandatory CI jobs of validate-template.yml into a single
+# receipt tied to one commit: which checks ran, what they returned, and
+# whether the tree is publishable. Fed by `needs.<job>.result` from the same
+# workflow run — same trigger, same SHA — not by querying job status from
+# elsewhere, which is exactly the trust gap Ф3 exists to close (a red main
+# for two days, one accidental green run, proved that "we run this check
+# somewhere" says nothing about whether THIS commit passed it).
+#
+# publishable=true requires every mandatory check to be success or skipped
+# (skipped = intentionally not run for this trigger, e.g. the macOS
+# integration job on a push event — see validate-template.yml condition on
+# integration-contract-macos). Any failure/cancelled/unknown → false, and
+# the script exits 1 so a future required_status_check can gate on this one
+# job instead of enumerating every individual job (Ф2 acceptance criterion,
+# still deferred by pilot decision as of 18.08).
+#
+# Usage (CI): RESULT_<JOB>=<needs.<job>.result> bash scripts/release-receipt.sh
+# Usage (local dry-run): bash scripts/release-receipt.sh — reads "unknown" for
+# unset RESULT_* vars, which counts as a failure (fail-closed, not fail-open).
+#
+# Exit 0 = publishable. Exit 1 = not publishable (receipt still written).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$SCRIPT_DIR/update-manifest.json"
+RECEIPT="${RELEASE_RECEIPT_OUT:-$SCRIPT_DIR/release-receipt.json}"
+
+[ -f "$MANIFEST" ] || { echo "ERROR: $MANIFEST не найден"; exit 2; }
+
+SHA="${RELEASE_RECEIPT_SHA:-$(git -C "$SCRIPT_DIR" rev-parse HEAD)}"
+# Same "second version bump in update-manifest.json history" logic
+# validate-template.yml's upgrade-test job already uses to find the previous
+# published version — reused here, not reimplemented, so the receipt's
+# base_sha always agrees with what upgrade-test actually exercised.
+BASE_SHA="$(git -C "$SCRIPT_DIR" log --format=%H -- "$MANIFEST" | sed -n '2p')"
+MANIFEST_HASH="$(sha256sum "$MANIFEST" | awk '{print $1}')"
+GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Ordered, not an associative array — JSON key order in the receipt should
+# be stable across runs, and bash associative-array iteration order isn't.
+CHECK_NAMES=(
+  release-sync
+  integration-contract-ubuntu
+  integration-contract-macos
+  shellcheck
+  platform-compat
+  validate
+  upgrade-test
+  guide-kit-drift
+)
+CHECK_ENV_VARS=(
+  RESULT_RELEASE_SYNC
+  RESULT_INTEGRATION_CONTRACT_UBUNTU
+  RESULT_INTEGRATION_CONTRACT_MACOS
+  RESULT_SHELLCHECK
+  RESULT_PLATFORM_COMPAT
+  RESULT_VALIDATE
+  RESULT_UPGRADE_TEST
+  RESULT_GUIDE_KIT_DRIFT
+)
+
+PUBLISHABLE=true
+CHECKS_JSON="[]"
+FAILED_NAMES=()
+
+for i in "${!CHECK_NAMES[@]}"; do
+  name="${CHECK_NAMES[$i]}"
+  var="${CHECK_ENV_VARS[$i]}"
+  result="${!var:-unknown}"
+  case "$result" in
+    success | skipped) ;;
+    *)
+      PUBLISHABLE=false
+      FAILED_NAMES+=("$name:$result")
+      ;;
+  esac
+  CHECKS_JSON=$(echo "$CHECKS_JSON" | jq --arg name "$name" --arg result "$result" \
+    '. + [{name: $name, result: $result}]')
+done
+
+jq -n \
+  --arg sha "$SHA" \
+  --arg base_sha "${BASE_SHA:-}" \
+  --arg manifest_hash "$MANIFEST_HASH" \
+  --arg generated_at "$GENERATED_AT" \
+  --argjson publishable "$PUBLISHABLE" \
+  --argjson checks "$CHECKS_JSON" \
+  '{sha: $sha, base_sha: $base_sha, manifest_hash: $manifest_hash,
+    generated_at: $generated_at, checks: $checks, publishable: $publishable}' \
+  > "$RECEIPT"
+
+if [ "$PUBLISHABLE" = "true" ]; then
+  echo "PASS: publishable=true — $SHA"
+else
+  echo "FAIL: publishable=false — $SHA"
+  echo "  Обязательные проверки без success/skipped: ${FAILED_NAMES[*]}"
+  exit 1
+fi

--- a/scripts/tests/test_release_receipt.sh
+++ b/scripts/tests/test_release_receipt.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# WP-529 Ф3: release-receipt.sh must be fail-closed — publishable=true only
+# when every mandatory check reports success or skipped (a job intentionally
+# not run for this trigger, e.g. the macOS integration job on a push event).
+# Any failure, cancelled run, or an unset RESULT_* var (the receipt job
+# never even wired that job's result in) must produce publishable=false and
+# a non-zero exit, not silently pass.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+SCRIPT="$ROOT/scripts/release-receipt.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+ALL_SUCCESS_ENV=(
+  RESULT_RELEASE_SYNC=success
+  RESULT_INTEGRATION_CONTRACT_UBUNTU=success
+  RESULT_INTEGRATION_CONTRACT_MACOS=skipped
+  RESULT_SHELLCHECK=success
+  RESULT_PLATFORM_COMPAT=success
+  RESULT_VALIDATE=success
+  RESULT_UPGRADE_TEST=success
+  RESULT_GUIDE_KIT_DRIFT=success
+)
+
+# Scenario 1: every mandatory check success/skipped -> publishable, exit 0.
+OUT1="$TMP/receipt-allpass.json"
+if ! RELEASE_RECEIPT_OUT="$OUT1" env "${ALL_SUCCESS_ENV[@]}" bash "$SCRIPT"; then
+  echo "FAIL: all-success scenario exited non-zero"
+  exit 1
+fi
+[ "$(jq -r '.publishable' "$OUT1")" = "true" ] || {
+  echo "FAIL: all-success scenario did not produce publishable=true"
+  exit 1
+}
+[ "$(jq '.checks | length' "$OUT1")" = "8" ] || {
+  echo "FAIL: all-success receipt does not list all 8 mandatory checks"
+  exit 1
+}
+[ "$(jq -r '.sha' "$OUT1")" = "$(git -C "$ROOT" rev-parse HEAD)" ] || {
+  echo "FAIL: receipt sha does not match HEAD"
+  exit 1
+}
+
+# Scenario 2: one mandatory check failed -> not publishable, exit 1, and the
+# failing check is identifiable in the receipt (not just a bare false).
+OUT2="$TMP/receipt-onefail.json"
+if RELEASE_RECEIPT_OUT="$OUT2" env "${ALL_SUCCESS_ENV[@]}" RESULT_VALIDATE=failure bash "$SCRIPT"; then
+  echo "FAIL: one-failure scenario exited 0, expected non-zero"
+  exit 1
+fi
+[ "$(jq -r '.publishable' "$OUT2")" = "false" ] || {
+  echo "FAIL: one-failure scenario did not produce publishable=false"
+  exit 1
+}
+[ "$(jq -r '.checks[] | select(.name=="validate") | .result' "$OUT2")" = "failure" ] || {
+  echo "FAIL: receipt does not record validate:failure"
+  exit 1
+}
+
+# Scenario 3: a cancelled run must fail closed too, not just a literal "failure".
+OUT3="$TMP/receipt-cancelled.json"
+if RELEASE_RECEIPT_OUT="$OUT3" env "${ALL_SUCCESS_ENV[@]}" RESULT_UPGRADE_TEST=cancelled bash "$SCRIPT"; then
+  echo "FAIL: cancelled scenario exited 0, expected non-zero"
+  exit 1
+fi
+[ "$(jq -r '.publishable' "$OUT3")" = "false" ] || {
+  echo "FAIL: cancelled scenario did not produce publishable=false"
+  exit 1
+}
+
+# Scenario 4: no RESULT_* vars set at all (e.g. a `needs:` entry added to the
+# receipt job's list but never wired as env) must fail closed, not read as
+# vacuously publishable.
+OUT4="$TMP/receipt-noenv.json"
+if RELEASE_RECEIPT_OUT="$OUT4" bash "$SCRIPT"; then
+  echo "FAIL: no-env scenario exited 0, expected non-zero"
+  exit 1
+fi
+[ "$(jq -r '.publishable' "$OUT4")" = "false" ] || {
+  echo "FAIL: no-env scenario did not produce publishable=false"
+  exit 1
+}
+[ "$(jq -r '.checks[] | select(.name=="release-sync") | .result' "$OUT4")" = "unknown" ] || {
+  echo "FAIL: no-env scenario did not record unknown result for unset checks"
+  exit 1
+}
+
+# Scenario 5: a RESULT_* var set to an empty string (not merely unset) must
+# still fail closed — `${!var:-unknown}` treats bash's null and unset the
+# same way, but that equivalence is exactly the kind of thing a future edit
+# could accidentally break, so assert it directly instead of trusting it.
+OUT5="$TMP/receipt-emptystring.json"
+if RELEASE_RECEIPT_OUT="$OUT5" env "${ALL_SUCCESS_ENV[@]}" RESULT_VALIDATE="" bash "$SCRIPT"; then
+  echo "FAIL: empty-string scenario exited 0, expected non-zero"
+  exit 1
+fi
+[ "$(jq -r '.publishable' "$OUT5")" = "false" ] || {
+  echo "FAIL: empty-string scenario did not produce publishable=false"
+  exit 1
+}
+[ "$(jq -r '.checks[] | select(.name=="validate") | .result' "$OUT5")" = "unknown" ] || {
+  echo "FAIL: empty-string RESULT_VALIDATE was not recorded as unknown"
+  exit 1
+}
+
+echo "PASS: release-receipt.sh is fail-closed across all-pass/failure/cancelled/unset/empty-string scenarios"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -633,7 +633,7 @@
     },
     {
       "path": ".gitignore",
-      "sha256": "5faf5868c204662a671ab1f4696ed8f06323b646fba12f18cf37a7c28a04c08f"
+      "sha256": "482fc43c3a96dcd12cfafc9e5aaf2937629a152a3c29095e06adace8f2dfc6a8"
     },
     {
       "path": ".mcp.json",
@@ -2212,6 +2212,10 @@
       "sha256": "09f091dc35474ca700060f0bd5a717f3617118d41ead190b3607a4aa0db015ad"
     },
     {
+      "path": "scripts/release-receipt.sh",
+      "sha256": "e70fac071cbe4731e21be3363c2fd29a9a4a66e13ef851f94d5c33bb6815dd06"
+    },
+    {
       "path": "scripts/restore-from-exocortex.sh",
       "sha256": "a296645184942d004e28921ea8d734c163729bcc148de5372e4fc39721ceaf39"
     },
@@ -2526,6 +2530,7 @@
     "scripts/tests/test_install_hooks.py",
     "scripts/tests/test_manifest_coverage_local.py",
     "scripts/tests/test_pending_phases_sweep.sh",
+    "scripts/tests/test_release_receipt.sh",
     "scripts/tests/test_residency_gate_skill_adapter.py",
     "scripts/tests/test_skill_promote.py",
     "scripts/tests/test_translate_delta.py",


### PR DESCRIPTION
## Что делает

Единая квитанция релиза (`release-receipt.json`), которая сама подтверждает публикуемость коммита, а не просто читает "зелёный" статус CI откуда-то ещё:

- новый `scripts/release-receipt.sh` — агрегирует `needs.<job>.result` восьми обязательных jobs текущего workflow run (тот же trigger, тот же SHA);
- `publishable = AND(success | skipped по всем обязательным)` — любой `failure`/`cancelled`/непереданный результат → `publishable=false`, exit 1;
- новый job `release-receipt` в `validate-template.yml` (`if: always()`, чтобы падение выше всё равно дало квитанцию с причиной), загружает receipt как artifact.

## Почему

WP-529 (конвейер доставки шаблона): main был красным почти непрерывно 16-18.08, единственный случайный зелёный прогон CI ничего не доказывал про реальную публикуемость конкретного коммита. Достигнуто консенсусом с Codex (пир-сессия 2026-08-18-15-wp529-f3-verification-matrix): не изобретать новую инфраструктуру проверки, но сделать fail-closed агрегатор поверх уже существующих jobs, который сам, в рамках того же run-id, подтверждает install/upgrade на релизном SHA — не заимствует статус как внешний факт.

## Проверено

- 5 сценариев regression-теста (`scripts/tests/test_release_receipt.sh`): все прошли / один failure / один cancelled / ничего не передано / пустая строка — все fail-closed.
- Cold-context code review (built-in Agent tool): 1 High + 2 Medium найдены и исправлены до коммита (детали — `review-01.md` пир-сессии).
- Ф1/Ф2 гейты (`check-critical-files-map.sh`, `verify-manifest.sh`, `check-delivery-route-label.sh`) и соседние тесты (`test-delivery-route-label.sh`, `test_update_install_path_guard.sh`) — все зелёные локально.
- Не проверено вживую: сама оркестрация GitHub Actions (`needs:`/artifact upload) — впервые пройдёт на CI этого PR.

`required_status_checks` на main по-прежнему не включён (acceptance-критерий Ф2, отложен решением пилота) — эта квитанция даёт будущую единую точку для branch protection вместо перечисления каждого job вручную.

🤖 Generated with [Claude Code](https://claude.com/claude-code)