### PR TITLE
fix(manifest): дрейф манифеста, найденный Евгением 19.08

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -453,6 +453,16 @@ jobs:
         run: |
           bash scripts/verify-manifest.sh
 
+      # Evgenii Red Team review 2026-08-19: B2 above only checks that files
+      # ALREADY IN the manifest have correct hashes — it says nothing about a
+      # tracked file that is in neither manifest.files nor
+      # manifest.excluded_paths (a silent delivery-coverage gap, as opposed
+      # to a delivered-but-stale hash). check-manifest-coverage.py already
+      # existed but was never wired into CI as its own gate.
+      - name: Check manifest coverage (no silent delivery gaps)
+        run: |
+          git ls-files | python3 scripts/check-manifest-coverage.py update-manifest.json
+
       # WP-529 Ф1: docs/critical-files-map.yaml должна оставаться согласованной
       # с живой классификацией generate-manifest.sh — та же гарантия, что B2
       # выше даёт для update-manifest.json, только для карты категорий.

--- a/generate-manifest.sh
+++ b/generate-manifest.sh
@@ -196,7 +196,14 @@ while IFS= read -r rel; do
     # setup/ contains install-time scripts; skip all except explicit includes
     # (validate-template.sh referenced by .githooks/pre-commit and update.sh
     # after delivery; setup-cloud-scheduler.sh — see SETUP_EXPLICIT_INCLUDE above).
+    # Register in EXCLUDED_PATHS same as .github/ above (#423) — Evgenii's
+    # Red Team review 2026-08-19 found setup/test-delivery-route-label.sh
+    # (and every other setup/test-*.sh) as a silent manifest-coverage gap:
+    # this branch's bare `continue` never recorded WHY the file was skipped,
+    # so check-manifest-coverage.py had no way to distinguish it from a
+    # forgotten delivery.
     if [[ "$rel" == setup/* ]] && ! is_explicit_include "$rel" "${SETUP_EXPLICIT_INCLUDE[@]}"; then
+        EXCLUDED_PATHS+=("$rel")
         continue
     fi
 

--- a/scripts/tests/test_generate_manifest_registers_setup_exclusions.sh
+++ b/scripts/tests/test_generate_manifest_registers_setup_exclusions.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# test_generate_manifest_registers_setup_exclusions.sh — Evgenii Red Team
+# review 2026-08-19 (post-merge manifest drift observation, #3).
+#
+# generate-manifest.sh's setup/* blanket-skip branch used to `continue`
+# without ever appending to EXCLUDED_PATHS — every setup/test-*.sh file
+# (and 20+ others under setup/) fell out of BOTH manifest.files and
+# manifest.excluded_paths silently. check-manifest-coverage.py (which
+# already existed, but was never wired into CI as its own gate) correctly
+# flags this as a coverage gap: no way to distinguish "forgotten delivery"
+# from "deliberately install-time-only".
+#
+# This test runs the REAL generate-manifest.sh + check-manifest-coverage.py
+# against a scratch clone of this repo (same harness pattern as
+# setup/test-update-issue-226.sh) — generate-manifest.sh has no --output
+# flag, it always writes $SCRIPT_DIR/update-manifest.json, so the whole
+# repo is cloned rather than pointed at the live manifest.
+set -uo pipefail
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SELF_DIR/../.." && pwd)"
+SCRATCH="/tmp/iwe-manifest-setup-exclusion-test-$$"
+
+FAIL=0
+fail() { echo "  ❌ FAIL: $*" >&2; FAIL=$((FAIL+1)); }
+pass() { echo "  ✅ PASS: $*"; }
+cleanup() { local rc=$?; rm -rf "$SCRATCH"; exit "$rc"; }
+trap cleanup EXIT INT TERM
+
+# generate-manifest.sh runs `git ls-files` internally, so the scratch copy
+# needs an actual .git, not just the tracked files — `git archive` strips
+# .git entirely and silently produces an empty manifest (0 files) instead
+# of failing loud, which would have made every setup/ file look "uncovered"
+# for the wrong reason. `git clone --local` gives a real repo at HEAD.
+git clone --local --quiet "$ROOT" "$SCRATCH" \
+    || { fail "git clone of $ROOT failed"; exit 1; }
+
+echo "--- generate-manifest.sh must register EVERY setup/ file it skips ---"
+( cd "$SCRATCH" && bash generate-manifest.sh >/dev/null 2>&1 ) \
+    || { fail "generate-manifest.sh itself failed"; exit 1; }
+
+# Cross-check against the REAL setup/ tree, not a fixture: any tracked file
+# under setup/ that generate-manifest.sh silently drops is exactly the
+# defect Evgenii found (test-delivery-route-label.sh was one instance among
+# several — the fix targets the branch, not one filename).
+UNCOVERED=""
+while IFS= read -r f; do
+    COVERED=$(cd "$SCRATCH" && python3 -c "
+import json
+m = json.load(open('update-manifest.json'))
+in_files = any(x['path'] == '$f' for x in m['files'])
+in_excluded = '$f' in m.get('excluded_paths', [])
+print('1' if (in_files or in_excluded) else '0')
+")
+    [ "$COVERED" = "0" ] && UNCOVERED="$UNCOVERED $f"
+done < <(git -C "$SCRATCH" ls-files setup/)
+
+if [ -z "$UNCOVERED" ]; then
+    pass "every tracked setup/ file is in manifest.files or manifest.excluded_paths"
+else
+    fail "uncovered setup/ files (in neither list):$UNCOVERED"
+fi
+
+echo "--- check-manifest-coverage.py must find zero gaps on the generated manifest ---"
+if ( cd "$SCRATCH" && git ls-files | python3 scripts/check-manifest-coverage.py update-manifest.json ) >/tmp/coverage-out-$$.log 2>&1; then
+    pass "check-manifest-coverage.py: zero gaps"
+else
+    fail "check-manifest-coverage.py found gaps:"
+    sed 's/^/  /' /tmp/coverage-out-$$.log >&2
+fi
+rm -f /tmp/coverage-out-$$.log
+
+echo "---"
+if [ "$FAIL" -gt 0 ]; then
+    echo "manifest setup-exclusion contract: $FAIL check(s) failed"
+    exit 1
+fi
+echo "manifest setup-exclusion contract: all checks passed"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2225,7 +2225,7 @@
     },
     {
       "path": "scripts/pending-phases-sweep.sh",
-      "sha256": "503709e24f6e191c571bd7adb407866dabe0ee596ea14c79368d8bcf4a43c3b2"
+      "sha256": "9e2434ef4b64154fc15cb3874588b086670c89d74993ecdb778fbd8a4e5e42b2"
     },
     {
       "path": "scripts/post-update-check-skills.sh",
@@ -2261,7 +2261,7 @@
     },
     {
       "path": "scripts/server-calendar.sh",
-      "sha256": "2fa9d4e61c38320150fc262806a87dc8ca56d3eed25f625d3a4a50e39539b9ff"
+      "sha256": "27e1c8f6c2a2d7b35f2a025d56f0f488132746f4fe79c7db7e0a5f53a3e4fa33"
     },
     {
       "path": "scripts/server-news.sh",
@@ -2561,6 +2561,7 @@
     "scripts/tests/test_delivery_content.py",
     "scripts/tests/test_delivery_formal.py",
     "scripts/tests/test_dry_run_gate.py",
+    "scripts/tests/test_generate_manifest_registers_setup_exclusions.sh",
     "scripts/tests/test_install_hooks.py",
     "scripts/tests/test_issue_434_pipeline_scaffold_only.sh",
     "scripts/tests/test_issue_453_calendar_private_visibility.sh",
@@ -2586,7 +2587,31 @@
     "sessions/2026-06/2026-06-17-01-kimi-setup/02-writer.md",
     "sessions/2026-06/2026-06-17-01-kimi-setup/03-peer.md",
     "sessions/2026-06/2026-06-17-01-kimi-setup/meta.yaml",
-    "sessions/2026-06/2026-06-17-01-kimi-setup/report.md"
+    "sessions/2026-06/2026-06-17-01-kimi-setup/report.md",
+    "setup/detector-fixtures/README.md",
+    "setup/detector-fixtures/detector_07/positive_backtick_slash.md",
+    "setup/detector-regex.sh",
+    "setup/integration-contract-validator.sh",
+    "setup/optional/COVER-IMAGES.md",
+    "setup/optional/README.md",
+    "setup/optional/generate-post-image.py",
+    "setup/optional/pomodoro-alert.plist",
+    "setup/optional/pomodoro-alert.py",
+    "setup/optional/setup-agent-workspace.sh",
+    "setup/optional/setup-calendar.sh",
+    "setup/promote-fixtures/README.md",
+    "setup/promote-fixtures/sample-hook.sh",
+    "setup/promote-fixtures/sample-script.sh",
+    "setup/promote-fixtures/sample-settings.json",
+    "setup/promote-fixtures/sample-skill/SKILL.md",
+    "setup/promote-fixtures/sample-skill/scripts/sample-tool.sh",
+    "setup/release-audit-prompt.md",
+    "setup/smoke-test-fresh-install.sh",
+    "setup/test-delivery-route-label.sh",
+    "setup/test-detectors.sh",
+    "setup/test-update-edge-cases.sh",
+    "setup/test-update-issue-226.sh",
+    "setup/ux-walkthrough-prompt.md"
   ],
   "deprecated_files": [
     {


### PR DESCRIPTION
## Что это

Евгений Селиверстов проверил свежий main (`0a4f3d7`) отдельно от трёх уже закрытых находок PR #478 (PyYAML, Delivery-Route trailer, TOTAL_CHANGES=0) и нашёл два новых, независимых дефекта конвейера доставки манифеста. Живой факт: плановый CI-прогон на main сейчас красный — https://github.com/TserenTserenov/FMT-exocortex-template/actions/runs/32210497489

## Находка 1 — SHA-дрейф между git tree и манифестом

Последний коммит template-sync (`0a4f3d7`) изменил `scripts/pending-phases-sweep.sh` и `scripts/server-calendar.sh` уже после последней регенерации манифеста. `verify-manifest.sh` и `check-manifest-coverage.py` воспроизводимо красные на main прямо сейчас. Фикс: манифест перегенерирован.

## Находка 2 — coverage gap

`generate-manifest.sh`'s `setup/*` blanket-skip ветка делала bare `continue` без регистрации пути в `EXCLUDED_PATHS` — 24 файла под `setup/` (включая все четыре `setup/test-*.sh`) тихо выпадали из ОБОИХ списков (`manifest.files` и `manifest.excluded_paths`). `check-manifest-coverage.py` уже существовал в репозитории и корректно фиксирует такие файлы как пробел покрытия, но не был подключён к CI как отдельный обязательный шаг — находка Евгения дословно: «coverage checker не является отдельным блокирующим шагом текущего workflow».

Интересная деталь: тот же генератор уже применяет паттерн `EXCLUDED_PATHS+=(path); continue` для `.github/` с прямой ссылкой на issue #423 — тот же класс дефекта был найден и починен для одного каталога, но не для другого.

**Фикс:**
- `setup/`-ветка регистрирует путь тем же способом, что `.github/`
- новый CI-шаг «Check manifest coverage» сразу после B2

## Проверено

- `scripts/verify-manifest.sh` — синхронизирован
- `git ls-files | python3 scripts/check-manifest-coverage.py` — 793 файла покрыты (0 пробелов)
- новый регресс-тест `test_generate_manifest_registers_setup_exclusions.sh` на реальном `git clone` (генератор не параметризует выходной путь) + обязательная мутационная проверка (откат фикса → тест реально падает на обеих проверках)
- `setup/validate-template.sh` (pristine + staged) — все проверки прошли

## Границы

Гипотеза Евгения про порядок `template-sync → manifest regeneration → coverage → release-receipt` — сам скрипт `template-sync.sh` живёт в `DS-ai-systems` (авторский конвейер платформы), не в этом репозитории — вне scope этого PR. Здесь закрыта защита СО СТОРОНЫ FMT: любой рассинхрон, независимо от причины, теперь ловится B2 + новым coverage-шагом до мерджа.

Мердж — решение пилота (тот же паттерн, что #472/#478).

🤖 Generated with [Claude Code](https://claude.com/claude-code)