### PR TITLE
fix(update): semver-гвард само-обновления — не даунгрейдить локальный update.sh

### DIFF
--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2225,7 +2225,7 @@
     },
     {
       "path": "scripts/pending-phases-sweep.sh",
-      "sha256": "503709e24f6e191c571bd7adb407866dabe0ee596ea14c79368d8bcf4a43c3b2"
+      "sha256": "9e2434ef4b64154fc15cb3874588b086670c89d74993ecdb778fbd8a4e5e42b2"
     },
     {
       "path": "scripts/post-update-check-skills.sh",
@@ -2261,7 +2261,7 @@
     },
     {
       "path": "scripts/server-calendar.sh",
-      "sha256": "2fa9d4e61c38320150fc262806a87dc8ca56d3eed25f625d3a4a50e39539b9ff"
+      "sha256": "27e1c8f6c2a2d7b35f2a025d56f0f488132746f4fe79c7db7e0a5f53a3e4fa33"
     },
     {
       "path": "scripts/server-news.sh",
@@ -2529,7 +2529,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "18b48aabbf229798821209040dda4989e5da6749184dd8413c5a8fc1b8ead99f"
+      "sha256": "93773cdc2339ae6338ac85f38cad61db4a4332b2f66450714643db61569cf4fd"
     }
   ],
   "excluded_paths": [

--- a/update.sh
+++ b/update.sh
@@ -21,7 +21,7 @@ EXIT_GENERAL=1
 
 trap 'echo "ОШИБКА: update.sh прервался на строке ${LINENO}: ${BASH_COMMAND}" >&2' ERR
 
-VERSION="2.4.1"  # fix (WP-401): deprecated-file removal now checks is_protected_user_file() — a protected file (e.g. sessions/00-index.md) listed in deprecated_files by mistake could previously be deleted despite the "Не затрагиваются" report claiming otherwise; fix #229: repair-pass no longer stale-repairs memory files with owner: user in frontmatter; fix #228: hot-budget validator warns when memory/*.md horizon:hot lines exceed threshold
+VERSION="2.4.2"  # fix (bug-2026-08-19): self-update semver guard — не даунгрейдить локальный update.sh более старым upstream (форк v2.5.0 была молча перезаписана v2.4.1: sha-сравнение не видит направления); prior: fix (WP-401): deprecated-file removal now checks is_protected_user_file(); fix #229: repair-pass no longer stale-repairs memory files with owner: user; fix #228: hot-budget validator warns on horizon:hot overflow
 REPO="TserenTserenov/FMT-exocortex-template" # UPSTREAM-CONST: do not substitute
 BRANCH="main"
 RAW_BASE="https://raw.githubusercontent.com/$REPO/$BRANCH"
@@ -700,7 +700,16 @@ if curl $CURL_BASE_OPTS $_CURL_SSL_OPT -sSfL "$RAW_BASE/update.sh" -o "$REMOTE_U
     LOCAL_HASH=$(hash_file "$SCRIPT_DIR/update.sh")
     REMOTE_HASH=$(hash_file "$REMOTE_UPDATE")
     if [ "$LOCAL_HASH" != "$REMOTE_HASH" ]; then
-        if $CHECK_ONLY; then
+        # bug-2026-08-19 (self-downgrade): локальный update.sh может быть новее
+        # upstream (авторский конвейер доставляет фиксы раньше мержа). Сравнение
+        # только по sha256 не видит направления — v2.5.0 была молча перезаписана
+        # upstream v2.4.1. Гвард: даунгрейд по semver запрещён.
+        LOCAL_VER=$(sed -n 's/^VERSION="\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' "$SCRIPT_DIR/update.sh" | head -1)
+        REMOTE_VER=$(sed -n 's/^VERSION="\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)".*/\1/p' "$REMOTE_UPDATE" | head -1)
+        if [ -n "$LOCAL_VER" ] && [ -n "$REMOTE_VER" ] && [ "$REMOTE_VER" != "$LOCAL_VER" ] \
+            && [ "$REMOTE_VER" = "$(printf '%s\n%s\n' "$LOCAL_VER" "$REMOTE_VER" | sort -V | head -1)" ]; then
+            echo "  Локальная v$LOCAL_VER новее upstream v$REMOTE_VER — даунгрейд пропущен."
+        elif $CHECK_ONLY; then
             # In --check mode: report available update without touching the file
             echo "  ⚠ Новая версия update.sh доступна. Запустите без --check для обновления."
         else


### PR DESCRIPTION
## Что

Шаг 0 (self-update) сравнивает локальный и remote update.sh только по sha256 — сравнение не видит направления версии. Если локальный файл новее upstream (например, фикс доставлен в форк раньше мержа), update.sh молча перезаписывает его более старой версией и перезапускается.

Реальный случай (bug-2026-08-19): локальная v2.5.0 (git worktree delivery, PR #474) была перезаписана upstream v2.4.1 при первом же запуске — пользователь потерял фикс до выяснения.

## Фикс

Перед заменой извлекаются VERSION из обоих файлов; если remote строго меньше локальной (semver через `sort -V`) — замена пропускается с сообщением «даунгрейд пропущен». Равные версии с разным sha (патч без бампа версии) по-прежнему применяются.

Версия: 2.4.2 (на базе 2.4.1; в форке аналогичный гвард живёт как 2.5.1 поверх #474).

## Заметки

- Манифест перегенерирован; при конфликте с #480 — взять regen обеих сторон (идемпотентен).