### PR TITLE
fix(scheduler): гонка двух вызывателей strategist — exit 2 не провал

### DIFF
--- a/roles/strategist/scripts/systemd/iwe-strategist-morning.service
+++ b/roles/strategist/scripts/systemd/iwe-strategist-morning.service
@@ -5,6 +5,9 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+# bug-2026-08-18/19: exit 2 = сценарий уже выполняется другим вызывателем
+# (гонка с hourly dispatch при пробуждении машины) — это успех, не сбой юнита.
+SuccessExitStatus=2
 ExecStart={{IWE_RUNTIME}}/roles/strategist/scripts/strategist.sh morning
 Environment=HOME={{HOME_DIR}}
 Environment=IWE_TEMPLATE={{IWE_TEMPLATE}}

--- a/roles/strategist/scripts/systemd/iwe-strategist-weekreview.service
+++ b/roles/strategist/scripts/systemd/iwe-strategist-weekreview.service
@@ -5,6 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+# bug-2026-08-18/19: exit 2 = сценарий уже выполняется другим вызывателем — не сбой.
+SuccessExitStatus=2
 ExecStart={{IWE_RUNTIME}}/roles/strategist/scripts/strategist.sh week-review
 Environment=HOME={{HOME_DIR}}
 Environment=IWE_TEMPLATE={{IWE_TEMPLATE}}

--- a/roles/synchronizer/scripts/scheduler.sh
+++ b/roles/synchronizer/scripts/scheduler.sh
@@ -155,6 +155,23 @@ mark_interval() {
     echo "$NOW" > "$STATE_DIR/$1-last"
 }
 
+# bug-2026-08-18/19 (гонка двух вызывателей): при пробуждении машины systemd-сервис
+# (iwe-strategist-morning) и hourly dispatch стартуют одновременно; проигравший
+# получает от strategist.sh exit 2 («mkdir-lock занят живым PID»), что не сбой.
+# Классификация: 0 = выполнено (ставим отметку); 2 = выполняется другим вызывателем
+# (отметку НЕ ставим — следующий dispatch перепроверит already_ran_today);
+# иное = сбой (WARN, will retry).
+run_strategist_task() {
+    local task="$1" rc=0
+    timeout "$TASK_TIMEOUT_LONG" "$STRATEGIST_SH" "$task" >> "$LOG_FILE" 2>&1 || rc=$?
+    if [ "$rc" -eq 2 ]; then
+        log "OK: strategist $task уже выполняется другим вызывателем (lock held) — не провал"
+    elif [ "$rc" -ne 0 ]; then
+        log "WARN: strategist $task failed rc=$rc (will retry next dispatch)"
+    fi
+    return "$rc"
+}
+
 # === Очистка старых маркеров (>7 дней) ===
 
 cleanup_state() {
@@ -197,10 +214,8 @@ dispatch() {
     # --- Стратег: week-review (Пн, до morning) ---
     if [ "$DOW" = "1" ] && ! ran_this_week "strategist-week-review"; then
         log "→ strategist week-review (catch-up: hour=$HOUR)"
-        if timeout "$TASK_TIMEOUT_LONG" "$STRATEGIST_SH" week-review >> "$LOG_FILE" 2>&1; then
+        if run_strategist_task week-review; then
             mark_done_week "strategist-week-review"
-        else
-            log "WARN: strategist week-review failed (will retry next dispatch)"
         fi
         ran=1
     fi
@@ -208,10 +223,8 @@ dispatch() {
     # --- Стратег: morning (04:00-21:59) ---
     if (( 10#$HOUR >= 4 && 10#$HOUR < 22 )) && ! ran_today "strategist-morning"; then
         log "→ strategist morning (catch-up: hour=$HOUR)"
-        if timeout "$TASK_TIMEOUT_LONG" "$STRATEGIST_SH" morning >> "$LOG_FILE" 2>&1; then
+        if run_strategist_task morning; then
             mark_done "strategist-morning"
-        else
-            log "WARN: strategist morning failed (will retry next dispatch)"
         fi
         ran=1
     fi
@@ -219,10 +232,8 @@ dispatch() {
     # --- Стратег: note-review (22:00+) ---
     if (( 10#$HOUR >= 22 )) && ! ran_today "strategist-note-review"; then
         log "→ strategist note-review (catch-up: hour=$HOUR)"
-        if timeout "$TASK_TIMEOUT_LONG" "$STRATEGIST_SH" note-review >> "$LOG_FILE" 2>&1; then
+        if run_strategist_task note-review; then
             mark_done "strategist-note-review"
-        else
-            log "WARN: strategist note-review failed (will retry next dispatch)"
         fi
         ran=1
     elif (( 10#$HOUR < 12 )); then
@@ -230,10 +241,8 @@ dispatch() {
         yesterday=$(portable_date_offset 1)
         if [ -n "$yesterday" ] && [ ! -f "$STATE_DIR/strategist-note-review-$yesterday" ]; then
             log "→ strategist note-review (catch-up for yesterday $yesterday)"
-            if timeout "$TASK_TIMEOUT_LONG" "$STRATEGIST_SH" note-review >> "$LOG_FILE" 2>&1; then
+            if run_strategist_task note-review; then
                 echo "$(date '+%H:%M:%S') catch-up" > "$STATE_DIR/strategist-note-review-$yesterday"
-            else
-                log "WARN: strategist note-review catch-up failed"
             fi
             ran=1
         fi

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1693,7 +1693,7 @@
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-morning.service",
-      "sha256": "977321695ba576f19214ccf219f98e6101cd94eae5c0de54fe374ad3738c2577"
+      "sha256": "fd73e2838e4c59e32e4032f6d3d7d56b09c6c12ee4559068def6cb2d2f10ed25"
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-morning.timer",
@@ -1701,7 +1701,7 @@
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-weekreview.service",
-      "sha256": "f300d3ea098e2bb653e1d3b8ba7c544811a7deaa65ecb51d81d9d55cbf270b49"
+      "sha256": "db576169df9041629a783bad9fbfa92818e3bad951535092fb8a23eb767ca62d"
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-weekreview.timer",
@@ -1753,7 +1753,7 @@
     },
     {
       "path": "roles/synchronizer/scripts/scheduler.sh",
-      "sha256": "57f8fa8ccaabd2c97bbcf9caa128a246dee46e05b25d2ce5e5d3de59cc15c6f1"
+      "sha256": "5d41a9c9aa31d1f81737add89f3217612935e019fd90ad98f89ddacc5b8d6869"
     },
     {
       "path": "roles/synchronizer/scripts/sync-files.sh",
@@ -2225,7 +2225,7 @@
     },
     {
       "path": "scripts/pending-phases-sweep.sh",
-      "sha256": "503709e24f6e191c571bd7adb407866dabe0ee596ea14c79368d8bcf4a43c3b2"
+      "sha256": "9e2434ef4b64154fc15cb3874588b086670c89d74993ecdb778fbd8a4e5e42b2"
     },
     {
       "path": "scripts/post-update-check-skills.sh",
@@ -2261,7 +2261,7 @@
     },
     {
       "path": "scripts/server-calendar.sh",
-      "sha256": "2fa9d4e61c38320150fc262806a87dc8ca56d3eed25f625d3a4a50e39539b9ff"
+      "sha256": "27e1c8f6c2a2d7b35f2a025d56f0f488132746f4fe79c7db7e0a5f53a3e4fa33"
     },
     {
       "path": "scripts/server-news.sh",


### PR DESCRIPTION
## Что

При пробуждении машины systemd-сервис (iwe-strategist-morning) и hourly dispatch стартуют одновременно. Проигравший получает от strategist.sh exit 2 («mkdir-lock занят живым PID») — scheduler трактовал любой non-zero как сбой: ложный WARN и ❌ «strategist morning failed» в SchedulerReport (воспроизведено 18 и 19 авг, bug-2026-08-18).

## Фикс

- `run_strategist_task` в scheduler.sh: классификация rc — 0 = отметка; 2 = «выполняется другим вызывателем» (лог OK, отметку не ставим — следующий dispatch перепроверит already_ran_today); иное = WARN. Все 4 вызова стратега переведены на хелпер.
- `SuccessExitStatus=2` в iwe-strategist-morning/weekreview.service — сервис, проигравший гонку, не помечается failed.
- Поведенческий тест стабами (rc 0/2/1) — пройден.

## Заметки

- Манифест перегенерирован под это дерево; при конфликте с #480 — взять обе стороны (regen идемпотентен).
- Аналогичный фикс уже_live на инсталляции автора (форк-мейн 3dac2bf), рантайм пересобран.