### PR TITLE
feat(hooks): расширить защиту от необратимых действий (WP-544 Ф1)

### DIFF
--- a/.claude/hooks/destructive-guard.sh
+++ b/.claude/hooks/destructive-guard.sh
@@ -16,7 +16,10 @@ block() {
 
 # Bypass: только из реального шелла пилота (тот же контракт, что secret-leak-block.sh —
 # хук читает свой процессный env, не текст команды, агент не может выставить это сам себе).
-[ -n "${CC_ALLOW_DESTRUCTIVE_INPUT:-}" ] && exit 0
+# Строгое сравнение с "1" (не -n) — та же несогласованность в secret-leak-block.sh
+# (там -n) допустима для существующего кода, но не стоит копировать её в новый
+# (пир-ревью Codex, WP-544 Ф1, 20.08): -n пропустил бы CC_ALLOW_DESTRUCTIVE_INPUT=0 как bypass.
+[ "${CC_ALLOW_DESTRUCTIVE_INPUT:-}" = "1" ] && exit 0
 
 # #362: a top-level `cd` persists between Bash calls in Claude Code. Strip
 # quoted spans before detecting command segments; `(cd ... && ...)` remains

--- a/.claude/hooks/destructive-guard.sh
+++ b/.claude/hooks/destructive-guard.sh
@@ -14,6 +14,10 @@ block() {
   exit 2
 }
 
+# Bypass: только из реального шелла пилота (тот же контракт, что secret-leak-block.sh —
+# хук читает свой процессный env, не текст команды, агент не может выставить это сам себе).
+[ -n "${CC_ALLOW_DESTRUCTIVE_INPUT:-}" ] && exit 0
+
 # #362: a top-level `cd` persists between Bash calls in Claude Code. Strip
 # quoted spans before detecting command segments; `(cd ... && ...)` remains
 # allowed because the opening parenthesis is not a top-level separator.
@@ -180,6 +184,34 @@ fi
 CLEAN_SEGMENT=$(git_segment clean)
 if [ -n "$CLEAN_SEGMENT" ] && echo "$CLEAN_SEGMENT" | grep -qE -- '(^|[[:space:]])-[a-zA-Z]*[dfx]'; then
   block "git clean -fdx запрещён (удаляет неотслеживаемые файлы). Согласуй с владельцем."
+fi
+
+# rm с одновременным recursive (-r/-R/--recursive) и force (-f/--force), в любом
+# сочетании флагов (слитных или раздельных) — вне временных/scratch-путей, где это
+# штатная уборка (пир-сессия с Codex, WP-544 Ф1, 20.08).
+if echo "$CMD" | grep -qE '(^|[[:space:]])rm([[:space:]]|$)' \
+  && echo "$CMD" | grep -qE -- '(^|[[:space:]])(-[^[:space:]]*[rR][^[:space:]]*|--recursive)([[:space:]]|$)' \
+  && echo "$CMD" | grep -qE -- '(^|[[:space:]])(-[^[:space:]]*f[^[:space:]]*|--force)([[:space:]]|$)' \
+  && ! echo "$CMD" | grep -qE '(/tmp/|/scratchpad/|\.claude/worktrees/)'; then
+  block "rm -r -f (в любом сочетании флагов) вне /tmp, scratchpad или worktree запрещён — удаление необратимо. Разовая необходимость: CC_ALLOW_DESTRUCTIVE_INPUT=1 из реального шелла пилота."
+fi
+
+# psql: DROP/TRUNCATE — необратимая потеря структуры/данных.
+if echo "$CMD" | grep -qiE '\bpsql\b' && echo "$CMD" | grep -qiE '\b(DROP[[:space:]]+(TABLE|SCHEMA|DATABASE)|TRUNCATE)\b'; then
+  block "DROP/TRUNCATE через psql запрещён — необратимая потеря данных. Разовая необходимость: CC_ALLOW_DESTRUCTIVE_INPUT=1 из реального шелла пилота."
+fi
+
+# psql: DELETE FROM без WHERE в том же операторе (эвристика: сегмент до ближайшего
+# ';' или конца строки — не защищает от WHERE в другом statement той же команды).
+if echo "$CMD" | grep -qiE '\bpsql\b' \
+  && echo "$CMD" | grep -qiE 'DELETE[[:space:]]+FROM' \
+  && ! echo "$CMD" | grep -qiE 'DELETE[[:space:]]+FROM[^;]*[[:space:]]WHERE([[:space:]]|$)'; then
+  block "DELETE FROM без WHERE через psql запрещён — удалит всю таблицу. Разовая необходимость: CC_ALLOW_DESTRUCTIVE_INPUT=1 из реального шелла пилота."
+fi
+
+# удаление репозитория на GitHub — необратимо.
+if echo "$CMD" | grep -qE '\bgh[[:space:]]+repo[[:space:]]+delete\b'; then
+  block "gh repo delete запрещён — необратимо. Разовая необходимость: CC_ALLOW_DESTRUCTIVE_INPUT=1 из реального шелла пилота."
 fi
 
 exit 0

--- a/.claude/hooks/destructive-mcp-guard.sh
+++ b/.claude/hooks/destructive-mcp-guard.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Destructive MCP Guard (WP-544 Ф1, пир-сессия с Codex 20.08)
+# Event: PreToolUse (matcher: mcp__.*)
+# Блокирует разрушительные MCP-вызовы (удаление облачных ресурсов), для которых
+# сейчас нет вообще никакой проверки — интерактивный вопрос выключен (bypassPermissions),
+# а до этого хука ни один matcher не смотрел на конкретное имя MCP-инструмента.
+#
+# Bypass: CC_ALLOW_DESTRUCTIVE_INPUT=1 (тот же контракт, что destructive-guard.sh —
+# хук читает свой процессный env, агент не может выставить это сам себе через
+# ещё не выполненный tool call).
+#
+# Лог: ~/IWE/.claude/logs/destructive-mcp-guard.jsonl
+
+set -uo pipefail
+export PATH="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+LOG_FILE="$IWE_ROOT/.claude/logs/destructive-mcp-guard.jsonl"
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+
+log_decision() {
+  local decision="$1" tool="$2"
+  local ts; ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  jq -nc --arg ts "$ts" --arg sid "${CLAUDE_SESSION_ID:-}" --arg dec "$decision" --arg tool "$tool" \
+    '{ts:$ts, hook:"destructive-mcp-guard", session_id:$sid, decision:$dec, tool:$tool}' \
+    >> "$LOG_FILE" 2>/dev/null || true
+}
+
+input=$(cat)
+tool_name=$(echo "$input" | jq -r '.tool_name // empty' 2>/dev/null)
+
+case "$tool_name" in mcp__*) ;; *) exit 0 ;; esac
+
+tn=$(printf '%s' "$tool_name" | tr 'A-Z' 'a-z')
+case "$tn" in
+  *remove_service*|*remove_volume*|*remove_tcp_proxy*|*remove_bucket*|*delete_domain*)
+    ;;
+  *) exit 0 ;;  # не разрушительный вызов — пропускаем
+esac
+
+if [ "${CC_ALLOW_DESTRUCTIVE_INPUT:-}" = "1" ]; then
+  log_decision "bypass-env" "$tool_name"
+  exit 0
+fi
+
+reason="Инструмент ${tool_name} необратимо удаляет облачный ресурс (сервис/хранилище/домен). Разовая необходимость — запусти с CC_ALLOW_DESTRUCTIVE_INPUT=1 (осознанно, из реального шелла пилота)."
+log_decision "deny" "$tool_name"
+jq -n --arg reason "$reason" \
+  '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -149,6 +149,15 @@
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/residency-gate-skill-adapter.sh"
           }
         ]
+      },
+      {
+        "matcher": "mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/destructive-mcp-guard.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -61,7 +61,11 @@
     },
     {
       "path": ".claude/hooks/destructive-guard.sh",
-      "sha256": "3fd94e91db31347513df92e1070fe09a48fce4b8db0b321f7bc67e3ffcc1829c"
+      "sha256": "c37d09bcbe3ec95581d31eec7a42a16f402fc5c221f1ca71e2b7a831967ba81f"
+    },
+    {
+      "path": ".claude/hooks/destructive-mcp-guard.sh",
+      "sha256": "9012de5deeaae4c6fdbbbbc5c955e5554d5d20f374fb8c1c7fbfeaf2a939b068"
     },
     {
       "path": ".claude/hooks/dry-run-gate.sh",
@@ -265,7 +269,7 @@
     },
     {
       "path": ".claude/settings.json",
-      "sha256": "c2d350e46293eaad3a390858be3c3d5ff8260f10ec288af411512be1611fc0e8"
+      "sha256": "3540ae0f183610eb87f987c20d13b4262078b5c5f2454f598c5ee22f501aaf0b"
     },
     {
       "path": ".claude/skills-catalog.yaml",

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -61,7 +61,7 @@
     },
     {
       "path": ".claude/hooks/destructive-guard.sh",
-      "sha256": "c37d09bcbe3ec95581d31eec7a42a16f402fc5c221f1ca71e2b7a831967ba81f"
+      "sha256": "6bedcfdbf461cee9059c235e60815d3cdbb3650e5f82a9449903552a7aac4a5d"
     },
     {
       "path": ".claude/hooks/destructive-mcp-guard.sh",

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2285,7 +2285,7 @@
     },
     {
       "path": "scripts/session-guard.sh",
-      "sha256": "37f0b652ac6e3fcdc64dc5ce3f1b31892e05f28e73e545a418cb5e123b6a6c2a"
+      "sha256": "b6789de0192b4fa57030e2e0f1308dac2c436aece13f2cb72e0430ba8abef76c"
     },
     {
       "path": "scripts/settings-promote.sh",


### PR DESCRIPTION
## Что

Три новые проверки в `destructive-guard.sh` + новый `destructive-mcp-guard.sh`:
- `rm -rf` (в любом сочетании флагов, включая раздельные и long-opts) вне `/tmp`, `scratchpad`, `.claude/worktrees`
- `psql ... DROP/TRUNCATE` и `DELETE FROM` без `WHERE`
- `gh repo delete`
- разрушительные вызовы Railway MCP (`remove_service`/`remove_volume`/`remove_tcp_proxy`/`remove_bucket`/`delete_domain`)

Bypass для всех новых проверок — `CC_ALLOW_DESTRUCTIVE_INPUT=1`, тот же контракт, что уже есть у `secret-leak-block.sh` (переменная читается из процессного env хука, агент не может выставить её сам себе через ещё не выполненную команду).

## Почему

Разбор реального использования показал: интерактивное подтверждение перед каждым действием — источник ощутимого трения (до 38 минут в день на одних только "да"). У части пользователей оно выключено (`bypassPermissions`). Живая проверка (два теста в реальной сессии) подтвердила: PreToolUse-хуки с `deny` продолжают работать независимо от режима разрешений — это единственный слой, который реально останавливает необратимое, когда интерактивный вопрос выключен. Но до этой правки под защитой были только git-операции и секреты; удаление файлов, разрушительные команды к боевой БД, удаление репозитория и удаление облачных ресурсов не проверялись никак.

Список классов и решение получены и перепроверены в пир-сессии с Codex (не поверил на слово, перечитал файлы сам, поймал два реальных пробела в первой версии регулярных выражений — раздельные флаги `-r -f` и multi-statement в проверке `DELETE`).

## Проверено

Поведенческие тесты (не просто «не упало» — конкретные assert по exit-коду для каждого случая): `rm -rf` реальный путь → блок, `rm -rf /tmp/...` → пропуск, `rm -r -f`/`rm --recursive --force` → блок, `psql DROP TABLE` → блок, `DELETE FROM` без/с `WHERE` → блок/пропуск, `gh repo delete` → блок, `git reset --hard` (регрессия существующей проверки) → блок, bypass через `CC_ALLOW_DESTRUCTIVE_INPUT=1` → пропуск, обычная безопасная команда → пропуск. Манифест обновления пересобран (`generate-manifest.sh`), новый файл получил исполняемый бит.

## Ограничения (честно, не проверено)

Matcher `mcp__.*` с фильтрацией по имени внутри хука технически стандартный (тот же паттерн, что уже использует `secret-mcp-dump-guard.sh`), но именно новый список имён Railway-инструментов проверен только юнит-вызовом хука напрямую, не живым вызовом через реальный Railway MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)