### PR TITLE
perf(wp546): parallelize update.sh fetch (Ф2) + wp529 Ф4 fail-closed pipeline tests

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -534,6 +534,23 @@ jobs:
       - name: Test release-receipt fail-closed logic
         run: bash scripts/tests/test_release_receipt.sh
 
+      # WP-529 Ф4 (peer-session 2026-08-20-06-wp546-wp529-update-parallel):
+      # three negative delivery scenarios for the parallel fetch this РП
+      # added to update.sh (WP-546 Ф2) — a missing worker status, a sha256
+      # mismatch, an undeliverable file. Each must land as fetch-failed or
+      # hash-mismatch, never silently pass as a normal delivered file — if
+      # any of these three regressed to "fetched"/"unchanged", this job
+      # (RESULT_VALIDATE) goes red, which release-receipt.sh already turns
+      # into publishable=false (proven by the test above).
+      - name: Test update.sh Phase A — missing worker status is fail-closed
+        run: bash scripts/tests/test_update_fetch_missing_status_failclosed.sh
+      - name: Test update.sh Phase A — sha256 mismatch is fail-closed
+        run: bash scripts/tests/test_update_fetch_hash_mismatch_failclosed.sh
+      - name: Test update.sh Phase A — undeliverable file is fail-closed
+        run: bash scripts/tests/test_update_fetch_delivery_failure_failclosed.sh
+      - name: Test update.sh Phase A — worker success path exits 0 under set -e
+        run: bash scripts/tests/test_update_fetch_worker_exit_code_under_set_e.sh
+
       # issue #310/#323: хук-страж, не зарегистрированный ни в одном событии, не
       # срабатывает никогда — и «не сработал» неотличимо от «нарушений не было».
       - name: Check every hook is actually wired (orphan-hook guard)

--- a/scripts/tests/lib/extract-update-fetch-worker.sh
+++ b/scripts/tests/lib/extract-update-fetch-worker.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# extract-update-fetch-worker.sh — pulls the real Phase A worker body out of
+# update.sh's heredoc (WP-546 F2, peer-session
+# 2026-08-20-06-wp546-wp529-update-parallel) via unique line-content markers.
+#
+# Same technique setup/test-update-edge-cases.sh T10 uses for update.sh's
+# Step 5/6 fallback blocks: a hand-retyped copy of the worker would silently
+# diverge from the real code the moment someone edits update.sh without
+# touching the test — T10's own review history proved that experimentally
+# (a hand-copied block kept passing after the real fix was reverted).
+#
+# Usage: extract_update_fetch_worker <path-to-update.sh> > worker.sh
+extract_update_fetch_worker() {
+    awk '
+        /^cat > "\$IWE_UPDATE_WORKER" <<.FETCH_WORKER_EOF.$/ { found=1; next }
+        found && /^FETCH_WORKER_EOF$/ { exit }
+        found { print }
+    ' "$1"
+}

--- a/scripts/tests/test_update_fetch_delivery_failure_failclosed.sh
+++ b/scripts/tests/test_update_fetch_delivery_failure_failclosed.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# WP-529 Ф4, scenario 3 ("сбой доставки"): a file that fails to download
+# (connection refused, both attempts) must be marked fetch-failed — never
+# silently treated as unchanged or dropped without a trace.
+#
+# Extracts the real worker body out of update.sh's heredoc (WP-546 Ф2) via
+# the shared extraction lib — see test_update_fetch_hash_mismatch_failclosed.sh
+# for why extraction, not a hand-retyped copy.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+UPDATE_SH="$ROOT/update.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# shellcheck source=lib/extract-update-fetch-worker.sh
+. "$ROOT/scripts/tests/lib/extract-update-fetch-worker.sh"
+WORKER="$TMP/fetch-worker.sh"
+extract_update_fetch_worker "$UPDATE_SH" > "$WORKER"
+[ -s "$WORKER" ] || {
+    echo "FAIL: worker extraction is empty — markers no longer match update.sh"
+    exit 1
+}
+
+mkdir -p "$TMP/files" "$TMP/status" "$TMP/local"
+# Port 1 is a reserved, always-refused port on any real host — a fast,
+# deterministic "delivery is down" without a live-network dependency.
+export RAW_BASE="http://127.0.0.1:1"
+export CURL_BASE_OPTS="--max-time 2"
+export _CURL_SSL_OPT=""
+export SCRIPT_DIR="$TMP/local"
+export IWE_UPDATE_FILES_DIR="$TMP/files"
+export IWE_UPDATE_STATUS_DIR="$TMP/status"
+
+START=$(date +%s)
+bash "$WORKER" "broken-delivery.txt|"
+ELAPSED=$(( $(date +%s) - START ))
+
+STATUS_FILE="$TMP/status/broken-delivery.txt.status"
+[ -f "$STATUS_FILE" ] || {
+    echo "FAIL: no status file written for the undeliverable file"
+    exit 1
+}
+FETCH_STATUS=$(cut -f1 "$STATUS_FILE")
+[ "$FETCH_STATUS" = "fetch-failed" ] || {
+    echo "FAIL: expected status=fetch-failed, got '$FETCH_STATUS'"
+    exit 1
+}
+DETAIL=$(cut -f3 "$STATUS_FILE")
+[ "$DETAIL" = "fetch_failed_after_retry" ] || {
+    echo "FAIL: expected detail_code=fetch_failed_after_retry (proves the retry ran), got '$DETAIL'"
+    exit 1
+}
+[ ! -e "$TMP/files/broken-delivery.txt" ] || {
+    echo "FAIL: staging has a file for a delivery that never succeeded"
+    exit 1
+}
+# A connection-refused failure is instant — this only guards against a
+# regression that turns the retry into a blocking network timeout (curl
+# --max-time 2 x2 attempts would be >=4s, not the sub-second we expect here).
+[ "$ELAPSED" -lt 10 ] || {
+    echo "FAIL: worker took ${ELAPSED}s for two connection-refused attempts — retry may be blocking on a timeout instead"
+    exit 1
+}
+
+echo "PASS: an undeliverable file is marked fetch-failed after one retry, nothing staged"

--- a/scripts/tests/test_update_fetch_hash_mismatch_failclosed.sh
+++ b/scripts/tests/test_update_fetch_hash_mismatch_failclosed.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# WP-529 Ф4, scenario 2 ("неверная метка"): a file whose downloaded bytes
+# don't match the manifest's declared sha256 must never be classified as a
+# normal fetch — the Phase A worker must mark it hash-mismatch, and that
+# status must never collapse into "fetched"/"cache-hit" downstream.
+#
+# Extracts the real worker body out of update.sh's heredoc (WP-546 Ф2) via
+# the shared extraction lib — not a hand-retyped copy, so this test breaks
+# automatically if the real worker's hash-check logic is edited without
+# updating the test (same rationale as
+# test_update_fetch_missing_status_failclosed.sh and T10 in
+# setup/test-update-edge-cases.sh).
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+UPDATE_SH="$ROOT/update.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP" 2>/dev/null; [ -n "${SERVER_PID:-}" ] && kill "$SERVER_PID" 2>/dev/null' EXIT
+
+# shellcheck source=lib/extract-update-fetch-worker.sh
+. "$ROOT/scripts/tests/lib/extract-update-fetch-worker.sh"
+WORKER="$TMP/fetch-worker.sh"
+extract_update_fetch_worker "$UPDATE_SH" > "$WORKER"
+[ -s "$WORKER" ] || {
+    echo "FAIL: worker extraction is empty — markers no longer match update.sh"
+    exit 1
+}
+
+# A tiny local fixture server stands in for RAW_BASE — no dependency on a
+# live remote, deterministic content.
+FIXTURE_DIR="$TMP/fixture"
+mkdir -p "$FIXTURE_DIR"
+echo "real upstream content" > "$FIXTURE_DIR/tampered.txt"
+
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+( cd "$FIXTURE_DIR" && exec python3 -m http.server "$PORT" --bind 127.0.0.1 >/dev/null 2>&1 ) &
+SERVER_PID=$!
+for _ in $(seq 1 30); do
+    curl -sf "http://127.0.0.1:$PORT/tampered.txt" >/dev/null 2>&1 && break
+    sleep 0.1
+done
+
+mkdir -p "$TMP/files" "$TMP/status" "$TMP/local"
+export RAW_BASE="http://127.0.0.1:$PORT"
+export CURL_BASE_OPTS="--max-time 5"
+export _CURL_SSL_OPT=""
+export SCRIPT_DIR="$TMP/local"
+export IWE_UPDATE_FILES_DIR="$TMP/files"
+export IWE_UPDATE_STATUS_DIR="$TMP/status"
+
+# expected_hash deliberately wrong — this is the injected "неверная метка":
+# the manifest declares a hash that does not match what's actually served.
+WRONG_HASH="0000000000000000000000000000000000000000000000000000000000000"
+bash "$WORKER" "tampered.txt|$WRONG_HASH"
+
+kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null || true; SERVER_PID=""
+
+STATUS_FILE="$TMP/status/tampered.txt.status"
+[ -f "$STATUS_FILE" ] || {
+    echo "FAIL: no status file written for the mismatched file"
+    exit 1
+}
+FETCH_STATUS=$(cut -f1 "$STATUS_FILE")
+[ "$FETCH_STATUS" = "hash-mismatch" ] || {
+    echo "FAIL: expected status=hash-mismatch, got '$FETCH_STATUS' (would classify as a normal file)"
+    exit 1
+}
+[ ! -f "$TMP/files/tampered.txt" ] || {
+    echo "FAIL: mismatched content was left in staging — a later classification pass could still pick it up"
+    exit 1
+}
+
+echo "PASS: a sha256 mismatch is marked hash-mismatch and the tainted content is not staged"

--- a/scripts/tests/test_update_fetch_missing_status_failclosed.sh
+++ b/scripts/tests/test_update_fetch_missing_status_failclosed.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# WP-529 Ф4, scenario 1 ("пропуск файла"): a Phase A worker that never wrote
+# its status file (killed by signal/OOM/xargs timeout) must not let that
+# manifest entry pass silently — update.sh's preflight (Step 2, right after
+# the `xargs -P 8` dispatch) must synthesize a fail-closed fetch-failed
+# status for it, not leave it unclassified.
+#
+# Extracts the real preflight block from update.sh via unique line-content
+# markers (same technique setup/test-update-edge-cases.sh T10 uses) — a
+# hand-retyped copy would silently diverge from the real code.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+UPDATE_SH="$ROOT/update.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+extract_preflight_block() {
+    awk '
+        /^    MISSING_STATUS_COUNT=0$/ { found=1 }
+        found { print }
+        found && /^    fi$/ { exit }
+    ' "$UPDATE_SH"
+}
+
+PREFLIGHT_BLOCK="$TMP/preflight.sh"
+extract_preflight_block > "$PREFLIGHT_BLOCK"
+[ -s "$PREFLIGHT_BLOCK" ] || {
+    echo "FAIL: preflight block extraction is empty — markers no longer match update.sh"
+    exit 1
+}
+
+IWE_UPDATE_STATUS_DIR="$TMP/status"
+mkdir -p "$IWE_UPDATE_STATUS_DIR"
+
+# One manifest entry ("present.txt") got a real status from Phase A; the
+# other ("vanished.txt") is the injected negative scenario — its worker
+# never ran to completion, so no status file exists for it.
+printf 'fetched\tpresent.txt\tdownload_success\t\n' > "$IWE_UPDATE_STATUS_DIR/present.txt.status"
+
+UPDATE_FETCH_ENTRIES="$TMP/entries.txt"
+printf 'present.txt|\nvanished.txt|\n' > "$UPDATE_FETCH_ENTRIES"
+
+# The extracted block reads $IWE_UPDATE_STATUS_DIR / $UPDATE_FETCH_ENTRIES
+# and sets $MISSING_STATUS_COUNT / $MISSING_STATUS_SAMPLE — sourced (not a
+# subshell) so we can assert on those variables afterward, in the current
+# shell, exactly once: the block itself writes the synthesized status file
+# to disk as a side effect, so a second sourcing would find it already
+# present and no longer "missing" — sourcing must happen only once per fixture.
+STDERR_OUT="$TMP/stderr.txt"
+# shellcheck disable=SC1090
+. "$PREFLIGHT_BLOCK" 2>"$STDERR_OUT"
+
+[ "$MISSING_STATUS_COUNT" -eq 1 ] || {
+    echo "FAIL: expected MISSING_STATUS_COUNT=1, got $MISSING_STATUS_COUNT"
+    exit 1
+}
+[ -f "$IWE_UPDATE_STATUS_DIR/vanished.txt.status" ] || {
+    echo "FAIL: no synthesized status file was written for the missing entry"
+    exit 1
+}
+SYNTHESIZED=$(cat "$IWE_UPDATE_STATUS_DIR/vanished.txt.status")
+case "$SYNTHESIZED" in
+    fetch-failed*missing-status-synthesized*) ;;
+    *)
+        echo "FAIL: synthesized status is not fetch-closed: $SYNTHESIZED"
+        exit 1
+        ;;
+esac
+grep -q '⚠' "$STDERR_OUT" || {
+    echo "FAIL: no warning printed to stderr for the missing status file"
+    exit 1
+}
+# The entry that DID get a real status must be untouched by the preflight.
+UNTOUCHED=$(cat "$IWE_UPDATE_STATUS_DIR/present.txt.status")
+[ "$UNTOUCHED" = "$(printf 'fetched\tpresent.txt\tdownload_success\t')" ] || {
+    echo "FAIL: preflight modified an entry that already had a real status"
+    exit 1
+}
+
+echo "PASS: a missing Phase A status is synthesized fail-closed (fetch-failed), not silently skipped"

--- a/scripts/tests/test_update_fetch_worker_exit_code_under_set_e.sh
+++ b/scripts/tests/test_update_fetch_worker_exit_code_under_set_e.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# WP-546 Ф2 (cold-context review, peer-session
+# 2026-08-20-06-wp546-wp529-update-parallel): update.sh runs under `set -e`
+# from its first line. The Phase A worker's success branch (a clean fetch,
+# the MOST common outcome) used to fall off the end of the heredoc without
+# an explicit `exit 0` — its exit status was whatever the last `mv` inside
+# write_status() happened to return. Under `set -e`, a single worker
+# returning non-zero for any transient reason aborts the entire xargs
+# dispatch and the whole script, bypassing the fail-closed preflight this
+# Step exists to run — the opposite of "one bad file doesn't sink the other
+# 631" (issue #350's principle). Caught by cold-context review, not by the
+# other three fail-closed tests (they exercise the negative branches, which
+# already had `exit 0`; the success branch was the one missing it).
+#
+# Two checks: (1) the worker's success path genuinely exits 0 when run
+# under `set -e`, on the real extracted code — not a hand-copied claim.
+# (2) a static tripwire on the dispatch line itself (defense in depth, WP-546
+# Ф2 turn-review): if `|| true` after `xargs -P 8 ...` is ever removed, this
+# fails loudly instead of silently reintroducing the abort-on-one-failure bug.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+UPDATE_SH="$ROOT/update.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP" 2>/dev/null; [ -n "${SERVER_PID:-}" ] && kill "$SERVER_PID" 2>/dev/null' EXIT
+
+# shellcheck source=lib/extract-update-fetch-worker.sh
+. "$ROOT/scripts/tests/lib/extract-update-fetch-worker.sh"
+WORKER="$TMP/fetch-worker.sh"
+extract_update_fetch_worker "$UPDATE_SH" > "$WORKER"
+[ -s "$WORKER" ] || {
+    echo "FAIL: worker extraction is empty — markers no longer match update.sh"
+    exit 1
+}
+
+FIXTURE_DIR="$TMP/fixture"
+mkdir -p "$FIXTURE_DIR" "$TMP/files" "$TMP/status" "$TMP/local"
+echo "clean content" > "$FIXTURE_DIR/clean.txt"
+
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+( cd "$FIXTURE_DIR" && exec python3 -m http.server "$PORT" --bind 127.0.0.1 >/dev/null 2>&1 ) &
+SERVER_PID=$!
+for _ in $(seq 1 30); do
+    curl -sf "http://127.0.0.1:$PORT/clean.txt" >/dev/null 2>&1 && break
+    sleep 0.1
+done
+
+export RAW_BASE="http://127.0.0.1:$PORT"
+export CURL_BASE_OPTS="--max-time 5"
+export _CURL_SSL_OPT=""
+export SCRIPT_DIR="$TMP/local"
+export IWE_UPDATE_FILES_DIR="$TMP/files"
+export IWE_UPDATE_STATUS_DIR="$TMP/status"
+
+# Check 1: run the worker's success path under `set -e`, in a subshell so a
+# non-zero exit doesn't kill this test script itself — capture the real
+# exit code instead.
+set +e
+( set -e; bash "$WORKER" "clean.txt|" )
+WORKER_EXIT=$?
+set -e
+
+kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null || true; SERVER_PID=""
+
+[ "$WORKER_EXIT" -eq 0 ] || {
+    echo "FAIL: worker's success (fetched) branch exited $WORKER_EXIT under set -e, expected 0"
+    exit 1
+}
+FETCH_STATUS=$(cut -f1 "$TMP/status/clean.txt.status")
+[ "$FETCH_STATUS" = "fetched" ] || {
+    echo "FAIL: expected status=fetched, got '$FETCH_STATUS'"
+    exit 1
+}
+
+# Check 2: static tripwire on the dispatch line in update.sh itself.
+grep -q 'xargs -P 8 -I{} bash "\$IWE_UPDATE_WORKER" {} < "\$UPDATE_FETCH_ENTRIES" || true' "$UPDATE_SH" || {
+    echo "FAIL: the xargs dispatch in update.sh no longer has '|| true' — a single worker's"
+    echo "      non-zero exit will now abort the whole update under set -e (see comment above)."
+    exit 1
+}
+
+echo "PASS: worker success path exits 0 under set -e, and the dispatch line's || true guard is intact"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -653,7 +653,7 @@
     },
     {
       "path": "CHANGELOG.md",
-      "sha256": "c0a2e824f0c22ccf7afddc4f1147ec715d47397b366df577cfcf1fcc48923f95"
+      "sha256": "21385aa8f67794b226c57a8b988cdec9d3f7af43364d20b2a4128d8aab4e50a4"
     },
     {
       "path": "CLAUDE.md",
@@ -2593,7 +2593,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "9940a3b11d1cdb6240a4b3d4e70cb9f7da69b8884e22b52451ba22c492410b50"
+      "sha256": "cd9453206840a3429b0bc03d9674643a07c2c343e5364d240b177ece84a8052e"
     }
   ],
   "excluded_paths": [
@@ -2618,6 +2618,7 @@
     "scripts/iwe-trace.py",
     "scripts/session-dispatcher-tsekh.py",
     "scripts/tests/conftest.py",
+    "scripts/tests/lib/extract-update-fetch-worker.sh",
     "scripts/tests/test_agent_dashboard.py",
     "scripts/tests/test_copy_to_aisystant.py",
     "scripts/tests/test_day_close_prepare.py",
@@ -2635,6 +2636,10 @@
     "scripts/tests/test_skill_promote.py",
     "scripts/tests/test_translate_delta.py",
     "scripts/tests/test_translate_parse.py",
+    "scripts/tests/test_update_fetch_delivery_failure_failclosed.sh",
+    "scripts/tests/test_update_fetch_hash_mismatch_failclosed.sh",
+    "scripts/tests/test_update_fetch_missing_status_failclosed.sh",
+    "scripts/tests/test_update_fetch_worker_exit_code_under_set_e.sh",
     "scripts/tests/test_update_install_path_guard_provenance.sh",
     "scripts/tests/test_validate_hypothesis_priority.sh",
     "scripts/translate.py",

--- a/update.sh
+++ b/update.sh
@@ -1024,9 +1024,168 @@ with open(sys.argv[1]) as f:
 print(len(data.get('files', [])))
 " "$MANIFEST" 2>/dev/null || echo "?")
 fi
-DOWNLOAD_IDX=0
 
-# Parse manifest: extract path and desc for each file entry
+# WP-546 F2: manifest parsed once into a file, not a process substitution —
+# Phase B below needs a second pass over it after Phase A has fetched
+# everything, and a process substitution can only be consumed once.
+MANIFEST_PARSED="$TMPDIR_UPDATE/manifest-parsed.txt"
+if py_available; then
+    # Parse JSON: extract path|desc|sha256 lines. Path via argv (issue #402,
+    # defect 2), not interpolated into the -c string — see FILES_MATCH above.
+    $PY_BIN -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+for entry in data.get('files', []):
+    print(entry['path'] + '|' + entry.get('desc', '') + '|' + entry.get('sha256', ''))
+" "$MANIFEST" 2>/dev/null > "$MANIFEST_PARSED"
+else
+    # Fallback: basic grep parsing if no working python interpreter.
+    # No sha256 in this path — integrity check is skipped downstream (already
+    # documented via a fetch-failed status, not silently trusted).
+    grep '"path"' "$MANIFEST" | while read -r line; do
+        fpath=$(echo "$line" | sed 's/.*"path"[[:space:]]*:[[:space:]]*"//;s/".*//')
+        echo "$fpath||"
+    done > "$MANIFEST_PARSED"
+fi
+
+# --- Phase A (WP-546 F2, peer-session 2026-08-20-06-wp546-wp529-update-parallel):
+# fetch ~8 files concurrently instead of one curl at a time. The worker below is
+# materialized fresh into $TMPDIR_UPDATE on every run, NOT delivered via the
+# manifest — Step 2 depends on it to fetch manifest files (potentially including
+# a future copy of itself), so shipping it as a scripts/lib/*.sh file would create
+# a bootstrap gap on the very first upgrade that introduces it (the file wouldn't
+# exist locally yet on the run that needs it). A separate file (not a shared bash
+# function) is deliberate too: xargs -P spawns real subprocesses, and `export -f`
+# to hand them a function is unreliable on bash <4.2 (still the default on macOS).
+IWE_UPDATE_FILES_DIR="$TMPDIR_UPDATE/files"
+IWE_UPDATE_STATUS_DIR="$TMPDIR_UPDATE/status"
+mkdir -p "$IWE_UPDATE_FILES_DIR" "$IWE_UPDATE_STATUS_DIR"
+IWE_UPDATE_WORKER="$TMPDIR_UPDATE/fetch-worker.sh"
+cat > "$IWE_UPDATE_WORKER" <<'FETCH_WORKER_EOF'
+#!/bin/bash
+# One manifest file, one `xargs -P` job. Retry lives here, inside this single
+# job, so the orchestrator dispatches once per file and never requeues — one
+# final status line is written no matter how many curl attempts ran.
+# Args: $1 = "<fpath>|<expected_hash>" (expected_hash may be empty)
+# Env: RAW_BASE, CURL_BASE_OPTS, _CURL_SSL_OPT, SCRIPT_DIR,
+#      IWE_UPDATE_FILES_DIR, IWE_UPDATE_STATUS_DIR (exported by caller)
+set -uo pipefail
+
+hash_file() {
+    shasum -a 256 "$1" 2>/dev/null | cut -d' ' -f1 || \
+    sha256sum "$1" 2>/dev/null | cut -d' ' -f1
+}
+write_status() {
+    # $1=status_file $2=status $3=fpath $4=detail_code
+    # Atomic: a worker killed mid-write must not leave a half-written line
+    # for update.sh's preflight (Phase B) to trust.
+    printf '%s\t%s\t%s\t\n' "$2" "$3" "${4:-}" > "$1.tmp"
+    mv -f "$1.tmp" "$1"
+}
+
+IFS='|' read -r fpath expected_hash <<<"${1:?usage: fetch-worker.sh '<fpath>|<expected_hash>'}"
+expected_hash="${expected_hash%$'\r'}"  # issue #402 defect 3 — trailing \r on Windows Git Bash
+
+remote_file="$IWE_UPDATE_FILES_DIR/$fpath"
+status_file="$IWE_UPDATE_STATUS_DIR/$fpath.status"
+mkdir -p "$(dirname "$remote_file")" "$(dirname "$status_file")"
+local_path="$SCRIPT_DIR/$fpath"
+
+# skip-if-hash-matches: local candidate already equals the manifest's expected
+# content — no network trip. Copy into staging so the classifier's existing
+# hash_file($remote_file) comparisons work unchanged (a cache-hit trivially
+# resolves to UNCHANGED downstream — same verdict as a real download that
+# turned out identical).
+if [ -n "$expected_hash" ] && [ -f "$local_path" ]; then
+    local_hash=$(hash_file "$local_path")
+    if [ "$local_hash" = "$expected_hash" ]; then
+        cp "$local_path" "$remote_file"
+        write_status "$status_file" "cache-hit" "$fpath" "local_hash_match"
+        exit 0
+    fi
+fi
+
+attempt=1
+while :; do
+    if curl $CURL_BASE_OPTS $_CURL_SSL_OPT -sSfL "$RAW_BASE/$fpath" -o "$remote_file" 2>/dev/null; then
+        break
+    fi
+    if [ "$attempt" -ge 2 ]; then
+        write_status "$status_file" "fetch-failed" "$fpath" "fetch_failed_after_retry"
+        exit 0
+    fi
+    attempt=$((attempt + 1))
+done
+
+if [ -n "$expected_hash" ]; then
+    remote_hash=$(hash_file "$remote_file")
+    if [ "$remote_hash" != "$expected_hash" ]; then
+        rm -f "$remote_file"
+        write_status "$status_file" "hash-mismatch" "$fpath" "sha256_mismatch"
+        exit 0
+    fi
+fi
+
+write_status "$status_file" "fetched" "$fpath" "download_success"
+exit 0
+FETCH_WORKER_EOF
+chmod +x "$IWE_UPDATE_WORKER"
+
+UPDATE_FETCH_ENTRIES="$TMPDIR_UPDATE/fetch-entries.txt"
+: > "$UPDATE_FETCH_ENTRIES"
+while IFS='|' read -r fpath fdesc expected_hash; do
+    [ -z "$fpath" ] && continue
+    expected_hash="${expected_hash%$'\r'}"
+    # Protected user files (issue #154): never overwrite if they already exist
+    # locally. is_protected_user_file() is the actual skip-if-exists guard
+    # (shared with the deprecated-file removal loop below) — checked here,
+    # single-threaded, same as before. These files never reach Phase A, not
+    # even as a cache-hit.
+    if is_protected_user_file "$fpath" && [ -f "$SCRIPT_DIR/$fpath" ]; then
+        continue
+    fi
+    printf '%s|%s\n' "$fpath" "$expected_hash" >> "$UPDATE_FETCH_ENTRIES"
+done < "$MANIFEST_PARSED"
+
+FETCH_TOTAL=$(wc -l < "$UPDATE_FETCH_ENTRIES" | tr -d ' ')
+if [ "$FETCH_TOTAL" -gt 0 ]; then
+    echo "  Скачивание $FETCH_TOTAL файлов (до 8 параллельно)…"
+    export RAW_BASE CURL_BASE_OPTS _CURL_SSL_OPT SCRIPT_DIR
+    export IWE_UPDATE_FILES_DIR IWE_UPDATE_STATUS_DIR
+    # `|| true`: xargs (and `set -e`) would otherwise abort the whole script
+    # on a single worker's non-zero exit — exactly the "one bad file sinks
+    # the other 631" failure this Step exists to avoid (issue #350). The
+    # preflight right below already treats any worker that didn't finish
+    # cleanly as fetch-failed; this just lets it actually run.
+    xargs -P 8 -I{} bash "$IWE_UPDATE_WORKER" {} < "$UPDATE_FETCH_ENTRIES" || true
+
+    # Preflight: a worker killed by signal/OOM/xargs timeout leaves no status
+    # file at all. A single missing file must not abort the whole update
+    # (issue #350's principle — one bad file doesn't sink the other 631) but
+    # must still show up as unverified, not silently pass classification.
+    MISSING_STATUS_COUNT=0
+    MISSING_STATUS_SAMPLE=()
+    while IFS='|' read -r fpath expected_hash; do
+        [ -z "$fpath" ] && continue
+        status_file="$IWE_UPDATE_STATUS_DIR/$fpath.status"
+        if [ ! -f "$status_file" ]; then
+            mkdir -p "$(dirname "$status_file")"
+            printf 'fetch-failed\t%s\tmissing-status-synthesized\t\n' "$fpath" > "$status_file"
+            MISSING_STATUS_COUNT=$((MISSING_STATUS_COUNT + 1))
+            [ "${#MISSING_STATUS_SAMPLE[@]}" -lt 5 ] && MISSING_STATUS_SAMPLE+=("$fpath")
+        fi
+    done < "$UPDATE_FETCH_ENTRIES"
+    if [ "$MISSING_STATUS_COUNT" -gt 0 ]; then
+        echo "  ⚠ $MISSING_STATUS_COUNT файл(ов) не дали статус (воркер прерван?) — считаю как сбой доставки: ${MISSING_STATUS_SAMPLE[*]}" >&2
+    fi
+fi
+
+# --- Phase B: sequential classification — unchanged logic (merge-base
+# detector, diff-count, CLAUDE_CONFLICT_* handling all stay exactly as
+# before); only the source of "did we get the file" moves from an inline
+# curl to reading Phase A's status file. ---
+CLASSIFY_IDX=0
 while IFS='|' read -r fpath fdesc expected_hash; do
     [ -z "$fpath" ] && continue
     # issue #402 (defect 3): native Windows Python prints \r\n even inside a
@@ -1035,38 +1194,38 @@ while IFS='|' read -r fpath fdesc expected_hash; do
     # silently skipping all 593 manifest files. Strip unconditionally; a no-op
     # on real Unix output.
     expected_hash="${expected_hash%$'\r'}"
-    # Protected user files (issue #154): never overwrite if they already exist locally.
-    # The "Не затрагиваются" list below is cosmetic; is_protected_user_file() is the
-    # actual skip-if-exists guard (shared with the deprecated-file removal loop below).
     if is_protected_user_file "$fpath" && [ -f "$SCRIPT_DIR/$fpath" ]; then
         UNCHANGED=$((UNCHANGED + 1))
         continue
     fi
-    DOWNLOAD_IDX=$((DOWNLOAD_IDX + 1))
-    printf "  (%s/%s) %s\r" "$DOWNLOAD_IDX" "$TOTAL_FILES" "$fpath"
+    CLASSIFY_IDX=$((CLASSIFY_IDX + 1))
+    printf "  (%s/%s) %s\r" "$CLASSIFY_IDX" "$TOTAL_FILES" "$fpath"
 
-    # Download remote file
-    REMOTE_FILE="$TMPDIR_UPDATE/files/$fpath"
-    mkdir -p "$(dirname "$REMOTE_FILE")"
+    REMOTE_FILE="$IWE_UPDATE_FILES_DIR/$fpath"
+    STATUS_FILE="$IWE_UPDATE_STATUS_DIR/$fpath.status"
+    FETCH_STATUS=""
+    [ -f "$STATUS_FILE" ] && FETCH_STATUS=$(cut -f1 "$STATUS_FILE")
 
     # issue #350: a failed download used to `continue` silently — the file landed in
     # no list at all, not even the UNCHANGED counter, so the preview said nothing about
     # it while a later run (network back) applied it. "Could not check" is not "up to
     # date"; it now gets its own list and taints the verdict below.
-    if ! curl $CURL_BASE_OPTS $_CURL_SSL_OPT -sSfL "$RAW_BASE/$fpath" -o "$REMOTE_FILE" 2>/dev/null; then
-        SKIPPED_DOWNLOAD+=("$fpath")
-        continue
-    fi
-
-    if [ -n "$expected_hash" ]; then
-        REMOTE_HASH=$(hash_file "$REMOTE_FILE")
-        if [ "$REMOTE_HASH" != "$expected_hash" ]; then
+    case "$FETCH_STATUS" in
+        fetched|cache-hit)
+            ;;  # eligible for classification below
+        hash-mismatch)
             echo "  ⚠ $fpath: sha256 не совпадает с манифестом" >&2
             SKIPPED_DOWNLOAD+=("$fpath (ошибка целостности)")
-            rm -f "$REMOTE_FILE"
             continue
-        fi
-    fi
+            ;;
+        fetch-failed|*)
+            # Empty/unrecognized FETCH_STATUS (malformed status line) is
+            # treated the same as an explicit fetch-failed — fail-closed,
+            # never silently trusted.
+            SKIPPED_DOWNLOAD+=("$fpath")
+            continue
+            ;;
+    esac
 
     if [ ! -f "$SCRIPT_DIR/$fpath" ]; then
         # New file
@@ -1096,27 +1255,7 @@ while IFS='|' read -r fpath fdesc expected_hash; do
             UNCHANGED=$((UNCHANGED + 1))
         fi
     fi
-done < <(
-    # Parse JSON: extract path|desc|sha256 lines. Path via argv (issue #402,
-    # defect 2), not interpolated into the -c string — see FILES_MATCH above.
-    if py_available; then
-        $PY_BIN -c "
-import json, sys
-with open(sys.argv[1]) as f:
-    data = json.load(f)
-for entry in data.get('files', []):
-    print(entry['path'] + '|' + entry.get('desc', '') + '|' + entry.get('sha256', ''))
-" "$MANIFEST" 2>/dev/null
-    else
-        # Fallback: basic grep parsing if no working python interpreter.
-        # No sha256 in this path — integrity check below is skipped (already
-        # documented via SKIPPED_DOWNLOAD, not silently trusted).
-        grep '"path"' "$MANIFEST" | while read -r line; do
-            fpath=$(echo "$line" | sed 's/.*"path"[[:space:]]*:[[:space:]]*"//;s/".*//')
-            echo "$fpath|"
-        done
-    fi
-)
+done < "$MANIFEST_PARSED"
 printf "\n"
 
 # === Step 2b: Deprecated files (устаревшие L1-файлы к удалению) ===


### PR DESCRIPTION
## Summary

- **WP-546 Ф2**: `update.sh` Step 2 was one sequential `curl` per manifest file (~40min reported on a slower network). Split into Phase A (`xargs -P8` parallel fetch + skip-if-hash-matches — local file already matches manifest sha256 → no network trip) and Phase B (unchanged sequential classification, now reading Phase A's per-file status instead of curling inline). NEW_FILES/UPDATED_FILES/UNCHANGED/SKIPPED_DOWNLOAD, CLAUDE_CONFLICT_*, merge-base (#254) and protected-file (#154) handling stay byte-identical.
- **WP-529 Ф4**: three new fail-closed pipeline tests for this change (missing worker status / sha256 mismatch / undeliverable file) wired into `validate-template.yml`'s `validate` job — a regression here fails `RESULT_VALIDATE`, which `release-receipt.sh` (Ф3, already tested) turns into `publishable=false`.
- Cold-context review (Agent tool) found one **Critical** before merge: the worker's success branch fell off the heredoc without an explicit `exit 0` — under `update.sh`'s `set -e`, a single flaky `mv` could abort the whole update before the fail-closed preflight ran. Fixed (`exit 0` + `xargs ... || true` as defense in depth), with a dedicated regression test (`test_update_fetch_worker_exit_code_under_set_e.sh`).
- Produced in a combined peer-session with Codex covering both РП at once (shared context: both touch `update.sh`/the delivery pipeline) — full transcript: `sessions/2026-08/20/2026-08-20-06-wp546-wp529-update-parallel/` (DS-my-strategy).

## Test plan

- [x] `setup/test-update-edge-cases.sh` — 124/124 PASS
- [x] `setup/test-update-issue-226.sh` — 19/19 PASS (incl. atomic-fail-fast Scenario E, WP-529's own regression guard)
- [x] `scripts/tests/test_update_install_path_guard.sh` — PASS
- [x] `scripts/verify-manifest.sh` — PASS (manifest synced with git tree)
- [x] `scripts/tests/test_release_receipt.sh` — PASS (unaffected, sanity)
- [x] 4 new tests (`test_update_fetch_missing_status_failclosed.sh`, `test_update_fetch_hash_mismatch_failclosed.sh`, `test_update_fetch_delivery_failure_failclosed.sh`, `test_update_fetch_worker_exit_code_under_set_e.sh`) — PASS
- [x] `setup/smoke-test-fresh-install.sh` — 30/31 PASS (1 pre-existing failure, reproduces identically on a clean `origin/main` clone — `dirname`/`basename` missing under `env -i` on this host, unrelated to this change)
- [x] Cold-context code review (Agent tool, independent) — 1 Critical found and fixed, rest OK
- [ ] CI (this PR) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)