### PR TITLE
feat(hooks): git add -A/-u/. guard in destructive-guard.sh (WP-544 Ф1 Д5)

### DIFF
--- a/.claude/hooks/destructive-guard.sh
+++ b/.claude/hooks/destructive-guard.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# PreToolUse:Bash guard — blocks irreversible git operations regardless of flag order.
-# Complements the global rm -rf blocker (which forces `trash`). Exit 2 = block.
+# PreToolUse:Bash guard — blocks irreversible operations: git (staging, history,
+# push/reset/clean), filesystem (rm -rf outside temp paths), prod DB (psql
+# DROP/TRUNCATE/DELETE without WHERE), GitHub repo deletion. Exit 2 = block.
 set -euo pipefail
 
 CMD=$(jq -r '.tool_input.command // empty' 2>/dev/null || true)
@@ -187,6 +188,22 @@ fi
 CLEAN_SEGMENT=$(git_segment clean)
 if [ -n "$CLEAN_SEGMENT" ] && echo "$CLEAN_SEGMENT" | grep -qE -- '(^|[[:space:]])-[a-zA-Z]*[dfx]'; then
   block "git clean -fdx запрещён (удаляет неотслеживаемые файлы). Согласуй с владельцем."
+fi
+
+# git add -A/--all/-u/--update/bare-dot (I7, WP-458: AR.216 жил только в rule-engine.sh
+# check_git_staged_only(), которая никогда не диспатчилась ни на одно живое событие —
+# реальная защита срабатывала только на commit (install-hooks.sh Check 8), уже после
+# стейджа. Здесь — фактический PreToolUse барьер, до того как чужие файлы попадут в индекс.
+# WP-544 Ф1 Д5, 21.08: перенесено из личной установки, где было с 17.07 — устраняет
+# расхождение версий хука между личной установкой и этим шаблоном.)
+ADD_SEGMENT=$(git_segment add)
+if [ -n "$ADD_SEGMENT" ]; then
+  if echo "$ADD_SEGMENT" | grep -qE -- '(^|[[:space:]])(-A|--all|-u|--update)([[:space:]]|$)'; then
+    block "git add -A/--all/-u/--update запрещён — подхватывает файлы других агентов (CLAUDE.md §Git Staging). Стейдж конкретные пути: git add <path>."
+  fi
+  if echo "$ADD_SEGMENT" | grep -qE -- '(^|[[:space:]])\.([[:space:]]|$)'; then
+    block "git add . запрещён — подхватывает файлы других агентов (CLAUDE.md §Git Staging). Стейдж конкретные пути: git add <path>."
+  fi
 fi
 
 # rm с одновременным recursive (-r/-R/--recursive) и force (-f/--force), в любом

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -61,7 +61,7 @@
     },
     {
       "path": ".claude/hooks/destructive-guard.sh",
-      "sha256": "6bedcfdbf461cee9059c235e60815d3cdbb3650e5f82a9449903552a7aac4a5d"
+      "sha256": "aaab111b500049cd078a86752e790083ff7a464c098eea5ab23cf5f3b4cdd3c5"
     },
     {
       "path": ".claude/hooks/destructive-mcp-guard.sh",


### PR DESCRIPTION
## Summary
- Personal install (Mac) has blocked `git add -A/--all/-u/--update/.` since 2026-07-17 (WP-458 I7) — this template never got the same guard.
- Ported the block, adapted to this file's `git_segment()` calling convention (verified identical signature before porting).
- No other logic changed; the rest of `destructive-guard.sh` (quote-aware command parser, cwd root-relative path check, safe fast-forward reset exception — all added 2026-08-20 via #495) already exceeds what the personal install had, and was ported back to Mac separately in this same session (WP-544 Ф1).

## Test plan
- [x] `bash -n` syntax check passes
- [x] `shellcheck` clean (2 pre-existing info-level findings unrelated to this change, confirmed via `git stash`)
- [x] Live smoke test, 14 scenarios covering git add variants, force push, hard reset, clean, filesystem delete, DB statements, repo delete, top-level cd, and a safe control command — all green
- [x] `verify-manifest.sh` green after `generate-manifest.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
