### PR TITLE
feat(day-open): контракт доставки Day Open графа (WP-529 Ф7) + un-red main (Ф4 tests)

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -587,6 +587,13 @@ jobs:
       - name: Run Day Open delivery-closure acceptance test
         run: bash setup/test-day-open-delivery-closure.sh
 
+      # WP-529 F7 follow-up (pilot decision 2026-08-21): update.sh delivers the
+      # last published release by default, moving main only via explicit
+      # IWE_UPDATE_CHANNEL=main or as an announced fallback when no release
+      # exists. Stubbed-curl cases over the real resolve_delivery_ref().
+      - name: Run update.sh release-channel test
+        run: bash setup/test-update-release-channel.sh
+
       # PR #385: cloud install paths may occur legitimately in old tracked text;
       # only additions made by the current updater run are publication blockers.
       - name: Test staged install-path guard

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -579,6 +579,14 @@ jobs:
       - name: Run delivery-route-label acceptance test
         run: bash setup/test-delivery-route-label.sh
 
+      # WP-529 F7 acceptance: every runtime dependency of the Day Open pipeline
+      # must resolve inside the delivery root (scripts/ + seed mirror), with
+      # transitive closure over imports/sources — dynamic extraction from the
+      # pipeline itself, no hand-kept list. Extension-graph dispatch is a strict
+      # xfail until ArchGate Q1; an XPASS fails the run on purpose.
+      - name: Run Day Open delivery-closure acceptance test
+        run: bash setup/test-day-open-delivery-closure.sh
+
       # PR #385: cloud install paths may occur legitimately in old tracked text;
       # only additions made by the current updater run are publication blockers.
       - name: Test staged install-path guard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,60 @@ Refs: WP-NNN
 
 
 
+
+
+
+
+
+## [Unreleased] — обновлено 2026-08-21
+
+### Added
+
+- `9fa32ce` feat(week-close): проактивный сторож каденции архивации карточек (WP-545 Ф3)
+- `86a1c01` feat(day-close): чек-лист — синхронизация рабочих копий ↔ GitHub кроме живых сессий (поручение пилота 21.08)
+- `a16106a` feat(hooks): git add -A/-u/. guard in destructive-guard.sh (WP-544 Ф1 Д5) (#497)
+- `f6d4132` feat(hooks): расширить защиту от необратимых действий (WP-544 Ф1) (#495)
+- `8112b1a` feat(update.sh): параллелизация скачивания манифеста + skip-if-hash-matches
+- `088aaad` feat(dev): явный список Python-зависимостей + инструкция venv
+
+### Changed
+
+- `f64dd72` Merge pull request #493 from TserenTserenov/wp529-f4-fail-closed-tests-2026-08-20
+- `0958b5f` test(wp529): fail-closed tests for update.sh parallel fetch (Ф4)
+- `2733422` chore(release): weekly auto-bump to v0.38.6
+- `1e88c48` docs(changelog): собрать [Unreleased] с 18.08 перед внеплановым релизом
+- `abd056e` Merge pull request #488 from TserenTserenov/wp529-merge-478-480
+- `43e170a` chore(wp529): regenerate manifest after merging #478+#480
+- `8e3bc40` Merge branch 'pr480' into wp529-merge-478-480
+- `c1c5bd3` Merge branch 'pr478' into wp529-merge-478-480
+- `56a28f8` chore(wp529): пустой коммит для нового прогона CI
+- `67bde25` chore(wp529): пересобрать манифест после ребейза на main
+- `f0eb4ec` Merge pull request #483 from TserenTserenov/wp452-f5-proposal-process
+- `11876de` chore: перегенерировать манифест после Ф5 и venv-инструкции
+- `3e53700` docs(wp452): добавить GitHub issue-шаблон для предложений разработчика
+- `5443f7c` docs(wp452): Ф5 — процесс предложений разработчика IWE
+
+### Fixed
+
+- `9630b5a` fix(wp545): починить счётчик в r-questionnaire.md (хвост 5/5, находка 2)
+- `c8d20e8` fix(update.sh): закрыть 2 тестовых долга ревью параллелизации (WP-546 Ф5)
+- `7996b69` fix(update.sh): 5 находок независимого ревью параллелизации (WP-546 Ф4)
+- `e129754` fix(session-guard): select_semaphore() -- строгая конъюнкция wp+slug
+- `d0f9a4d` fix(wp529): Ф9 — python3-resolver contract + bash 3.2 compat (2 confirmed sites) (#494)
+- `52a5189` fix(update): shellcheck-safe comment + real unbound-variable bug it caught
+- `7fd3837` fix(update): restore integrity-mismatch message + fix curl shim for -K batch mode
+- `68d8d88` fix(day-open,calendar,manifest): closes #477, #489, #486
+- `f0c8ee3` fix(release): sync README badge + regenerate manifest for v0.38.6 bump
+- `9a6e60a` fix(wp529): register 2 issue-tests in delivery contract (cold review find)
+- `ea4551c` fix(wp-545): исключить временные worktree из iCloud-бэкапа
+- `4d3727c` fix(WP-529): delivery-route-label фикстура должна нести find-python3.sh рядом с копией чекера
+- `4da487e` fix(WP-529): T11-фикстура должна нести find-python3.sh для изолированного source
+- `6908df9` fix(WP-529): перевести оставшихся heredoc-потребителей PyYAML на общий резолвер
+- `becf4e4` fix(wp529): удалить дубль-файл теста, застрявший в предыдущем коммите
+- `76d2cdd` fix(WP-529): закрыть 5 находок Red Team-ревью Евгения (раунд 2, 19.08)
+- `1a6ca46` fix(WP-529 Ф6): конвейер доставки — фиксы по находкам Евгения 18.08
+
+
 ## [0.38.6] — 2026-08-20
 
 ### Added

--- a/scripts/day-open-bottleneck-patch.sh
+++ b/scripts/day-open-bottleneck-patch.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# day-open-bottleneck-patch.sh — deterministic "Горлышко недели" injection (WP-484 Ф2)
+#
+# Runs AFTER day-open-llm-fill.py in day-open-pipeline.sh (moved 2026-07-14 — see BUGFIX
+# below) so this script always has the last, authoritative word on "Горлышко недели":
+# llm-fill.py fills whole `<details>` chunks generically and cannot be trusted to leave
+# this sub-section untouched, since day-open.checks.md hard-blocks hand-written content
+# here without the BY-SCRIPT marker (feedback_skill_manual_synthesis_bypass, 2026-05-28-04).
+#
+# Reused by extensions/day-open.after.md (interactive path) so both call sites share one
+# correct implementation instead of two divergent copies.
+#
+# BUGFIX (WP-484 Ф2, 2026-07-13): the previous inline copy of this logic (still visible in
+# after.md's git history) anchored its replacement regex on a closing "**Контекст недели W"
+# markdown-bold string that day-open-scaffold.sh has not emitted since it moved to
+# <details><summary><b> HTML markup — the substitution silently no-opped on every run.
+# Verified empirically against scaffold.sh's actual output before fixing.
+#
+# BUGFIX (code-review same day): the first version of this script picked the latest YAML
+# by mtime with no date check, and treated the honest BOTTLENECK-PENDING marker as
+# terminal (same as BY-SCRIPT) for idempotency. Two bugs followed: (1) day-open.checks.md's
+# second bottleneck check requires a YAML dated exactly today — an older file passed the
+# marker check only to hard-block on that second check, moving the failure instead of
+# removing it; (2) once BOTTLENECK-PENDING was written, a later run with a real same-day
+# YAML available would never upgrade it (the after.md text promising "next run picks it up"
+# was false). Both fixed below: reject non-today YAML as unavailable, and only BY-SCRIPT
+# counts as done.
+#
+# Usage: day-open-bottleneck-patch.sh <dayplan-path>
+
+set -uo pipefail
+
+IWE="${IWE_ROOT:-$HOME/IWE}"
+DAYPLAN="${1:?Usage: day-open-bottleneck-patch.sh <dayplan-path>}"
+
+if [ ! -f "$DAYPLAN" ]; then
+  echo "  ⚠️ bottleneck-patch: $DAYPLAN not found — skip" >&2
+  exit 0
+fi
+
+# Real analysis already inserted — the only truly terminal state.
+if grep -q "<!-- BY-SCRIPT: bottleneck-section-from-yaml.sh -->" "$DAYPLAN" 2>/dev/null; then
+  echo "  bottleneck-patch: BY-SCRIPT marker already present — skip"
+  exit 0
+fi
+
+TODAY=$(date +%Y-%m-%d)
+RUNS_DIR="$IWE/${IWE_GOVERNANCE_REPO:-DS-strategy}/inbox/bottleneck-pick-runs"
+# bug-2026-07-17: `stat -f` is BSD/macOS syntax — on the Linux server it's the
+# filesystem-status flag instead, so this silently produced garbage there (never a
+# same-day YAML), always falling through to BOTTLENECK-PENDING regardless of freshness.
+# Filenames are ISO-date-prefixed, so a plain lexical sort orders them chronologically
+# without needing mtime at all — portable across both platforms.
+LATEST_YAML=$(find "$RUNS_DIR" -name "*-weekplan*.yaml" 2>/dev/null | sort | tail -1)
+
+# day-open.checks.md's second bottleneck check requires a YAML dated exactly today —
+# accepting an older one here would insert a BY-SCRIPT section that passes the first
+# check only to hard-block on the second. Treat anything not dated today as unavailable.
+if [ -n "$LATEST_YAML" ] && [[ "$(basename "$LATEST_YAML")" != "$TODAY-weekplan"* ]]; then
+  echo "  bottleneck-patch: latest YAML ($(basename "$LATEST_YAML")) is not dated $TODAY — treating as unavailable" >&2
+  LATEST_YAML=""
+fi
+
+if [ -n "$LATEST_YAML" ]; then
+  SECTION=$(bash "$IWE/${IWE_GOVERNANCE_REPO:-DS-strategy}/scripts/bottleneck-section-from-yaml.sh" "$LATEST_YAML" 2>/dev/null)
+  if [ -z "$SECTION" ]; then
+    echo "  ⚠️ bottleneck-patch: $LATEST_YAML found but generator produced no output — treating as no-yaml" >&2
+    LATEST_YAML=""
+  fi
+fi
+
+if [ -z "$LATEST_YAML" ]; then
+  # No today-dated YAML. If an earlier run already left the honest marker, there is
+  # nothing new to say — stop here instead of re-writing the same content.
+  if grep -q "<!-- BOTTLENECK-PENDING:" "$DAYPLAN" 2>/dev/null; then
+    echo "  bottleneck-patch: still no today-dated YAML — BOTTLENECK-PENDING marker stands"
+    exit 0
+  fi
+  # Honest, visible "not done" marker — never a silent gap (WP-484 invariant).
+  # Distinct from a hand-written heading: day-open.checks.md recognizes this marker
+  # and reports it as a non-blocking 🟡 in «Требует внимания» instead of hard-blocking,
+  # since nobody is claiming a fake analysis — the headless run structurally cannot
+  # invoke the /bottleneck-pick LLM skill on its own.
+  SECTION="<!-- BOTTLENECK-PENDING: no-yaml-headless -->
+**Горлышко недели:** нет данных — headless-конвейер не может вызвать LLM-скилл \`/bottleneck-pick\`. Запусти вручную: \`/bottleneck-pick --target weekplan --layer intra --horizon week --depth 1\`."
+fi
+
+python3 - "$DAYPLAN" "$SECTION" <<'PYEOF'
+import re
+import sys
+
+path, section = sys.argv[1], sys.argv[2]
+content = open(path).read()
+
+# BUGFIX (WP-484, confirmed on 2026-07-14 headless run): the "Контекст недели" <details>
+# chunk holds a second, independent PENDING marker (week_context) — llm-fill.py's
+# has_pending check is whole-chunk, so that marker alone made it regenerate this whole
+# chunk and overwrite an already-inserted BOTTLENECK-PENDING with unmarked prose.
+# Anchor on "**Горлышко недели" itself (present in all 3 possible prior states) instead
+# of one specific predecessor marker, so this script always has the final, authoritative
+# word — paired with running it after llm-fill.py in day-open-pipeline.sh now.
+# bug-2026-07-17: llm-fill.py regenerated «Контекст недели» via LLM and dropped that
+# chunk's own </details> — with no boundary before the NEXT section's opening tag, the
+# match ran through to "Итоги вчера"'s closing </details> and deleted that whole section.
+# `\n<summary><b>` is a hard backstop: a details block never nests a second <summary>,
+# so this boundary holds even when </details> itself goes missing upstream.
+pattern = re.compile(
+    r'(?:<!-- PENDING: bottleneck-week.*?-->|<!-- BOTTLENECK-PENDING:.*?-->)?'
+    r'\s*\n*\*\*Горлышко недели.*?'
+    r'(?=\n\n<!-- PENDING: week_context|\n\n\*\*Контекст недели:|\n\n</details>|\n<summary><b>)',
+    re.DOTALL,
+)
+
+
+# `\s*\n*` above greedily swallows the blank line separating this section from whatever
+# precedes it (the </summary> line, in every observed state) as part of the match, so
+# the replacement must restore it explicitly — otherwise the closing tag and the marker
+# comment end up jammed onto one line.
+def replace(m):
+    tail = section.strip()
+    # The `\n<summary><b>` backstop above is zero-width and stops one section short of
+    # a real </details> — reaching it means the current chunk's own closing tag was
+    # already missing upstream (bug-2026-07-17), so restore it here instead of leaving
+    # this section jammed straight into the next one's <summary>.
+    if content[m.end():m.end() + 2] != "\n\n":
+        tail += "\n\n</details>\n\n<details>"
+    return "\n\n" + tail
+
+
+content_new, n = pattern.subn(replace, content, count=1)
+
+if n == 0:
+    print("  ⚠️ bottleneck-patch: anchor not found — DayPlan structure unexpected, left untouched")
+else:
+    open(path, "w").write(content_new)
+    print("  bottleneck-patch: inserted")
+PYEOF

--- a/scripts/day-open-close-error-patch.py
+++ b/scripts/day-open-close-error-patch.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Patch DayPlan «Требует внимания» with last night's Close-cycle failure.
+
+Same non-blocking-finding pattern as day-open-priorities-patch.py: when the
+Close half of the night cycle (facts_digest / reflection / mechanical
+governance) fails, night-cycle-day.sh no longer stops before Open runs
+(WP-484 Ф113) — Open still renders and publishes today's DayPlan, and the
+failure becomes a visible finding in the plan itself instead of a silently
+skipped night.
+"""
+
+import re
+import sys
+import argparse
+from pathlib import Path
+
+ATTENTION_HEADER_RE = re.compile(r"(<summary><b>Требует внимания</b></summary>\s*\n)")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dayplan", required=True, help="Path to DayPlan .md")
+    p.add_argument("--error", required=True, help="Close-cycle failure text (empty = no-op)")
+    return p.parse_args()
+
+
+def append_attention_line(text, finding):
+    line = f"- ⚠️ Закрытие предыдущего дня не завершилось: {finding}\n"
+    # lambda replacement: the Close-error text is arbitrary (tracebacks contain
+    # backslashes) and must not be parsed as a regex replacement template
+    patched, n = ATTENTION_HEADER_RE.subn(lambda m: m.group(1) + line, text, count=1)
+    return patched if n else text
+
+
+def main():
+    args = parse_args()
+    error_text = args.error.strip()
+    if not error_text:
+        print("close-error-patch: no close error — no-op", file=sys.stderr)
+        return
+
+    dayplan = Path(args.dayplan)
+    text = dayplan.read_text(encoding="utf-8")
+    patched = append_attention_line(text, error_text)
+    if patched == text:
+        print(
+            f"close-error-patch: finding present but «Требует внимания» header not found — cannot patch, finding lost: {error_text}",
+            file=sys.stderr,
+        )
+        return
+
+    dayplan.write_text(patched, encoding="utf-8")
+    print(f"close-error-patch: written to «Требует внимания»: {error_text}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/day-open-ledger-render-patch.py
+++ b/scripts/day-open-ledger-render-patch.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""day-open-ledger-render-patch.py — WP-484 Ф16.2 2b: appends render-open.py's
+ledger-derived sections ("Итоги вчера"/"Очередь решений"/"Предлагаемые действия",
+Ф16.2 2c) into an already-scaffolded+filled DayPlan.
+
+Design decision (documented per task instructions, read this before changing anchor
+logic): day-open-scaffold.sh ALREADY renders its own non-ledger "Итоги вчера"
+<details> block (render_yesterday() in day-open-scaffold.sh, git-log based). This
+script does NOT touch or replace that block — CONCEPT-night-cycle.md §16 "Миграция"
+explicitly specifies a parallel run, not a big-bang replacement ("не big-bang,
+параллельный прогон... работают одновременно минимум один полный цикл своего такта"),
+so the ledger-rendered sections are appended as an ADDITIONAL block near the end of
+the file, never overwriting the legacy section. Once the ledger path has proven itself
+(§16.5 — N clean autoruns), a future phase can retire the legacy block; not this one.
+
+Graceful no-op invariant (the single biggest risk this script must avoid, per task
+instructions): when no real ledger data exists yet for the target date (the normal
+case until scripts/day-close-prepare.sh, WP-484 Ф16.2 2a, starts landing facts_digest
+events most nights), this script changes NOTHING in the DayPlan — no PENDING marker,
+no empty section, no visual noise. Each of the three sub-sections is gated
+independently on the ledger event kind it actually needs (facts_digest / blocked_
+question / pilot_answer) rather than render-open.py's own PENDING fallback text, so
+this script never has to parse render-open.py's markdown output to tell "real data"
+from "honest placeholder" apart — it just doesn't call render-open.py for a
+sub-section it has no real data for.
+
+Idempotent by fact (CONCEPT-night-cycle.md §5 invariant): a marker HTML comment is
+checked before inserting — a second run against an already-patched DayPlan is a no-op,
+not a duplicate block.
+
+Self-heal on marker mismatch (added 2026-07-26, WP-484 — root-caused the 04:35 26.07
+incident): the marker used to mean "trust whatever's there, skip." That let a stray
+write (e.g. strategist.sh's free-form LLM fallback, which has no awareness of this
+marker at all) fabricate a block carrying this exact marker with numbers no
+deterministic render could produce, and this script would silently accept it forever
+after — exactly the "no fabrication" invariant §5 exists to prevent, via a path this
+script's own idempotency check didn't cover. Now: marker present → recompute the
+block fresh from the ledger and diff it against what's on disk. Identical → true
+no-op (unchanged, matches the invariant this script has always claimed). Different →
+overwrite with the freshly-computed honest text (self-heal, logged). No real ledger
+data anymore → remove the block entirely (back to the true no-op state a fresh render
+would produce).
+
+Usage:
+  day-open-ledger-render-patch.py --dayplan PATH --date YYYY-MM-DD
+      [--ledger-dir DIR] [--ledger-archive-dir DIR]
+
+--date is TODAY's date (matches day-open-pipeline.sh's $DATE) — the ledger period
+rendered for the summary is the PREVIOUS calendar day ("Итоги ВЧЕРА"), computed here
+the same way day-open-scaffold.sh computes $YDAY (calendar day before --date, not
+"yesterday" by wall clock — deterministic and testable with an arbitrary --date).
+
+Day split (WP-481 Ф22 audit №3 repair, 2026-08-08): the summary belongs to the
+closed day (D−1), but the morning queue and the night drift scan belong to TODAY's
+ledger day (D) — night WP-503 jobs write blocked_question / wp_drift_found into D
+around 01:00, before this render runs. Reading them from D−1 surfaced yesterday's
+already-stale queue and never surfaced drift at all (render_drift_scan existed in
+render-open.py but was never called from here). Contract: summary/actions ← D−1,
+queue/drift_scan ← D.
+
+Exit code: always 0 (this is a best-effort deterministic patch in the same family as
+day-open-bottleneck-patch.sh / day-open-budget-patch.py, both called with `|| true` /
+non-fatal semantics in day-open-pipeline.sh — a problem here must never abort Day Open).
+"""
+import argparse
+import datetime
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+from ledger_path import resolve_ledger_path  # noqa: E402
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+MARKER = "<!-- LEDGER-RENDER: WP-484 Ф16.2 2b -->"
+FOOTER_PATTERN = re.compile(
+    r"^\*Создан: \d{4}-\d{2}-\d{2} \(Day Open / day-open-scaffold\.sh WP-264 Ф2\)\*\s*$",
+    re.MULTILINE,
+)
+# Captures the entire previously-inserted block (marker through its closing
+# </details>\n\n) so a second run can diff/replace it instead of just detecting its
+# presence — see "Self-heal on marker mismatch" in the module docstring.
+BLOCK_PATTERN = re.compile(
+    re.escape(MARKER) + r"\n\n<details>\n.*?\n</details>\n\n",
+    re.DOTALL,
+)
+
+
+def load_events(ledger_dir, archive_dir, period):
+    if yaml is None:
+        return [], "pyyaml not available"
+    try:
+        path = resolve_ledger_path("day", period, ledger_dir, archive_dir)
+    except RuntimeError as exc:
+        return [], str(exc)
+    if not os.path.isfile(path):
+        return [], None
+    try:
+        with open(path, encoding="utf-8") as f:
+            doc = yaml.safe_load(f)
+    except Exception as exc:
+        return [], str(exc)
+    if not isinstance(doc, dict):
+        return [], "ledger document is not a mapping"
+    events = doc.get("events")
+    return (events if isinstance(events, list) else []), None
+
+
+def has_kind(events, kind):
+    return any(isinstance(e, dict) and e.get("kind") == kind for e in events)
+
+
+def has_digest_for_period(events, period):
+    """Accept an explicit target match, or a legacy event with no for_date field."""
+    for event in events:
+        if not isinstance(event, dict) or event.get("kind") != "facts_digest":
+            continue
+        data = event.get("data")
+        if not isinstance(data, dict):
+            continue
+        if data.get("for_date") == period or "for_date" not in data:
+            return True
+    return False
+
+
+def render_section(render_open_py, period, ledger_dir, archive_dir, section):
+    cmd = [sys.executable, render_open_py, "--scale", "day", "--period", period, "--section", section]
+    if ledger_dir:
+        cmd += ["--ledger-dir", ledger_dir]
+    if archive_dir:
+        cmd += ["--ledger-archive-dir", archive_dir]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    except Exception as e:
+        return None, str(e)
+    if proc.returncode != 0:
+        return None, proc.stderr.strip() or f"exit {proc.returncode}"
+    text = proc.stdout.rstrip("\n")
+    return (text or None), None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dayplan", required=True)
+    parser.add_argument("--date", required=True, help="today's date (YYYY-MM-DD), matches day-open-pipeline.sh $DATE")
+    parser.add_argument("--ledger-dir", default=None)
+    parser.add_argument("--ledger-archive-dir", default=None)
+    args = parser.parse_args()
+
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", args.date):
+        print(f"  ledger-render-patch: invalid --date '{args.date}' — skip", file=sys.stderr)
+        return 0
+
+    if not os.path.isfile(args.dayplan):
+        print(f"  ledger-render-patch: {args.dayplan} not found — skip")
+        return 0
+
+    with open(args.dayplan, encoding="utf-8") as f:
+        content = f.read()
+
+    had_marker = MARKER in content
+
+    iwe_root = os.environ.get("IWE_ROOT", os.path.expanduser("~/IWE"))
+    governance = os.environ.get("IWE_GOVERNANCE_REPO", "DS-strategy")
+    ledger_dir = args.ledger_dir or os.environ.get(
+        "IWE_LEDGER_DIR", os.path.join(iwe_root, governance, "machine/ledger")
+    )
+    archive_dir = args.ledger_archive_dir or os.environ.get("IWE_LEDGER_ARCHIVE_DIR")
+    if archive_dir is None and args.ledger_dir is None and "IWE_LEDGER_DIR" not in os.environ:
+        archive_dir = os.path.join(iwe_root, governance, "archive/ledger")
+    render_open_py = os.path.join(iwe_root, governance, "scripts/render-open.py")
+
+    if not os.path.isfile(render_open_py):
+        print(f"  ledger-render-patch: render-open.py not found at {render_open_py} — skip")
+        return 0
+    if yaml is None:
+        print("  ledger-render-patch: pyyaml not available — skip")
+        return 0
+
+    today = datetime.datetime.strptime(args.date, "%Y-%m-%d").date()
+    yday = (today - datetime.timedelta(days=1)).isoformat()
+    today_str = today.isoformat()
+
+    events, load_error = load_events(ledger_dir, archive_dir, yday)
+
+    # Queue and drift read from TODAY's ledger (D), not the closed day — see
+    # "Day split" in the module docstring. A missing/corrupt today-ledger must
+    # not take down yesterday's summary: treat it as "no morning events yet".
+    events_today, load_error_today = load_events(ledger_dir, archive_dir, today_str)
+    if load_error_today:
+        print(f"  ledger-render-patch: today ledger ({today_str}): {load_error_today} — queue/drift skipped")
+        events_today = []
+
+    if load_error:
+        # Symmetric degradation (cold review 2026-08-08): a corrupt YESTERDAY
+        # ledger kills summary/actions, but the morning queue/drift from D do
+        # not depend on it — render them anyway. Bail out untouched only when
+        # D has nothing renderable either (the old safe behavior).
+        print(f"  ledger-render-patch: yday ledger ({yday}): {load_error} — summary/actions skipped")
+        events = []
+        if not (has_kind(events_today, "blocked_question") or has_kind(events_today, "wp_drift_found")):
+            print("  ledger-render-patch: nothing renderable from today either — left DayPlan untouched")
+            return 0
+
+    blocks = []
+    errors = []
+    if has_digest_for_period(events, yday):
+        text, err = render_section(render_open_py, yday, ledger_dir, archive_dir, "summary")
+        if text:
+            blocks.append(text)
+        elif err:
+            errors.append(f"summary: {err}")
+    if has_kind(events_today, "blocked_question"):
+        text, err = render_section(render_open_py, today_str, ledger_dir, archive_dir, "queue")
+        if text:
+            blocks.append(text)
+        elif err:
+            errors.append(f"queue: {err}")
+    if has_kind(events_today, "wp_drift_found"):
+        text, err = render_section(render_open_py, today_str, ledger_dir, archive_dir, "drift_scan")
+        if text:
+            blocks.append(text)
+        elif err:
+            errors.append(f"drift_scan: {err}")
+    if has_kind(events, "pilot_answer"):
+        text, err = render_section(render_open_py, yday, ledger_dir, archive_dir, "actions")
+        if text:
+            blocks.append(text)
+        elif err:
+            errors.append(f"actions: {err}")
+
+    if not blocks:
+        # The graceful no-op invariant this whole script exists to protect: no
+        # facts_digest/blocked_question/pilot_answer for yesterday yet (expected
+        # for the next several nights, until day-close-prepare.sh, WP-484 Ф16.2 2a,
+        # starts landing facts_digest events) — leave the DayPlan untouched, don't
+        # inject an empty or PENDING-looking section.
+        if had_marker:
+            if load_error:
+                # Yesterday's ledger is corrupt — a block on disk may carry a
+                # perfectly good summary we cannot recompute right now. Never
+                # remove on partial data (cold review 2026-08-08).
+                print("  ledger-render-patch: marker present but yday ledger unreadable — left untouched, needs manual look")
+                return 0
+            # A block exists on disk but a fresh render says there's no real data for
+            # it anymore — it can't have come from this script (it never writes a
+            # block with nothing behind it), so it's a stray/fabricated one. Remove
+            # it to reach the same honest no-op state a clean run would produce.
+            new_content = BLOCK_PATTERN.sub("", content, count=1)
+            if new_content == content:
+                print("  ledger-render-patch: marker present but block pattern didn't match — left untouched, needs manual look")
+                return 0
+            with open(args.dayplan, "w", encoding="utf-8") as f:
+                f.write(new_content)
+            print(f"  ledger-render-patch: SELF-HEAL — removed stray block for {yday} (no real ledger data behind it)")
+            return 0
+        detail = f" (errors: {'; '.join(errors)})" if errors else ""
+        print(f"  ledger-render-patch: no real ledger data for {yday}/{today_str} yet — no-op{detail}")
+        return 0
+
+    insertion = (
+        MARKER
+        + "\n\n<details>\n<summary><b>Ночной цикл (ledger, WP-484 Ф16.2)</b></summary>\n\n"
+        + "\n\n".join(blocks)
+        + "\n\n</details>\n\n"
+    )
+
+    if had_marker:
+        existing_match = BLOCK_PATTERN.search(content)
+        if existing_match and existing_match.group(0) == insertion:
+            print("  ledger-render-patch: already inserted, matches fresh render — skip")
+            return 0
+        if load_error:
+            # Same partial-data guard as above: with yesterday's ledger corrupt
+            # the fresh insertion can be missing a summary the on-disk block
+            # legitimately has — overwriting would destroy honest data.
+            print("  ledger-render-patch: block differs but yday ledger unreadable — left untouched, needs manual look")
+            return 0
+        if not existing_match:
+            print("  ledger-render-patch: marker present but block pattern didn't match — left untouched, needs manual look")
+            return 0
+        # Marker present but content differs from what a fresh, honest render
+        # produces — self-heal (see module docstring "Self-heal on marker mismatch").
+        new_content = BLOCK_PATTERN.sub(lambda m: insertion, content, count=1)
+        with open(args.dayplan, "w", encoding="utf-8") as f:
+            f.write(new_content)
+        print(f"  ledger-render-patch: SELF-HEAL — block for {yday} didn't match a fresh render, overwrote with honest data"
+              + (f" (partial — errors: {'; '.join(errors)})" if errors else ""))
+        return 0
+
+    new_content, n = FOOTER_PATTERN.subn(lambda m: insertion + m.group(0), content, count=1)
+    if n == 0:
+        print("  ledger-render-patch: footer anchor not found — DayPlan structure unexpected, left untouched")
+        return 0
+
+    with open(args.dayplan, "w", encoding="utf-8") as f:
+        f.write(new_content)
+    print(f"  ledger-render-patch: inserted {len(blocks)} section(s) for {yday}/{today_str}"
+          + (f" (partial — errors: {'; '.join(errors)})" if errors else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/day-open-pipeline.sh
+++ b/scripts/day-open-pipeline.sh
@@ -15,6 +15,9 @@ set -uo pipefail
 
 DS_STRATEGY="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IWE="${IWE_ROOT:-$(cd "$DS_STRATEGY/.." && pwd)}"
+# Child patch steps (4.2/4.3) fall back to ~/IWE when IWE_ROOT is unset —
+# a launchd/cron env typically has no IWE_ROOT, so pass the resolved root down.
+export IWE_ROOT="$IWE"
 CONFIG="$DS_STRATEGY/exocortex/day-rhythm-config.yaml"
 # shellcheck source=lib/ledger-path.sh
 . "$DS_STRATEGY/scripts/lib/ledger-path.sh"
@@ -817,6 +820,14 @@ fi
 echo "=== 4.2. Bottleneck patch ==="
 bash "$DS_STRATEGY/scripts/day-open-bottleneck-patch.sh" "$DAYPLAN_PATH" 2>&1 || true
 
+
+# Shared resolver for the deterministic patch steps below (4.3, 4.55-4.57).
+# WP-529 F7 port (peer session 2026-08-21-17): ledger-render imports yaml, so a
+# bare `python3` can be a yaml-less interpreter (same defect class as F6/F9);
+# the stdlib-only patches get the same binary with a soft fallback — a missing
+# resolver must not break steps that never needed PyYAML in the first place.
+_PATCH_PY=$("$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/find-python3.sh" 2>/dev/null) || _PATCH_PY=""
+[ -n "$_PATCH_PY" ] || _PATCH_PY=python3
 # ============================================
 # 4.3. Ledger render (deterministic, AFTER LLM Fill — same reason as 4.2 above:
 # WP-484 Ф16.2 2b). Appends render-open.py's ledger sections (Итоги вчера/Очередь
@@ -828,7 +839,7 @@ bash "$DS_STRATEGY/scripts/day-open-bottleneck-patch.sh" "$DAYPLAN_PATH" 2>&1 ||
 # own docstring for the graceful-degradation design.
 # ============================================
 echo "=== 4.3. Ledger render ==="
-python3 "$DS_STRATEGY/scripts/day-open-ledger-render-patch.py" \
+"$_PATCH_PY" "$DS_STRATEGY/scripts/day-open-ledger-render-patch.py" \
   --dayplan "$DAYPLAN_PATH" \
   --date "$DATE" 2>&1 || true
 
@@ -839,6 +850,49 @@ echo "=== 4.5. Budget patch ==="
 python3 "$DS_STRATEGY/scripts/day-open-budget-patch.py" \
   --dayplan "$DAYPLAN_PATH" \
   --priorities "$DS_STRATEGY/current/priorities.yaml" 2>&1 || true
+
+# ============================================
+# 4.55. Priorities patch (deterministic — WP-484, pilot instruction 16.08: Day
+# Open must never fail to run because of a priorities discrepancy; the finding
+# belongs in the DayPlan itself, not as a commit-blocking exit 1). Writes into
+# «Требует внимания» while the section header is still guaranteed to exist
+# (before archive/sync can touch the file) — same slot pattern as 4.5 above.
+# Ported from the author pipeline (WP-529 F7): resolver-based interpreter, not
+# bare python3 — see _PATCH_PY above.
+# ============================================
+echo "=== 4.55. Priorities patch ==="
+"$_PATCH_PY" "$DS_STRATEGY/scripts/day-open-priorities-patch.py" \
+  --dayplan "$DAYPLAN_PATH" \
+  --priorities "$DS_STRATEGY/current/priorities.yaml" 2>&1 || true
+
+# ============================================
+# 4.56. Close-error patch (deterministic — WP-484 F113: the night runner exports
+# IWE_CLOSE_ERROR instead of stopping before this pipeline when the Close half
+# fails. Empty/unset in every other invocation (manual runs, probes, installs
+# without a night cycle) — no-op then. Same non-blocking pattern as 4.55.
+# ============================================
+echo "=== 4.56. Close-error patch ==="
+"$_PATCH_PY" "$DS_STRATEGY/scripts/day-open-close-error-patch.py" \
+  --dayplan "$DAYPLAN_PATH" \
+  --error "${IWE_CLOSE_ERROR:-}" 2>&1 || true
+
+# ============================================
+# 4.57. Version-check patch (deterministic — WP-484 stage-0 wiring: a stale
+# checkout is a visible finding, not a silent commit block). Template port
+# guard (WP-529 F7, peer consensus 2026-08-21-17): comparing HEAD..origin/main
+# only makes sense when such a remote ref exists. A template/offline install
+# without it is a NORMAL mode, not a pipeline error — diagnose to stderr and
+# move on, never non-zero, never a DayPlan «Требует внимания» entry.
+# ============================================
+echo "=== 4.57. Version-check patch ==="
+if git -C "$DS_STRATEGY" remote get-url origin >/dev/null 2>&1 \
+   && git -C "$DS_STRATEGY" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  "$_PATCH_PY" "$DS_STRATEGY/scripts/day-open-version-check-patch.py" \
+    --dayplan "$DAYPLAN_PATH" \
+    --repo "$DS_STRATEGY" 2>&1 || true
+else
+  echo "version-check: no origin/main to compare against — skipped (comparison context unavailable, normal for template/offline installs)" >&2
+fi
 
 # ============================================
 # 4.6. Sync + archive stale DayPlans (moved ahead of Checks — WP-484 Ф2)

--- a/scripts/day-open-priorities-patch.py
+++ b/scripts/day-open-priorities-patch.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Patch DayPlan «Требует внимания» with priorities.yaml discrepancies.
+
+Same detection logic as the two blocking checks in extensions/day-open.checks.md
+(WP-453 missing-from-plan class, phys_hours fallback class) — but writes the
+finding into the DayPlan's own «Требует внимания» section instead of blocking
+the commit. Runs deterministically after LLM Fill, before Checks (same slot as
+day-open-budget-patch.py), so the marker is already staged by the time
+day-open-checks-runner.sh's now-non-blocking versions of these checks run.
+"""
+
+import re
+import sys
+import argparse
+from pathlib import Path
+
+try:
+    import yaml as _yaml
+    _YAML_AVAILABLE = True
+except ImportError:
+    _YAML_AVAILABLE = False
+
+PHYS_HOURS_CEILING = 14.0
+ATTENTION_HEADER_RE = re.compile(r"(<summary><b>Требует внимания</b></summary>\s*\n)")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dayplan", required=True, help="Path to DayPlan .md")
+    p.add_argument("--priorities", required=True, help="Path to priorities.yaml")
+    return p.parse_args()
+
+
+def load_priorities(path):
+    text = Path(path).read_text(encoding="utf-8")
+    if _YAML_AVAILABLE:
+        return _yaml.safe_load(text) or {}
+    # PyYAML unavailable: only the two keys this script reads, same fallback
+    # class as day-open-budget-patch.py's regex path. Scope the dash-items to
+    # the today: block — a bare list regex over the whole file would collect
+    # WP items from ANY other yaml key (cold review 2026-08-21-17, Medium).
+    today_block = re.search(
+        r"^today:\s*\n((?:^[ \t]+-[^\n]*\n?)+)", text, re.MULTILINE
+    )
+    today = (
+        re.findall(r"^\s*-\s*(WP-\d+)", today_block.group(1), re.MULTILINE)
+        if today_block
+        else []
+    )
+    m = re.search(r"^phys_hours:\s*([\d.]+)", text, re.MULTILINE)
+    return {"today": today, "phys_hours": float(m.group(1)) if m else None}
+
+
+def extract_plan_table(dayplan_text):
+    """Same scoping fix as day-open.checks.md (bug-2026-07-01): only the
+    «План на сегодня» table, not the whole file — a WP number can legitimately
+    appear elsewhere (e.g. a cross-reference in another RP's row) without being
+    IN the plan."""
+    lines = dayplan_text.splitlines()
+    out = []
+    in_section = False
+    for line in lines:
+        if "<summary><b>План на сегодня</b></summary>" in line:
+            in_section = True
+            continue
+        if in_section:
+            if "</details>" in line:
+                break
+            if line.startswith("|"):
+                out.append(line)
+    return out
+
+
+def missing_priority_wps(today_wps, plan_table):
+    """Same two-format match as day-open.checks.md (bug-2026-07-16 rewrite):
+    column 3 bare number OR a WP-prefixed number anywhere in that row."""
+    missing = []
+    for wp in today_wps:
+        num = str(wp).replace("WP-", "").strip()
+        found = False
+        for row in plan_table:
+            cells = row.split("|")
+            col3 = cells[3].strip() if len(cells) > 3 else ""
+            if col3 == num or re.search(rf"WP-{re.escape(num)}(?!\d)", row):
+                found = True
+                break
+        if not found:
+            missing.append(f"WP-{num}")
+    return missing
+
+
+def phys_hours_finding(priorities):
+    """Returns a warning string, or None if phys_hours is set and sane."""
+    val = priorities.get("phys_hours")
+    if val is None:
+        return "phys_hours не задан в priorities.yaml — физ. часы будут посчитаны с fallback 1.0x (не прогноз, а копия суммы РП)"
+    if float(val) > PHYS_HOURS_CEILING:
+        return f"phys_hours={val} превышает потолок пилота ({PHYS_HOURS_CEILING:.0f}ч) — физически маловероятно для одного дня"
+    return None
+
+
+def append_attention_lines(text, findings):
+    lines = "".join(f"- ⚠️ {f}\n" for f in findings)
+    patched, n = ATTENTION_HEADER_RE.subn(r"\1" + lines, text, count=1)
+    return patched if n else text
+
+
+def main():
+    args = parse_args()
+    dayplan = Path(args.dayplan)
+    text = dayplan.read_text(encoding="utf-8")
+    priorities = load_priorities(args.priorities)
+
+    findings = []
+
+    today_wps = priorities.get("today") or []
+    plan_table = extract_plan_table(text)
+    missing = missing_priority_wps(today_wps, plan_table)
+    if missing:
+        findings.append(
+            f"{', '.join(missing)} из priorities.yaml отсутствует в таблице «План на сегодня»"
+        )
+
+    phys_finding = phys_hours_finding(priorities)
+    if phys_finding:
+        findings.append(phys_finding)
+
+    if not findings:
+        print("priorities-patch: no discrepancies found", file=sys.stderr)
+        return
+
+    patched = append_attention_lines(text, findings)
+    if patched == text:
+        print(
+            f"priorities-patch: {len(findings)} finding(s) but «Требует внимания» header not found — cannot patch, findings lost",
+            file=sys.stderr,
+        )
+        return
+
+    dayplan.write_text(patched, encoding="utf-8")
+    print(f"priorities-patch: {len(findings)} finding(s) written to «Требует внимания»", file=sys.stderr)
+    for f in findings:
+        print(f"  - {f}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/day-open-version-check-patch.py
+++ b/scripts/day-open-version-check-patch.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Patch DayPlan «Требует внимания» when this host's code is stale vs origin/main.
+
+Same non-blocking-finding pattern as day-open-close-error-patch.py: a stale
+checkout must not silently pass — WP-484 Ф124 plan, Этап 0 line 1, wiring 3б
+(single-host scope, no multi-host registry — that part stays open per the
+2026-08-20-48 peer-session consensus).
+"""
+
+import re
+import subprocess
+import sys
+import argparse
+from pathlib import Path
+
+ATTENTION_HEADER_RE = re.compile(r"(<summary><b>Требует внимания</b></summary>\s*\n)")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dayplan", required=True, help="Path to DayPlan .md")
+    p.add_argument("--repo", required=True, help="Path to a git checkout to compare HEAD against origin/main")
+    return p.parse_args()
+
+
+def local_head_is_stale(repo):
+    """True if origin/main has commits this checkout's HEAD doesn't."""
+    result = subprocess.run(
+        ["git", "-C", repo, "rev-list", "--count", "HEAD..origin/main"],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        print(f"version-check-patch: git rev-list failed — {result.stderr.strip()}", file=sys.stderr)
+        return None
+    behind = int(result.stdout.strip() or "0")
+    return behind if behind > 0 else 0
+
+
+def append_attention_line(text, behind_count):
+    line = f"- ⚠️ Этот хост отстал от общего репозитория на {behind_count} коммит(ов) — код может быть устаревшим.\n"
+    patched, n = ATTENTION_HEADER_RE.subn(r"\1" + line, text, count=1)
+    return patched if n else text
+
+
+def main():
+    args = parse_args()
+    behind = local_head_is_stale(args.repo)
+    if behind is None:
+        return  # git call failed — already logged, no-op rather than block Day Open
+    if behind == 0:
+        print("version-check-patch: host is current with origin/main — no-op", file=sys.stderr)
+        return
+
+    dayplan = Path(args.dayplan)
+    text = dayplan.read_text(encoding="utf-8")
+    patched = append_attention_line(text, behind)
+    if patched == text:
+        print(
+            f"version-check-patch: stale by {behind} commits but «Требует внимания» header not found — cannot patch, finding lost",
+            file=sys.stderr,
+        )
+        return
+
+    dayplan.write_text(patched, encoding="utf-8")
+    print(f"version-check-patch: written to «Требует внимания» — stale by {behind} commits", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# install-hooks.sh — устанавливает .githooks/ как core.hooksPath для governance-репо.
+#
+# Usage:
+#   bash scripts/install-hooks.sh [REPO_PATH]
+#
+# If REPO_PATH is omitted, uses the current working directory.
+# This script is intentionally minimal and template-safe: it does not hardcode
+# governance-repo paths or agent-specific checks. It only wires the repository
+# to the tracked .githooks/ directory (pre-commit + pre-push guards).
+#
+# issue #342: an install where .githooks/ predates the pre-push guard (only
+# pre-commit tracked) would run this script, get "✅ Hooks wired" and still
+# have no force-push protection — nothing here ever copied the hook content,
+# only backed up / chmod'd whatever already happened to exist. Fixed by
+# copying missing hooks from the template's canonical seed/strategy/.githooks/
+# (found via IWE_TEMPLATE / IWE_ROOT, same fallback chain roles/extractor and
+# create-wp.sh already use) and by refusing to claim success if a hook is
+# still missing afterwards.
+#
+# see WP-436 (force-push guard) + seed/strategy/.githooks/
+
+set -euo pipefail
+
+REPO="${1:-${PWD}}"
+HOOK_DIR="$REPO/.githooks"
+BACKUP_DIR="$REPO/.git/hook-backups"
+
+if [ ! -d "$REPO/.git" ]; then
+  echo "❌ Not a git repo: $REPO"
+  exit 1
+fi
+
+CANONICAL_HOOKS_DIR=""
+for candidate in \
+  "${IWE_TEMPLATE:-}/seed/strategy/.githooks" \
+  "${IWE_ROOT:-$HOME/IWE}/FMT-exocortex-template/seed/strategy/.githooks" \
+  "$HOME/IWE/FMT-exocortex-template/seed/strategy/.githooks"
+do
+  if [ -n "$candidate" ] && [ -d "$candidate" ]; then
+    CANONICAL_HOOKS_DIR="$candidate"
+    break
+  fi
+done
+
+mkdir -p "$HOOK_DIR" "$BACKUP_DIR"
+
+for hook in pre-commit pre-push; do
+  target="$HOOK_DIR/$hook"
+  source_hook="$CANONICAL_HOOKS_DIR/$hook"
+
+  if [ -f "$target" ]; then
+    backup="$BACKUP_DIR/$hook.backup.$(date +%s)"
+    cp "$target" "$backup"
+    echo "📝 Existing $hook backed up to: $backup"
+  fi
+
+  if [ -n "$CANONICAL_HOOKS_DIR" ] && [ -f "$source_hook" ]; then
+    cp "$source_hook" "$target"
+  fi
+
+  [ -f "$target" ] && chmod +x "$target"
+done
+
+git -C "$REPO" config core.hooksPath .githooks
+
+MISSING=""
+for hook in pre-commit pre-push; do
+  [ -x "$HOOK_DIR/$hook" ] || MISSING="$MISSING $hook"
+done
+
+if [ -n "$MISSING" ]; then
+  echo "⚠️  core.hooksPath = .githooks, но отсутствуют:$MISSING"
+  echo "   Канонический источник не найден (искали в \$IWE_TEMPLATE, \$IWE_ROOT/FMT-exocortex-template, \$HOME/IWE/FMT-exocortex-template)."
+  echo "   Хуки НЕ активны, пока эти файлы не появятся в $HOOK_DIR."
+  exit 1
+fi
+
+echo "✅ Hooks wired: $HOOK_DIR"
+echo "   core.hooksPath = $(git -C "$REPO" config core.hooksPath)"

--- a/scripts/lib/ledger_path.py
+++ b/scripts/lib/ledger_path.py
@@ -1,0 +1,61 @@
+"""ledger_path.py — Python twin of lib/ledger-path.sh (WP-484, 31.07: same
+year/month hierarchy migration for machine/ledger/, kept in lock-step by hand
+since there are only two languages here, not a build step worth adding for two files).
+"""
+
+import os
+from typing import Optional
+
+_SCALE_TEMPLATES = {
+    "day": "day/{year}/{month}/day-{period}.yaml",
+    "week": "week/{year}/week-{period}.yaml",
+    "month": "month/{year}/month-{period}.yaml",
+}
+
+
+def ledger_path_rel(scale: str, period: str) -> str:
+    """Suffix only (no root, no mkdir) -- for existence checks against multiple
+    roots (ledger_dir vs archive_dir) or a git-relative string, where creating
+    a directory would be wasteful or wrong.
+
+    day   period=YYYY-MM-DD -> day/YYYY/MM/day-YYYY-MM-DD.yaml
+    week  period=YYYY-Wnn   -> week/YYYY/week-YYYY-Wnn.yaml
+    month period=YYYY-MM    -> month/YYYY/month-YYYY-MM.yaml
+    """
+    template = _SCALE_TEMPLATES.get(scale)
+    if template is None:
+        raise ValueError(f"ledger_path_rel: недопустимый scale {scale!r} (day|week|month)")
+    return template.format(year=period[:4], month=period[5:7], period=period)
+
+
+def ledger_path(scale: str, period: str, root: str) -> str:
+    """Full hierarchical path for a ledger file; creates parent dirs."""
+    path = os.path.join(root, ledger_path_rel(scale, period))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    return path
+
+
+def resolve_ledger_path(
+    scale: str,
+    period: str,
+    active_root: str,
+    archive_root: Optional[str] = None,
+) -> str:
+    """Return the period's one canonical readable path without creating anything.
+
+    An archived file is used only when the active copy is absent. Two existing copies
+    are split-brain drift, not an arbitrary precedence decision.
+    """
+    relative = ledger_path_rel(scale, period)
+    active_path = os.path.join(active_root, relative)
+    archive_path = os.path.join(archive_root, relative) if archive_root else None
+    if archive_path and os.path.exists(active_path) and os.path.exists(archive_path):
+        raise RuntimeError(
+            f"ledger drift for {scale} {period}: both active and archived files exist "
+            f"({active_path}; {archive_path})"
+        )
+    if os.path.exists(active_path):
+        return active_path
+    if archive_path and os.path.exists(archive_path):
+        return archive_path
+    return active_path

--- a/scripts/lib/wp_inbox.py
+++ b/scripts/lib/wp_inbox.py
@@ -1,0 +1,31 @@
+"""WP inbox card discovery (WP-434 convention: one WP = one folder).
+
+A WP card lives at the canonical folder path ``inbox/WP-N/WP-N.md`` or, for
+legacy/transition stragglers, as a flat file ``inbox/WP-N*.md``. Readers that
+scan the inbox for WP frontmatter must look at BOTH levels — a flat-only glob
+silently drops folder cards (the regression that hid WP-426 from
+active-wp-sweep and zeroed Day Open WP facts after the WP-434 migration).
+
+Single source for this two-level traversal so every reader stays consistent.
+"""
+
+import glob
+import os
+
+
+def wp_card_paths(base_dir):
+    """Paths of WP card files under ``base_dir`` — flat plus folder-canonical.
+
+    - Flat: ``base_dir/WP-*.md`` (legacy cards and non-numbered WP-INCIDENT-* ).
+    - Folder: ``base_dir/WP-N/WP-N.md`` — the canonical main file only, never
+      sub-files inside the folder.
+
+    Returns a list of string paths (callers wrap in ``pathlib.Path`` as needed).
+    """
+    paths = glob.glob(os.path.join(base_dir, "WP-*.md"))
+    for folder in glob.glob(os.path.join(base_dir, "WP-*", "")):
+        name = os.path.basename(os.path.normpath(folder))  # "WP-7"
+        main = os.path.join(folder, name + ".md")
+        if os.path.isfile(main):
+            paths.append(main)
+    return paths

--- a/scripts/tests/test_update_download_batch_network_failure_failclosed.sh
+++ b/scripts/tests/test_update_download_batch_network_failure_failclosed.sh
@@ -21,7 +21,10 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
 UPDATE_SH="$ROOT/update.sh"
 CLEANUP_DIRS=()
 SERVER_PID=""
-trap '[ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null; for d in "${CLEANUP_DIRS[@]}"; do rm -rf "$d" 2>/dev/null; done' EXIT
+# ${arr[@]+...} idiom: a bare "${CLEANUP_DIRS[@]}" on an EMPTY array is an
+# unbound-variable error under set -u on Bash 3.2 (fixed in 4.4+) — the trap
+# then dies mid-cleanup and masks the test's real failure (WP-529 F9 class).
+trap '[ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null; for d in ${CLEANUP_DIRS[@]+"${CLEANUP_DIRS[@]}"}; do rm -rf "$d" 2>/dev/null; done' EXIT
 
 # shellcheck source=lib/extract-update-download-batch.sh
 . "$ROOT/scripts/tests/lib/extract-update-download-batch.sh"
@@ -38,6 +41,13 @@ CLEANUP_DIRS+=("$FUNCS")
 }
 # shellcheck disable=SC1090
 . "$FUNCS"
+
+# download_batch's serial/parallel switch lives in update.sh's MAIN BODY
+# (WP-546 parallelization), not inside the extracted function — without it the
+# first `if $USE_PARALLEL_DOWNLOAD` dies as unbound under set -u (live red CI
+# on main, run 32470798303). Pin the serial path: these cases assert the
+# fail-closed download contract, which must hold identically in both modes.
+USE_PARALLEL_DOWNLOAD=false
 
 # --- Case 1: network failure — RAW_BASE is unreachable ---
 # Fresh TMPDIR_UPDATE per case (Codex review point 3: no state leaking

--- a/scripts/tests/test_update_retry_and_classify_undeliverable_file.sh
+++ b/scripts/tests/test_update_retry_and_classify_undeliverable_file.sh
@@ -20,7 +20,10 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
 UPDATE_SH="$ROOT/update.sh"
 CLEANUP_DIRS=()
 SERVER_PID=""
-trap '[ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null; for d in "${CLEANUP_DIRS[@]}"; do rm -rf "$d" 2>/dev/null; done' EXIT
+# ${arr[@]+...} idiom: a bare "${CLEANUP_DIRS[@]}" on an EMPTY array is an
+# unbound-variable error under set -u on Bash 3.2 (fixed in 4.4+) — the trap
+# then dies mid-cleanup and masks the test's real failure (WP-529 F9 class).
+trap '[ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null; for d in ${CLEANUP_DIRS[@]+"${CLEANUP_DIRS[@]}"}; do rm -rf "$d" 2>/dev/null; done' EXIT
 
 # shellcheck source=lib/extract-update-download-batch.sh
 . "$ROOT/scripts/tests/lib/extract-update-download-batch.sh"
@@ -38,6 +41,13 @@ CLEANUP_DIRS+=("$FUNCS")
 }
 # shellcheck disable=SC1090
 . "$FUNCS"
+
+# download_batch's serial/parallel switch lives in update.sh's MAIN BODY
+# (WP-546 parallelization), not inside the extracted function — without it the
+# first `if $USE_PARALLEL_DOWNLOAD` dies as unbound under set -u (live red CI
+# on main, run 32470798303). Pin the serial path: these cases assert the
+# fail-closed download contract, which must hold identically in both modes.
+USE_PARALLEL_DOWNLOAD=false
 
 GLUE=$(mktemp)
 CLEANUP_DIRS+=("$GLUE")

--- a/scripts/tests/test_update_verify_batch_integrity_hash_mismatch_failclosed.sh
+++ b/scripts/tests/test_update_verify_batch_integrity_hash_mismatch_failclosed.sh
@@ -20,7 +20,10 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
 UPDATE_SH="$ROOT/update.sh"
 CLEANUP_DIRS=()
 SERVER_PID=""
-trap '[ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null; for d in "${CLEANUP_DIRS[@]}"; do rm -rf "$d" 2>/dev/null; done' EXIT
+# ${arr[@]+...} idiom: a bare "${CLEANUP_DIRS[@]}" on an EMPTY array is an
+# unbound-variable error under set -u on Bash 3.2 (fixed in 4.4+) — the trap
+# then dies mid-cleanup and masks the test's real failure (WP-529 F9 class).
+trap '[ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null; for d in ${CLEANUP_DIRS[@]+"${CLEANUP_DIRS[@]}"}; do rm -rf "$d" 2>/dev/null; done' EXIT
 
 # shellcheck source=lib/extract-update-download-batch.sh
 . "$ROOT/scripts/tests/lib/extract-update-download-batch.sh"
@@ -38,6 +41,13 @@ CLEANUP_DIRS+=("$FUNCS")
 }
 # shellcheck disable=SC1090
 . "$FUNCS"
+
+# download_batch's serial/parallel switch lives in update.sh's MAIN BODY
+# (WP-546 parallelization), not inside the extracted function — without it the
+# first `if $USE_PARALLEL_DOWNLOAD` dies as unbound under set -u (live red CI
+# on main, run 32470798303). Pin the serial path: these cases assert the
+# fail-closed download contract, which must hold identically in both modes.
+USE_PARALLEL_DOWNLOAD=false
 
 TMPDIR_UPDATE=$(mktemp -d)
 CLEANUP_DIRS+=("$TMPDIR_UPDATE")

--- a/seed/strategy/scripts/day-open-bottleneck-patch.sh
+++ b/seed/strategy/scripts/day-open-bottleneck-patch.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SNAPSHOT — synced manually via script-promote.sh from FMT-exocortex-template/scripts/. Do not edit here directly.
+# day-open-bottleneck-patch.sh — deterministic "Горлышко недели" injection (WP-484 Ф2)
+#
+# Runs AFTER day-open-llm-fill.py in day-open-pipeline.sh (moved 2026-07-14 — see BUGFIX
+# below) so this script always has the last, authoritative word on "Горлышко недели":
+# llm-fill.py fills whole `<details>` chunks generically and cannot be trusted to leave
+# this sub-section untouched, since day-open.checks.md hard-blocks hand-written content
+# here without the BY-SCRIPT marker (feedback_skill_manual_synthesis_bypass, 2026-05-28-04).
+#
+# Reused by extensions/day-open.after.md (interactive path) so both call sites share one
+# correct implementation instead of two divergent copies.
+#
+# BUGFIX (WP-484 Ф2, 2026-07-13): the previous inline copy of this logic (still visible in
+# after.md's git history) anchored its replacement regex on a closing "**Контекст недели W"
+# markdown-bold string that day-open-scaffold.sh has not emitted since it moved to
+# <details><summary><b> HTML markup — the substitution silently no-opped on every run.
+# Verified empirically against scaffold.sh's actual output before fixing.
+#
+# BUGFIX (code-review same day): the first version of this script picked the latest YAML
+# by mtime with no date check, and treated the honest BOTTLENECK-PENDING marker as
+# terminal (same as BY-SCRIPT) for idempotency. Two bugs followed: (1) day-open.checks.md's
+# second bottleneck check requires a YAML dated exactly today — an older file passed the
+# marker check only to hard-block on that second check, moving the failure instead of
+# removing it; (2) once BOTTLENECK-PENDING was written, a later run with a real same-day
+# YAML available would never upgrade it (the after.md text promising "next run picks it up"
+# was false). Both fixed below: reject non-today YAML as unavailable, and only BY-SCRIPT
+# counts as done.
+#
+# Usage: day-open-bottleneck-patch.sh <dayplan-path>
+
+set -uo pipefail
+
+IWE="${IWE_ROOT:-$HOME/IWE}"
+DAYPLAN="${1:?Usage: day-open-bottleneck-patch.sh <dayplan-path>}"
+
+if [ ! -f "$DAYPLAN" ]; then
+  echo "  ⚠️ bottleneck-patch: $DAYPLAN not found — skip" >&2
+  exit 0
+fi
+
+# Real analysis already inserted — the only truly terminal state.
+if grep -q "<!-- BY-SCRIPT: bottleneck-section-from-yaml.sh -->" "$DAYPLAN" 2>/dev/null; then
+  echo "  bottleneck-patch: BY-SCRIPT marker already present — skip"
+  exit 0
+fi
+
+TODAY=$(date +%Y-%m-%d)
+RUNS_DIR="$IWE/${IWE_GOVERNANCE_REPO:-DS-strategy}/inbox/bottleneck-pick-runs"
+# bug-2026-07-17: `stat -f` is BSD/macOS syntax — on the Linux server it's the
+# filesystem-status flag instead, so this silently produced garbage there (never a
+# same-day YAML), always falling through to BOTTLENECK-PENDING regardless of freshness.
+# Filenames are ISO-date-prefixed, so a plain lexical sort orders them chronologically
+# without needing mtime at all — portable across both platforms.
+LATEST_YAML=$(find "$RUNS_DIR" -name "*-weekplan*.yaml" 2>/dev/null | sort | tail -1)
+
+# day-open.checks.md's second bottleneck check requires a YAML dated exactly today —
+# accepting an older one here would insert a BY-SCRIPT section that passes the first
+# check only to hard-block on the second. Treat anything not dated today as unavailable.
+if [ -n "$LATEST_YAML" ] && [[ "$(basename "$LATEST_YAML")" != "$TODAY-weekplan"* ]]; then
+  echo "  bottleneck-patch: latest YAML ($(basename "$LATEST_YAML")) is not dated $TODAY — treating as unavailable" >&2
+  LATEST_YAML=""
+fi
+
+if [ -n "$LATEST_YAML" ]; then
+  SECTION=$(bash "$IWE/${IWE_GOVERNANCE_REPO:-DS-strategy}/scripts/bottleneck-section-from-yaml.sh" "$LATEST_YAML" 2>/dev/null)
+  if [ -z "$SECTION" ]; then
+    echo "  ⚠️ bottleneck-patch: $LATEST_YAML found but generator produced no output — treating as no-yaml" >&2
+    LATEST_YAML=""
+  fi
+fi
+
+if [ -z "$LATEST_YAML" ]; then
+  # No today-dated YAML. If an earlier run already left the honest marker, there is
+  # nothing new to say — stop here instead of re-writing the same content.
+  if grep -q "<!-- BOTTLENECK-PENDING:" "$DAYPLAN" 2>/dev/null; then
+    echo "  bottleneck-patch: still no today-dated YAML — BOTTLENECK-PENDING marker stands"
+    exit 0
+  fi
+  # Honest, visible "not done" marker — never a silent gap (WP-484 invariant).
+  # Distinct from a hand-written heading: day-open.checks.md recognizes this marker
+  # and reports it as a non-blocking 🟡 in «Требует внимания» instead of hard-blocking,
+  # since nobody is claiming a fake analysis — the headless run structurally cannot
+  # invoke the /bottleneck-pick LLM skill on its own.
+  SECTION="<!-- BOTTLENECK-PENDING: no-yaml-headless -->
+**Горлышко недели:** нет данных — headless-конвейер не может вызвать LLM-скилл \`/bottleneck-pick\`. Запусти вручную: \`/bottleneck-pick --target weekplan --layer intra --horizon week --depth 1\`."
+fi
+
+python3 - "$DAYPLAN" "$SECTION" <<'PYEOF'
+import re
+import sys
+
+path, section = sys.argv[1], sys.argv[2]
+content = open(path).read()
+
+# BUGFIX (WP-484, confirmed on 2026-07-14 headless run): the "Контекст недели" <details>
+# chunk holds a second, independent PENDING marker (week_context) — llm-fill.py's
+# has_pending check is whole-chunk, so that marker alone made it regenerate this whole
+# chunk and overwrite an already-inserted BOTTLENECK-PENDING with unmarked prose.
+# Anchor on "**Горлышко недели" itself (present in all 3 possible prior states) instead
+# of one specific predecessor marker, so this script always has the final, authoritative
+# word — paired with running it after llm-fill.py in day-open-pipeline.sh now.
+# bug-2026-07-17: llm-fill.py regenerated «Контекст недели» via LLM and dropped that
+# chunk's own </details> — with no boundary before the NEXT section's opening tag, the
+# match ran through to "Итоги вчера"'s closing </details> and deleted that whole section.
+# `\n<summary><b>` is a hard backstop: a details block never nests a second <summary>,
+# so this boundary holds even when </details> itself goes missing upstream.
+pattern = re.compile(
+    r'(?:<!-- PENDING: bottleneck-week.*?-->|<!-- BOTTLENECK-PENDING:.*?-->)?'
+    r'\s*\n*\*\*Горлышко недели.*?'
+    r'(?=\n\n<!-- PENDING: week_context|\n\n\*\*Контекст недели:|\n\n</details>|\n<summary><b>)',
+    re.DOTALL,
+)
+
+
+# `\s*\n*` above greedily swallows the blank line separating this section from whatever
+# precedes it (the </summary> line, in every observed state) as part of the match, so
+# the replacement must restore it explicitly — otherwise the closing tag and the marker
+# comment end up jammed onto one line.
+def replace(m):
+    tail = section.strip()
+    # The `\n<summary><b>` backstop above is zero-width and stops one section short of
+    # a real </details> — reaching it means the current chunk's own closing tag was
+    # already missing upstream (bug-2026-07-17), so restore it here instead of leaving
+    # this section jammed straight into the next one's <summary>.
+    if content[m.end():m.end() + 2] != "\n\n":
+        tail += "\n\n</details>\n\n<details>"
+    return "\n\n" + tail
+
+
+content_new, n = pattern.subn(replace, content, count=1)
+
+if n == 0:
+    print("  ⚠️ bottleneck-patch: anchor not found — DayPlan structure unexpected, left untouched")
+else:
+    open(path, "w").write(content_new)
+    print("  bottleneck-patch: inserted")
+PYEOF

--- a/seed/strategy/scripts/day-open-close-error-patch.py
+++ b/seed/strategy/scripts/day-open-close-error-patch.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# SNAPSHOT — synced manually via script-promote.sh from FMT-exocortex-template/scripts/. Do not edit here directly.
+"""Patch DayPlan «Требует внимания» with last night's Close-cycle failure.
+
+Same non-blocking-finding pattern as day-open-priorities-patch.py: when the
+Close half of the night cycle (facts_digest / reflection / mechanical
+governance) fails, night-cycle-day.sh no longer stops before Open runs
+(WP-484 Ф113) — Open still renders and publishes today's DayPlan, and the
+failure becomes a visible finding in the plan itself instead of a silently
+skipped night.
+"""
+
+import re
+import sys
+import argparse
+from pathlib import Path
+
+ATTENTION_HEADER_RE = re.compile(r"(<summary><b>Требует внимания</b></summary>\s*\n)")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dayplan", required=True, help="Path to DayPlan .md")
+    p.add_argument("--error", required=True, help="Close-cycle failure text (empty = no-op)")
+    return p.parse_args()
+
+
+def append_attention_line(text, finding):
+    line = f"- ⚠️ Закрытие предыдущего дня не завершилось: {finding}\n"
+    # lambda replacement: the Close-error text is arbitrary (tracebacks contain
+    # backslashes) and must not be parsed as a regex replacement template
+    patched, n = ATTENTION_HEADER_RE.subn(lambda m: m.group(1) + line, text, count=1)
+    return patched if n else text
+
+
+def main():
+    args = parse_args()
+    error_text = args.error.strip()
+    if not error_text:
+        print("close-error-patch: no close error — no-op", file=sys.stderr)
+        return
+
+    dayplan = Path(args.dayplan)
+    text = dayplan.read_text(encoding="utf-8")
+    patched = append_attention_line(text, error_text)
+    if patched == text:
+        print(
+            f"close-error-patch: finding present but «Требует внимания» header not found — cannot patch, finding lost: {error_text}",
+            file=sys.stderr,
+        )
+        return
+
+    dayplan.write_text(patched, encoding="utf-8")
+    print(f"close-error-patch: written to «Требует внимания»: {error_text}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/seed/strategy/scripts/day-open-ledger-render-patch.py
+++ b/seed/strategy/scripts/day-open-ledger-render-patch.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+# SNAPSHOT — synced manually via script-promote.sh from FMT-exocortex-template/scripts/. Do not edit here directly.
+"""day-open-ledger-render-patch.py — WP-484 Ф16.2 2b: appends render-open.py's
+ledger-derived sections ("Итоги вчера"/"Очередь решений"/"Предлагаемые действия",
+Ф16.2 2c) into an already-scaffolded+filled DayPlan.
+
+Design decision (documented per task instructions, read this before changing anchor
+logic): day-open-scaffold.sh ALREADY renders its own non-ledger "Итоги вчера"
+<details> block (render_yesterday() in day-open-scaffold.sh, git-log based). This
+script does NOT touch or replace that block — CONCEPT-night-cycle.md §16 "Миграция"
+explicitly specifies a parallel run, not a big-bang replacement ("не big-bang,
+параллельный прогон... работают одновременно минимум один полный цикл своего такта"),
+so the ledger-rendered sections are appended as an ADDITIONAL block near the end of
+the file, never overwriting the legacy section. Once the ledger path has proven itself
+(§16.5 — N clean autoruns), a future phase can retire the legacy block; not this one.
+
+Graceful no-op invariant (the single biggest risk this script must avoid, per task
+instructions): when no real ledger data exists yet for the target date (the normal
+case until scripts/day-close-prepare.sh, WP-484 Ф16.2 2a, starts landing facts_digest
+events most nights), this script changes NOTHING in the DayPlan — no PENDING marker,
+no empty section, no visual noise. Each of the three sub-sections is gated
+independently on the ledger event kind it actually needs (facts_digest / blocked_
+question / pilot_answer) rather than render-open.py's own PENDING fallback text, so
+this script never has to parse render-open.py's markdown output to tell "real data"
+from "honest placeholder" apart — it just doesn't call render-open.py for a
+sub-section it has no real data for.
+
+Idempotent by fact (CONCEPT-night-cycle.md §5 invariant): a marker HTML comment is
+checked before inserting — a second run against an already-patched DayPlan is a no-op,
+not a duplicate block.
+
+Self-heal on marker mismatch (added 2026-07-26, WP-484 — root-caused the 04:35 26.07
+incident): the marker used to mean "trust whatever's there, skip." That let a stray
+write (e.g. strategist.sh's free-form LLM fallback, which has no awareness of this
+marker at all) fabricate a block carrying this exact marker with numbers no
+deterministic render could produce, and this script would silently accept it forever
+after — exactly the "no fabrication" invariant §5 exists to prevent, via a path this
+script's own idempotency check didn't cover. Now: marker present → recompute the
+block fresh from the ledger and diff it against what's on disk. Identical → true
+no-op (unchanged, matches the invariant this script has always claimed). Different →
+overwrite with the freshly-computed honest text (self-heal, logged). No real ledger
+data anymore → remove the block entirely (back to the true no-op state a fresh render
+would produce).
+
+Usage:
+  day-open-ledger-render-patch.py --dayplan PATH --date YYYY-MM-DD
+      [--ledger-dir DIR] [--ledger-archive-dir DIR]
+
+--date is TODAY's date (matches day-open-pipeline.sh's $DATE) — the ledger period
+rendered for the summary is the PREVIOUS calendar day ("Итоги ВЧЕРА"), computed here
+the same way day-open-scaffold.sh computes $YDAY (calendar day before --date, not
+"yesterday" by wall clock — deterministic and testable with an arbitrary --date).
+
+Day split (WP-481 Ф22 audit №3 repair, 2026-08-08): the summary belongs to the
+closed day (D−1), but the morning queue and the night drift scan belong to TODAY's
+ledger day (D) — night WP-503 jobs write blocked_question / wp_drift_found into D
+around 01:00, before this render runs. Reading them from D−1 surfaced yesterday's
+already-stale queue and never surfaced drift at all (render_drift_scan existed in
+render-open.py but was never called from here). Contract: summary/actions ← D−1,
+queue/drift_scan ← D.
+
+Exit code: always 0 (this is a best-effort deterministic patch in the same family as
+day-open-bottleneck-patch.sh / day-open-budget-patch.py, both called with `|| true` /
+non-fatal semantics in day-open-pipeline.sh — a problem here must never abort Day Open).
+"""
+import argparse
+import datetime
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+from ledger_path import resolve_ledger_path  # noqa: E402
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+MARKER = "<!-- LEDGER-RENDER: WP-484 Ф16.2 2b -->"
+FOOTER_PATTERN = re.compile(
+    r"^\*Создан: \d{4}-\d{2}-\d{2} \(Day Open / day-open-scaffold\.sh WP-264 Ф2\)\*\s*$",
+    re.MULTILINE,
+)
+# Captures the entire previously-inserted block (marker through its closing
+# </details>\n\n) so a second run can diff/replace it instead of just detecting its
+# presence — see "Self-heal on marker mismatch" in the module docstring.
+BLOCK_PATTERN = re.compile(
+    re.escape(MARKER) + r"\n\n<details>\n.*?\n</details>\n\n",
+    re.DOTALL,
+)
+
+
+def load_events(ledger_dir, archive_dir, period):
+    if yaml is None:
+        return [], "pyyaml not available"
+    try:
+        path = resolve_ledger_path("day", period, ledger_dir, archive_dir)
+    except RuntimeError as exc:
+        return [], str(exc)
+    if not os.path.isfile(path):
+        return [], None
+    try:
+        with open(path, encoding="utf-8") as f:
+            doc = yaml.safe_load(f)
+    except Exception as exc:
+        return [], str(exc)
+    if not isinstance(doc, dict):
+        return [], "ledger document is not a mapping"
+    events = doc.get("events")
+    return (events if isinstance(events, list) else []), None
+
+
+def has_kind(events, kind):
+    return any(isinstance(e, dict) and e.get("kind") == kind for e in events)
+
+
+def has_digest_for_period(events, period):
+    """Accept an explicit target match, or a legacy event with no for_date field."""
+    for event in events:
+        if not isinstance(event, dict) or event.get("kind") != "facts_digest":
+            continue
+        data = event.get("data")
+        if not isinstance(data, dict):
+            continue
+        if data.get("for_date") == period or "for_date" not in data:
+            return True
+    return False
+
+
+def render_section(render_open_py, period, ledger_dir, archive_dir, section):
+    cmd = [sys.executable, render_open_py, "--scale", "day", "--period", period, "--section", section]
+    if ledger_dir:
+        cmd += ["--ledger-dir", ledger_dir]
+    if archive_dir:
+        cmd += ["--ledger-archive-dir", archive_dir]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    except Exception as e:
+        return None, str(e)
+    if proc.returncode != 0:
+        return None, proc.stderr.strip() or f"exit {proc.returncode}"
+    text = proc.stdout.rstrip("\n")
+    return (text or None), None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dayplan", required=True)
+    parser.add_argument("--date", required=True, help="today's date (YYYY-MM-DD), matches day-open-pipeline.sh $DATE")
+    parser.add_argument("--ledger-dir", default=None)
+    parser.add_argument("--ledger-archive-dir", default=None)
+    args = parser.parse_args()
+
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", args.date):
+        print(f"  ledger-render-patch: invalid --date '{args.date}' — skip", file=sys.stderr)
+        return 0
+
+    if not os.path.isfile(args.dayplan):
+        print(f"  ledger-render-patch: {args.dayplan} not found — skip")
+        return 0
+
+    with open(args.dayplan, encoding="utf-8") as f:
+        content = f.read()
+
+    had_marker = MARKER in content
+
+    iwe_root = os.environ.get("IWE_ROOT", os.path.expanduser("~/IWE"))
+    governance = os.environ.get("IWE_GOVERNANCE_REPO", "DS-strategy")
+    ledger_dir = args.ledger_dir or os.environ.get(
+        "IWE_LEDGER_DIR", os.path.join(iwe_root, governance, "machine/ledger")
+    )
+    archive_dir = args.ledger_archive_dir or os.environ.get("IWE_LEDGER_ARCHIVE_DIR")
+    if archive_dir is None and args.ledger_dir is None and "IWE_LEDGER_DIR" not in os.environ:
+        archive_dir = os.path.join(iwe_root, governance, "archive/ledger")
+    render_open_py = os.path.join(iwe_root, governance, "scripts/render-open.py")
+
+    if not os.path.isfile(render_open_py):
+        print(f"  ledger-render-patch: render-open.py not found at {render_open_py} — skip")
+        return 0
+    if yaml is None:
+        print("  ledger-render-patch: pyyaml not available — skip")
+        return 0
+
+    today = datetime.datetime.strptime(args.date, "%Y-%m-%d").date()
+    yday = (today - datetime.timedelta(days=1)).isoformat()
+    today_str = today.isoformat()
+
+    events, load_error = load_events(ledger_dir, archive_dir, yday)
+
+    # Queue and drift read from TODAY's ledger (D), not the closed day — see
+    # "Day split" in the module docstring. A missing/corrupt today-ledger must
+    # not take down yesterday's summary: treat it as "no morning events yet".
+    events_today, load_error_today = load_events(ledger_dir, archive_dir, today_str)
+    if load_error_today:
+        print(f"  ledger-render-patch: today ledger ({today_str}): {load_error_today} — queue/drift skipped")
+        events_today = []
+
+    if load_error:
+        # Symmetric degradation (cold review 2026-08-08): a corrupt YESTERDAY
+        # ledger kills summary/actions, but the morning queue/drift from D do
+        # not depend on it — render them anyway. Bail out untouched only when
+        # D has nothing renderable either (the old safe behavior).
+        print(f"  ledger-render-patch: yday ledger ({yday}): {load_error} — summary/actions skipped")
+        events = []
+        if not (has_kind(events_today, "blocked_question") or has_kind(events_today, "wp_drift_found")):
+            print("  ledger-render-patch: nothing renderable from today either — left DayPlan untouched")
+            return 0
+
+    blocks = []
+    errors = []
+    if has_digest_for_period(events, yday):
+        text, err = render_section(render_open_py, yday, ledger_dir, archive_dir, "summary")
+        if text:
+            blocks.append(text)
+        elif err:
+            errors.append(f"summary: {err}")
+    if has_kind(events_today, "blocked_question"):
+        text, err = render_section(render_open_py, today_str, ledger_dir, archive_dir, "queue")
+        if text:
+            blocks.append(text)
+        elif err:
+            errors.append(f"queue: {err}")
+    if has_kind(events_today, "wp_drift_found"):
+        text, err = render_section(render_open_py, today_str, ledger_dir, archive_dir, "drift_scan")
+        if text:
+            blocks.append(text)
+        elif err:
+            errors.append(f"drift_scan: {err}")
+    if has_kind(events, "pilot_answer"):
+        text, err = render_section(render_open_py, yday, ledger_dir, archive_dir, "actions")
+        if text:
+            blocks.append(text)
+        elif err:
+            errors.append(f"actions: {err}")
+
+    if not blocks:
+        # The graceful no-op invariant this whole script exists to protect: no
+        # facts_digest/blocked_question/pilot_answer for yesterday yet (expected
+        # for the next several nights, until day-close-prepare.sh, WP-484 Ф16.2 2a,
+        # starts landing facts_digest events) — leave the DayPlan untouched, don't
+        # inject an empty or PENDING-looking section.
+        if had_marker:
+            if load_error:
+                # Yesterday's ledger is corrupt — a block on disk may carry a
+                # perfectly good summary we cannot recompute right now. Never
+                # remove on partial data (cold review 2026-08-08).
+                print("  ledger-render-patch: marker present but yday ledger unreadable — left untouched, needs manual look")
+                return 0
+            # A block exists on disk but a fresh render says there's no real data for
+            # it anymore — it can't have come from this script (it never writes a
+            # block with nothing behind it), so it's a stray/fabricated one. Remove
+            # it to reach the same honest no-op state a clean run would produce.
+            new_content = BLOCK_PATTERN.sub("", content, count=1)
+            if new_content == content:
+                print("  ledger-render-patch: marker present but block pattern didn't match — left untouched, needs manual look")
+                return 0
+            with open(args.dayplan, "w", encoding="utf-8") as f:
+                f.write(new_content)
+            print(f"  ledger-render-patch: SELF-HEAL — removed stray block for {yday} (no real ledger data behind it)")
+            return 0
+        detail = f" (errors: {'; '.join(errors)})" if errors else ""
+        print(f"  ledger-render-patch: no real ledger data for {yday}/{today_str} yet — no-op{detail}")
+        return 0
+
+    insertion = (
+        MARKER
+        + "\n\n<details>\n<summary><b>Ночной цикл (ledger, WP-484 Ф16.2)</b></summary>\n\n"
+        + "\n\n".join(blocks)
+        + "\n\n</details>\n\n"
+    )
+
+    if had_marker:
+        existing_match = BLOCK_PATTERN.search(content)
+        if existing_match and existing_match.group(0) == insertion:
+            print("  ledger-render-patch: already inserted, matches fresh render — skip")
+            return 0
+        if load_error:
+            # Same partial-data guard as above: with yesterday's ledger corrupt
+            # the fresh insertion can be missing a summary the on-disk block
+            # legitimately has — overwriting would destroy honest data.
+            print("  ledger-render-patch: block differs but yday ledger unreadable — left untouched, needs manual look")
+            return 0
+        if not existing_match:
+            print("  ledger-render-patch: marker present but block pattern didn't match — left untouched, needs manual look")
+            return 0
+        # Marker present but content differs from what a fresh, honest render
+        # produces — self-heal (see module docstring "Self-heal on marker mismatch").
+        new_content = BLOCK_PATTERN.sub(lambda m: insertion, content, count=1)
+        with open(args.dayplan, "w", encoding="utf-8") as f:
+            f.write(new_content)
+        print(f"  ledger-render-patch: SELF-HEAL — block for {yday} didn't match a fresh render, overwrote with honest data"
+              + (f" (partial — errors: {'; '.join(errors)})" if errors else ""))
+        return 0
+
+    new_content, n = FOOTER_PATTERN.subn(lambda m: insertion + m.group(0), content, count=1)
+    if n == 0:
+        print("  ledger-render-patch: footer anchor not found — DayPlan structure unexpected, left untouched")
+        return 0
+
+    with open(args.dayplan, "w", encoding="utf-8") as f:
+        f.write(new_content)
+    print(f"  ledger-render-patch: inserted {len(blocks)} section(s) for {yday}/{today_str}"
+          + (f" (partial — errors: {'; '.join(errors)})" if errors else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/seed/strategy/scripts/day-open-pipeline.sh
+++ b/seed/strategy/scripts/day-open-pipeline.sh
@@ -16,6 +16,9 @@ set -uo pipefail
 
 DS_STRATEGY="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IWE="${IWE_ROOT:-$(cd "$DS_STRATEGY/.." && pwd)}"
+# Child patch steps (4.2/4.3) fall back to ~/IWE when IWE_ROOT is unset —
+# a launchd/cron env typically has no IWE_ROOT, so pass the resolved root down.
+export IWE_ROOT="$IWE"
 CONFIG="$DS_STRATEGY/exocortex/day-rhythm-config.yaml"
 # shellcheck source=lib/ledger-path.sh
 . "$DS_STRATEGY/scripts/lib/ledger-path.sh"
@@ -818,6 +821,14 @@ fi
 echo "=== 4.2. Bottleneck patch ==="
 bash "$DS_STRATEGY/scripts/day-open-bottleneck-patch.sh" "$DAYPLAN_PATH" 2>&1 || true
 
+
+# Shared resolver for the deterministic patch steps below (4.3, 4.55-4.57).
+# WP-529 F7 port (peer session 2026-08-21-17): ledger-render imports yaml, so a
+# bare `python3` can be a yaml-less interpreter (same defect class as F6/F9);
+# the stdlib-only patches get the same binary with a soft fallback — a missing
+# resolver must not break steps that never needed PyYAML in the first place.
+_PATCH_PY=$("$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/find-python3.sh" 2>/dev/null) || _PATCH_PY=""
+[ -n "$_PATCH_PY" ] || _PATCH_PY=python3
 # ============================================
 # 4.3. Ledger render (deterministic, AFTER LLM Fill — same reason as 4.2 above:
 # WP-484 Ф16.2 2b). Appends render-open.py's ledger sections (Итоги вчера/Очередь
@@ -829,7 +840,7 @@ bash "$DS_STRATEGY/scripts/day-open-bottleneck-patch.sh" "$DAYPLAN_PATH" 2>&1 ||
 # own docstring for the graceful-degradation design.
 # ============================================
 echo "=== 4.3. Ledger render ==="
-python3 "$DS_STRATEGY/scripts/day-open-ledger-render-patch.py" \
+"$_PATCH_PY" "$DS_STRATEGY/scripts/day-open-ledger-render-patch.py" \
   --dayplan "$DAYPLAN_PATH" \
   --date "$DATE" 2>&1 || true
 
@@ -840,6 +851,49 @@ echo "=== 4.5. Budget patch ==="
 python3 "$DS_STRATEGY/scripts/day-open-budget-patch.py" \
   --dayplan "$DAYPLAN_PATH" \
   --priorities "$DS_STRATEGY/current/priorities.yaml" 2>&1 || true
+
+# ============================================
+# 4.55. Priorities patch (deterministic — WP-484, pilot instruction 16.08: Day
+# Open must never fail to run because of a priorities discrepancy; the finding
+# belongs in the DayPlan itself, not as a commit-blocking exit 1). Writes into
+# «Требует внимания» while the section header is still guaranteed to exist
+# (before archive/sync can touch the file) — same slot pattern as 4.5 above.
+# Ported from the author pipeline (WP-529 F7): resolver-based interpreter, not
+# bare python3 — see _PATCH_PY above.
+# ============================================
+echo "=== 4.55. Priorities patch ==="
+"$_PATCH_PY" "$DS_STRATEGY/scripts/day-open-priorities-patch.py" \
+  --dayplan "$DAYPLAN_PATH" \
+  --priorities "$DS_STRATEGY/current/priorities.yaml" 2>&1 || true
+
+# ============================================
+# 4.56. Close-error patch (deterministic — WP-484 F113: the night runner exports
+# IWE_CLOSE_ERROR instead of stopping before this pipeline when the Close half
+# fails. Empty/unset in every other invocation (manual runs, probes, installs
+# without a night cycle) — no-op then. Same non-blocking pattern as 4.55.
+# ============================================
+echo "=== 4.56. Close-error patch ==="
+"$_PATCH_PY" "$DS_STRATEGY/scripts/day-open-close-error-patch.py" \
+  --dayplan "$DAYPLAN_PATH" \
+  --error "${IWE_CLOSE_ERROR:-}" 2>&1 || true
+
+# ============================================
+# 4.57. Version-check patch (deterministic — WP-484 stage-0 wiring: a stale
+# checkout is a visible finding, not a silent commit block). Template port
+# guard (WP-529 F7, peer consensus 2026-08-21-17): comparing HEAD..origin/main
+# only makes sense when such a remote ref exists. A template/offline install
+# without it is a NORMAL mode, not a pipeline error — diagnose to stderr and
+# move on, never non-zero, never a DayPlan «Требует внимания» entry.
+# ============================================
+echo "=== 4.57. Version-check patch ==="
+if git -C "$DS_STRATEGY" remote get-url origin >/dev/null 2>&1 \
+   && git -C "$DS_STRATEGY" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  "$_PATCH_PY" "$DS_STRATEGY/scripts/day-open-version-check-patch.py" \
+    --dayplan "$DAYPLAN_PATH" \
+    --repo "$DS_STRATEGY" 2>&1 || true
+else
+  echo "version-check: no origin/main to compare against — skipped (comparison context unavailable, normal for template/offline installs)" >&2
+fi
 
 # ============================================
 # 4.6. Sync + archive stale DayPlans (moved ahead of Checks — WP-484 Ф2)

--- a/seed/strategy/scripts/day-open-priorities-patch.py
+++ b/seed/strategy/scripts/day-open-priorities-patch.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SNAPSHOT — synced manually via script-promote.sh from FMT-exocortex-template/scripts/. Do not edit here directly.
+"""Patch DayPlan «Требует внимания» with priorities.yaml discrepancies.
+
+Same detection logic as the two blocking checks in extensions/day-open.checks.md
+(WP-453 missing-from-plan class, phys_hours fallback class) — but writes the
+finding into the DayPlan's own «Требует внимания» section instead of blocking
+the commit. Runs deterministically after LLM Fill, before Checks (same slot as
+day-open-budget-patch.py), so the marker is already staged by the time
+day-open-checks-runner.sh's now-non-blocking versions of these checks run.
+"""
+
+import re
+import sys
+import argparse
+from pathlib import Path
+
+try:
+    import yaml as _yaml
+    _YAML_AVAILABLE = True
+except ImportError:
+    _YAML_AVAILABLE = False
+
+PHYS_HOURS_CEILING = 14.0
+ATTENTION_HEADER_RE = re.compile(r"(<summary><b>Требует внимания</b></summary>\s*\n)")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dayplan", required=True, help="Path to DayPlan .md")
+    p.add_argument("--priorities", required=True, help="Path to priorities.yaml")
+    return p.parse_args()
+
+
+def load_priorities(path):
+    text = Path(path).read_text(encoding="utf-8")
+    if _YAML_AVAILABLE:
+        return _yaml.safe_load(text) or {}
+    # PyYAML unavailable: only the two keys this script reads, same fallback
+    # class as day-open-budget-patch.py's regex path. Scope the dash-items to
+    # the today: block — a bare list regex over the whole file would collect
+    # WP items from ANY other yaml key (cold review 2026-08-21-17, Medium).
+    today_block = re.search(
+        r"^today:\s*\n((?:^[ \t]+-[^\n]*\n?)+)", text, re.MULTILINE
+    )
+    today = (
+        re.findall(r"^\s*-\s*(WP-\d+)", today_block.group(1), re.MULTILINE)
+        if today_block
+        else []
+    )
+    m = re.search(r"^phys_hours:\s*([\d.]+)", text, re.MULTILINE)
+    return {"today": today, "phys_hours": float(m.group(1)) if m else None}
+
+
+def extract_plan_table(dayplan_text):
+    """Same scoping fix as day-open.checks.md (bug-2026-07-01): only the
+    «План на сегодня» table, not the whole file — a WP number can legitimately
+    appear elsewhere (e.g. a cross-reference in another RP's row) without being
+    IN the plan."""
+    lines = dayplan_text.splitlines()
+    out = []
+    in_section = False
+    for line in lines:
+        if "<summary><b>План на сегодня</b></summary>" in line:
+            in_section = True
+            continue
+        if in_section:
+            if "</details>" in line:
+                break
+            if line.startswith("|"):
+                out.append(line)
+    return out
+
+
+def missing_priority_wps(today_wps, plan_table):
+    """Same two-format match as day-open.checks.md (bug-2026-07-16 rewrite):
+    column 3 bare number OR a WP-prefixed number anywhere in that row."""
+    missing = []
+    for wp in today_wps:
+        num = str(wp).replace("WP-", "").strip()
+        found = False
+        for row in plan_table:
+            cells = row.split("|")
+            col3 = cells[3].strip() if len(cells) > 3 else ""
+            if col3 == num or re.search(rf"WP-{re.escape(num)}(?!\d)", row):
+                found = True
+                break
+        if not found:
+            missing.append(f"WP-{num}")
+    return missing
+
+
+def phys_hours_finding(priorities):
+    """Returns a warning string, or None if phys_hours is set and sane."""
+    val = priorities.get("phys_hours")
+    if val is None:
+        return "phys_hours не задан в priorities.yaml — физ. часы будут посчитаны с fallback 1.0x (не прогноз, а копия суммы РП)"
+    if float(val) > PHYS_HOURS_CEILING:
+        return f"phys_hours={val} превышает потолок пилота ({PHYS_HOURS_CEILING:.0f}ч) — физически маловероятно для одного дня"
+    return None
+
+
+def append_attention_lines(text, findings):
+    lines = "".join(f"- ⚠️ {f}\n" for f in findings)
+    patched, n = ATTENTION_HEADER_RE.subn(r"\1" + lines, text, count=1)
+    return patched if n else text
+
+
+def main():
+    args = parse_args()
+    dayplan = Path(args.dayplan)
+    text = dayplan.read_text(encoding="utf-8")
+    priorities = load_priorities(args.priorities)
+
+    findings = []
+
+    today_wps = priorities.get("today") or []
+    plan_table = extract_plan_table(text)
+    missing = missing_priority_wps(today_wps, plan_table)
+    if missing:
+        findings.append(
+            f"{', '.join(missing)} из priorities.yaml отсутствует в таблице «План на сегодня»"
+        )
+
+    phys_finding = phys_hours_finding(priorities)
+    if phys_finding:
+        findings.append(phys_finding)
+
+    if not findings:
+        print("priorities-patch: no discrepancies found", file=sys.stderr)
+        return
+
+    patched = append_attention_lines(text, findings)
+    if patched == text:
+        print(
+            f"priorities-patch: {len(findings)} finding(s) but «Требует внимания» header not found — cannot patch, findings lost",
+            file=sys.stderr,
+        )
+        return
+
+    dayplan.write_text(patched, encoding="utf-8")
+    print(f"priorities-patch: {len(findings)} finding(s) written to «Требует внимания»", file=sys.stderr)
+    for f in findings:
+        print(f"  - {f}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/seed/strategy/scripts/day-open-version-check-patch.py
+++ b/seed/strategy/scripts/day-open-version-check-patch.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# SNAPSHOT — synced manually via script-promote.sh from FMT-exocortex-template/scripts/. Do not edit here directly.
+"""Patch DayPlan «Требует внимания» when this host's code is stale vs origin/main.
+
+Same non-blocking-finding pattern as day-open-close-error-patch.py: a stale
+checkout must not silently pass — WP-484 Ф124 plan, Этап 0 line 1, wiring 3б
+(single-host scope, no multi-host registry — that part stays open per the
+2026-08-20-48 peer-session consensus).
+"""
+
+import re
+import subprocess
+import sys
+import argparse
+from pathlib import Path
+
+ATTENTION_HEADER_RE = re.compile(r"(<summary><b>Требует внимания</b></summary>\s*\n)")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dayplan", required=True, help="Path to DayPlan .md")
+    p.add_argument("--repo", required=True, help="Path to a git checkout to compare HEAD against origin/main")
+    return p.parse_args()
+
+
+def local_head_is_stale(repo):
+    """True if origin/main has commits this checkout's HEAD doesn't."""
+    result = subprocess.run(
+        ["git", "-C", repo, "rev-list", "--count", "HEAD..origin/main"],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        print(f"version-check-patch: git rev-list failed — {result.stderr.strip()}", file=sys.stderr)
+        return None
+    behind = int(result.stdout.strip() or "0")
+    return behind if behind > 0 else 0
+
+
+def append_attention_line(text, behind_count):
+    line = f"- ⚠️ Этот хост отстал от общего репозитория на {behind_count} коммит(ов) — код может быть устаревшим.\n"
+    patched, n = ATTENTION_HEADER_RE.subn(r"\1" + line, text, count=1)
+    return patched if n else text
+
+
+def main():
+    args = parse_args()
+    behind = local_head_is_stale(args.repo)
+    if behind is None:
+        return  # git call failed — already logged, no-op rather than block Day Open
+    if behind == 0:
+        print("version-check-patch: host is current with origin/main — no-op", file=sys.stderr)
+        return
+
+    dayplan = Path(args.dayplan)
+    text = dayplan.read_text(encoding="utf-8")
+    patched = append_attention_line(text, behind)
+    if patched == text:
+        print(
+            f"version-check-patch: stale by {behind} commits but «Требует внимания» header not found — cannot patch, finding lost",
+            file=sys.stderr,
+        )
+        return
+
+    dayplan.write_text(patched, encoding="utf-8")
+    print(f"version-check-patch: written to «Требует внимания» — stale by {behind} commits", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/seed/strategy/scripts/lib/find-python3.sh
+++ b/seed/strategy/scripts/lib/find-python3.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SNAPSHOT — synced manually via script-promote.sh from FMT-exocortex-template/scripts/. Do not edit here directly.
+# find-python3.sh — single Python resolver for template scripts (WP-529 F6,
+# issues #453/#463, Evgenii 18.08).
+#
+# Contract (peer-session 2026-08-19-01, codex В1): standalone executable, not a
+# sourced lib. stdout = path to a python3 whose `import yaml` succeeds, exit 0.
+# No candidate → exit 1 with actionable diagnostics on stderr. Callers use
+# command substitution and MUST check the exit code, failing with an explicit
+# dependency error instead of a misleading domain error ("calendar_ids не
+# найдены" while the real cause was a missing PyYAML).
+#
+# Before this file the same _find_python3() lived in three diverging copies
+# (server-calendar.sh, server-news.sh, active-wp-sweep.sh); none knew
+# /opt/homebrew/bin/python3, so stock macOS Apple Silicon always fell through
+# to a yaml-less interpreter.
+set -u
+
+candidates=(
+    python3
+    /opt/homebrew/bin/python3
+    /usr/local/bin/python3
+    /usr/bin/python3
+)
+
+for cand in "${candidates[@]}"; do
+    resolved=$(command -v "$cand" 2>/dev/null) || continue
+    if "$resolved" -c "import yaml" >/dev/null 2>&1; then
+        printf '%s\n' "$resolved"
+        exit 0
+    fi
+done
+
+# Nix: no hardcoded /nix/store hash (they rot on every nixos-rebuild), scan is
+# the last resort. NOTE: no `find | while` pipeline here — the loop would run
+# in a subshell and `exit` would not terminate the script (the historical bug
+# that made this branch dead code in server-calendar.sh).
+if [ -d /nix/store ]; then
+    while IFS= read -r cand; do
+        if "$cand" -c "import yaml" >/dev/null 2>&1; then
+            printf '%s\n' "$cand"
+            exit 0
+        fi
+    done < <(find /nix/store -maxdepth 3 -name python3 -path "*env*/bin/*" 2>/dev/null)
+fi
+
+{
+    echo "ERROR: python3 с библиотекой PyYAML не найден (проверены: PATH, /opt/homebrew, /usr/local, /usr/bin, Nix)."
+    echo "PyYAML — заявленная зависимость шаблона (requirements.txt). Установка:"
+    echo "  - macOS (Homebrew): pip3 install pyyaml   (python3 из brew уже содержит pip3)"
+    echo "  - Debian/Ubuntu:    sudo apt install python3-yaml"
+    echo "  - универсально:     pip3 install pyyaml"
+} >&2
+exit 1

--- a/seed/strategy/scripts/lib/ledger-path.sh
+++ b/seed/strategy/scripts/lib/ledger-path.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# SNAPSHOT — synced manually via script-promote.sh from FMT-exocortex-template/scripts/. Do not edit here directly.
+# ledger-path.sh — single point of truth for machine/ledger/ file paths
+# (WP-484, 31.07: pilot decision to move flat day-/week-/month-*.yaml files
+# into a year/month hierarchy so the folder doesn't grow unbounded forever).
+# Source, don't execute: `. "$(dirname "${BASH_SOURCE[0]}")/lib/ledger-path.sh"`
+#
+# Was 24 hand-written path constructions across 14 scripts (day-<period>.yaml
+# flat in one directory) — the P2 threshold for extraction, same principle
+# already applied to escape_json() in preclose-helpers.sh.
+
+# ledger_path <scale> <period> [ledger-root, default $IWE_LEDGER_DIR] — prints
+# the full hierarchical path, creating parent directories so callers can
+# write immediately without a separate mkdir -p.
+#   day   period=YYYY-MM-DD -> <root>/day/YYYY/MM/day-YYYY-MM-DD.yaml
+#   week  period=YYYY-Wnn   -> <root>/week/YYYY/week-YYYY-Wnn.yaml
+#   month period=YYYY-MM    -> <root>/month/YYYY/month-YYYY-MM.yaml
+ledger_path() {
+  local scale="$1" period="$2" root="${3:-$IWE_LEDGER_DIR}"
+  local path
+  path="$(ledger_path_rel "$scale" "$period")" || return 1
+  path="$root/$path"
+  mkdir -p "$(dirname "$path")"
+  echo "$path"
+}
+
+# ledger_path_rel <scale> <period> — same suffix as ledger_path(), WITHOUT the
+# root prefix and without the mkdir side effect. For callers that need a
+# repo-relative string (git show <rel-path>, a pointer field inside a ledger
+# event's own JSON payload) where creating a directory would be wrong or
+# pointless — e.g. day-open-pipeline.sh reads a PAST day's ledger via `git
+# show HEAD:<path>` before it has cd'd into the repo at all.
+ledger_path_rel() {
+  # Separate statements, not `local a="$1" b="$2" c="${b:...}"` in one line —
+  # bash 3.2 (macOS default, Apple GPLv3 licensing freeze) doesn't reliably see
+  # an earlier assignment in the SAME `local` statement when a later one reads
+  # it (live-reproduced: year came out empty). Same class of quirk already
+  # documented elsewhere in this codebase for bash 3.2.
+  local scale="$1"
+  local period="$2"
+  local year="${period:0:4}"
+  case "$scale" in
+    day)   echo "day/$year/${period:5:2}/day-$period.yaml" ;;
+    week)  echo "week/$year/week-$period.yaml" ;;
+    month) echo "month/$year/month-$period.yaml" ;;
+    *) echo "ledger_path_rel: недопустимый scale '$scale' (day|week|month)" >&2; return 1 ;;
+  esac
+}

--- a/seed/strategy/scripts/lib/ledger_path.py
+++ b/seed/strategy/scripts/lib/ledger_path.py
@@ -1,0 +1,62 @@
+# SNAPSHOT — synced manually via script-promote.sh from FMT-exocortex-template/scripts/. Do not edit here directly.
+"""ledger_path.py — Python twin of lib/ledger-path.sh (WP-484, 31.07: same
+year/month hierarchy migration for machine/ledger/, kept in lock-step by hand
+since there are only two languages here, not a build step worth adding for two files).
+"""
+
+import os
+from typing import Optional
+
+_SCALE_TEMPLATES = {
+    "day": "day/{year}/{month}/day-{period}.yaml",
+    "week": "week/{year}/week-{period}.yaml",
+    "month": "month/{year}/month-{period}.yaml",
+}
+
+
+def ledger_path_rel(scale: str, period: str) -> str:
+    """Suffix only (no root, no mkdir) -- for existence checks against multiple
+    roots (ledger_dir vs archive_dir) or a git-relative string, where creating
+    a directory would be wasteful or wrong.
+
+    day   period=YYYY-MM-DD -> day/YYYY/MM/day-YYYY-MM-DD.yaml
+    week  period=YYYY-Wnn   -> week/YYYY/week-YYYY-Wnn.yaml
+    month period=YYYY-MM    -> month/YYYY/month-YYYY-MM.yaml
+    """
+    template = _SCALE_TEMPLATES.get(scale)
+    if template is None:
+        raise ValueError(f"ledger_path_rel: недопустимый scale {scale!r} (day|week|month)")
+    return template.format(year=period[:4], month=period[5:7], period=period)
+
+
+def ledger_path(scale: str, period: str, root: str) -> str:
+    """Full hierarchical path for a ledger file; creates parent dirs."""
+    path = os.path.join(root, ledger_path_rel(scale, period))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    return path
+
+
+def resolve_ledger_path(
+    scale: str,
+    period: str,
+    active_root: str,
+    archive_root: Optional[str] = None,
+) -> str:
+    """Return the period's one canonical readable path without creating anything.
+
+    An archived file is used only when the active copy is absent. Two existing copies
+    are split-brain drift, not an arbitrary precedence decision.
+    """
+    relative = ledger_path_rel(scale, period)
+    active_path = os.path.join(active_root, relative)
+    archive_path = os.path.join(archive_root, relative) if archive_root else None
+    if archive_path and os.path.exists(active_path) and os.path.exists(archive_path):
+        raise RuntimeError(
+            f"ledger drift for {scale} {period}: both active and archived files exist "
+            f"({active_path}; {archive_path})"
+        )
+    if os.path.exists(active_path):
+        return active_path
+    if archive_path and os.path.exists(archive_path):
+        return archive_path
+    return active_path

--- a/seed/strategy/scripts/lib/wp_inbox.py
+++ b/seed/strategy/scripts/lib/wp_inbox.py
@@ -1,0 +1,32 @@
+# SNAPSHOT — synced manually via script-promote.sh from FMT-exocortex-template/scripts/. Do not edit here directly.
+"""WP inbox card discovery (WP-434 convention: one WP = one folder).
+
+A WP card lives at the canonical folder path ``inbox/WP-N/WP-N.md`` or, for
+legacy/transition stragglers, as a flat file ``inbox/WP-N*.md``. Readers that
+scan the inbox for WP frontmatter must look at BOTH levels — a flat-only glob
+silently drops folder cards (the regression that hid WP-426 from
+active-wp-sweep and zeroed Day Open WP facts after the WP-434 migration).
+
+Single source for this two-level traversal so every reader stays consistent.
+"""
+
+import glob
+import os
+
+
+def wp_card_paths(base_dir):
+    """Paths of WP card files under ``base_dir`` — flat plus folder-canonical.
+
+    - Flat: ``base_dir/WP-*.md`` (legacy cards and non-numbered WP-INCIDENT-* ).
+    - Folder: ``base_dir/WP-N/WP-N.md`` — the canonical main file only, never
+      sub-files inside the folder.
+
+    Returns a list of string paths (callers wrap in ``pathlib.Path`` as needed).
+    """
+    paths = glob.glob(os.path.join(base_dir, "WP-*.md"))
+    for folder in glob.glob(os.path.join(base_dir, "WP-*", "")):
+        name = os.path.basename(os.path.normpath(folder))  # "WP-7"
+        main = os.path.join(folder, name + ".md")
+        if os.path.isfile(main):
+            paths.append(main)
+    return paths

--- a/setup/test-day-open-delivery-closure.sh
+++ b/setup/test-day-open-delivery-closure.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# test-day-open-delivery-closure.sh — WP-529 F7 acceptance test for the Day Open
+# delivery contract: every runtime dependency of scripts/day-open-pipeline.sh
+# must resolve inside the delivery root (template scripts/ + seed mirror), with
+# transitive closure over python imports and shell sources — not just the files
+# someone remembered to list. Spec: peer sessions 2026-08-20-42 (5-point fixture
+# spec) and 2026-08-21-17 (baseline->promote->green protocol, codex amendments:
+# dynamic call sites, +x/shebang, manifest duplicates, extension-graph strict
+# xfail until ArchGate Q1).
+#
+# Bash 3.2 compatible on purpose (macOS /bin/bash): no declare -A, no mapfile.
+#
+# Usage: bash setup/test-day-open-delivery-closure.sh
+
+set -uo pipefail
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SELF_DIR")"
+PIPELINE="$REPO_ROOT/scripts/day-open-pipeline.sh"
+SEED_SCRIPTS="$REPO_ROOT/seed/strategy/scripts"
+MANIFEST="$REPO_ROOT/update-manifest.json"
+
+FAIL_COUNT=0
+PASS_COUNT=0
+XFAIL_COUNT=0
+fail() { echo "  ❌ FAIL: $*" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "  ✅ PASS: $*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+xfail() { echo "  ⏸  XFAIL (expected until ArchGate): $*"; XFAIL_COUNT=$((XFAIL_COUNT + 1)); }
+
+[ -f "$PIPELINE" ] || { echo "FATAL: $PIPELINE not found" >&2; exit 2; }
+
+# --- 1. Closure of $DS_STRATEGY/scripts/ references in the pipeline ----------
+# Dynamic extraction (codex amendment: no hand-kept list): every literal
+# $DS_STRATEGY/scripts/<path> the pipeline mentions, in any call form (direct,
+# bash -c, heredoc) — the literal is what delivery must satisfy.
+echo "=== 1. Pipeline references resolve inside the delivery root ==="
+STRATEGY_REFS=$(grep -o '\$DS_STRATEGY/scripts/[a-zA-Z0-9._/-]*' "$PIPELINE" | sed 's|^\$DS_STRATEGY/||' | sort -u)
+# An empty extraction means the regex no longer matches the pipeline (variable
+# renamed, quoting changed) — every section below would loop zero times and the
+# test would pass while checking nothing (cold review 2026-08-21-17, High).
+if [ -z "$STRATEGY_REFS" ]; then
+  fail "no \$DS_STRATEGY/scripts/ references extracted from pipeline — extraction regex broken"
+fi
+for rel in $STRATEGY_REFS; do
+  f="$REPO_ROOT/$rel"
+  if [ -f "$f" ]; then
+    pass "delivered: $rel"
+  else
+    fail "referenced by pipeline but NOT delivered in template: $rel"
+    continue
+  fi
+  case "$rel" in
+    *.sh)
+      [ -x "$f" ] && pass "executable bit: $rel" || fail "missing +x: $rel"
+      head -1 "$f" | grep -q '^#!' && pass "shebang: $rel" || fail "missing shebang: $rel"
+      ;;
+  esac
+  # Seed mirror: the pipeline itself ships in seed for fresh installs, so every
+  # $DS_STRATEGY-relative dependency must ship there too (2026-08-20-42, theme 4:
+  # update path and seed are two separate delivery axes).
+  if [ -f "$SEED_SCRIPTS/$rel" ] || [ -f "$SEED_SCRIPTS/${rel#scripts/}" ]; then
+    pass "seed mirror: $rel"
+  else
+    fail "not mirrored into seed/strategy/: $rel"
+  fi
+done
+
+# --- 2. Transitive closure: python imports and shell sources ------------------
+echo "=== 2. Transitive closure (imports / sources) ==="
+LIB_PY_MODULES=""
+if [ -d "$REPO_ROOT/scripts/lib" ]; then
+  LIB_PY_MODULES=$(ls "$REPO_ROOT/scripts/lib"/*.py 2>/dev/null | sed 's|.*/||; s|\.py$||')
+fi
+for rel in $STRATEGY_REFS; do
+  f="$REPO_ROOT/$rel"
+  [ -f "$f" ] || continue
+  case "$rel" in
+    *.py)
+      # Local module imports (scripts/lib/*.py style: from X import / import X).
+      IMPORTS=$(grep -E '^[[:space:]]*(from|import)[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*' "$f" | sed -E 's/^[[:space:]]*(from|import)[[:space:]]+([a-zA-Z_][a-zA-Z0-9_]*).*/\2/' | sort -u)
+      for mod in $IMPORTS; do
+        # Only local lib modules are delivery obligations; stdlib/3rd-party are not.
+        libfile="$REPO_ROOT/scripts/lib/$mod.py"
+        if echo "$IMPORTS" | grep -q "^$mod$" && [ -f "$libfile" ]; then
+          pass "local import satisfied: $rel -> lib/$mod.py"
+          [ -f "$SEED_SCRIPTS/lib/$mod.py" ] && pass "seed mirror: lib/$mod.py" || fail "lib/$mod.py not mirrored into seed"
+        else
+          # Missing local module is only a failure if some scripts/lib/<mod>.py
+          # exists nowhere AND the import is known-local (wp_inbox, ledger_path
+          # naming convention: module files we deliver under scripts/lib/).
+          case "$mod" in
+            wp_inbox|ledger_path)
+              [ -f "$libfile" ] || fail "local import NOT delivered: $rel imports $mod (expected scripts/lib/$mod.py)"
+              ;;
+          esac
+        fi
+      done
+      ;;
+    *.sh)
+      SOURCES=$(grep -oE '(source|\.)[[:space:]]+"?\$?[A-Za-z_{}]*/?(scripts/)?lib/[a-zA-Z0-9._-]+\.sh' "$f" | grep -o 'lib/[a-zA-Z0-9._-]*\.sh' | sort -u)
+      for libref in $SOURCES; do
+        if [ -f "$REPO_ROOT/scripts/$libref" ]; then
+          pass "shell source satisfied: $rel -> $libref"
+          [ -f "$SEED_SCRIPTS/$libref" ] && pass "seed mirror: $libref" || fail "$libref not mirrored into seed"
+        else
+          fail "shell source NOT delivered: $rel sources $libref"
+        fi
+      done
+      ;;
+  esac
+done
+
+# --- 2b. Pipeline-own dependencies invisible to $DS_STRATEGY extraction -------
+# find-python3.sh is sourced via $(dirname BASH_SOURCE)/lib/ — not a
+# $DS_STRATEGY literal, so section 1 never sees it; without this check its
+# deletion would go unnoticed (RESOLVED_PY silently falls back to python3).
+echo "=== 2b. Resolver delivery (BASH_SOURCE-relative dependency) ==="
+if [ -f "$REPO_ROOT/scripts/lib/find-python3.sh" ] && [ -x "$REPO_ROOT/scripts/lib/find-python3.sh" ]; then
+  pass "delivered + executable: scripts/lib/find-python3.sh"
+else
+  fail "scripts/lib/find-python3.sh missing or not executable"
+fi
+[ -f "$SEED_SCRIPTS/lib/find-python3.sh" ] && pass "seed mirror: lib/find-python3.sh" || fail "lib/find-python3.sh not mirrored into seed"
+if [ -f "$MANIFEST" ]; then
+  n=$(grep -c '"scripts/lib/find-python3.sh"' "$MANIFEST") || true
+  [ "$n" -eq 1 ] && pass "manifest exactly once: scripts/lib/find-python3.sh" || fail "manifest entries for scripts/lib/find-python3.sh: $n (expected 1)"
+fi
+
+# --- 3. Entry points run from a foreign cwd with a clean PYTHONPATH -----------
+echo "=== 3. Foreign-cwd smoke (clean PYTHONPATH) ==="
+RESOLVED_PY=""
+[ -x "$REPO_ROOT/scripts/lib/find-python3.sh" ] && RESOLVED_PY=$("$REPO_ROOT/scripts/lib/find-python3.sh" 2>/dev/null) || true
+[ -n "$RESOLVED_PY" ] || RESOLVED_PY="python3"
+SMOKE_DIR="/tmp/iwe-dayopen-closure-smoke-$$"
+mkdir -p "$SMOKE_DIR"
+for rel in $STRATEGY_REFS; do
+  f="$REPO_ROOT/$rel"
+  [ -f "$f" ] || continue
+  case "$rel" in
+    scripts/day-open-*.py)
+      if (cd "$SMOKE_DIR" && PYTHONPATH= "$RESOLVED_PY" "$f" --help >/dev/null 2>&1); then
+        pass "runs from foreign cwd: $rel --help"
+      else
+        fail "broken from foreign cwd (import/path error?): $rel --help"
+      fi
+      ;;
+  esac
+done
+rm -rf "$SMOKE_DIR"
+
+# --- 4. Manifest: each delivered closure file present, no duplicate entries ---
+echo "=== 4. update-manifest.json coverage ==="
+if [ -f "$MANIFEST" ]; then
+  for rel in $STRATEGY_REFS; do
+    [ -f "$REPO_ROOT/$rel" ] || continue
+    n=$(grep -c "\"$rel\"" "$MANIFEST") || true
+    if [ "$n" -eq 1 ]; then
+      pass "manifest exactly once: $rel"
+    elif [ "$n" -eq 0 ]; then
+      fail "missing from manifest: $rel"
+    else
+      fail "duplicate manifest entries ($n): $rel"
+    fi
+  done
+else
+  fail "update-manifest.json not found"
+fi
+
+# --- 5. Extension graph: strict xfail until ArchGate question 1 ---------------
+# The before/core/after/checks hook order is NOT implemented yet by design —
+# ArchGate question 1 (WP-529 F7, peer session 2026-08-20-42 §4). If a dispatcher
+# appears, this XPASS must fail loudly so the test is consciously updated with
+# the decided contract, never silently blessed (no unnoticed XPASS).
+echo "=== 5. Extension graph (ArchGate Q1) ==="
+if grep -qE 'load-extensions\.sh[[:space:]]+day-open|extension-graph' "$PIPELINE"; then
+  fail "XPASS: extension dispatcher appeared in pipeline — update this test per ArchGate Q1 decision before merging"
+else
+  xfail "extension-graph before/core/after/checks not dispatched by pipeline — ArchGate Q1 pending"
+fi
+
+# --- 6. Workspace-root references: inventory only (ArchGate question 2) -------
+echo "=== 6. \$IWE-root references (out of contract until ArchGate Q2) ==="
+grep -o '\$IWE/scripts/[a-zA-Z0-9._/-]*' "$PIPELINE" | sort -u | sed 's/^/  ℹ️  /'
+
+echo
+echo "Result: $PASS_COUNT PASS, $FAIL_COUNT FAIL, $XFAIL_COUNT XFAIL"
+[ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1

--- a/setup/test-update-release-channel.sh
+++ b/setup/test-update-release-channel.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# test-update-release-channel.sh — WP-529 F7 follow-up (pilot decision
+# 2026-08-21): update.sh delivers the LAST PUBLISHED RELEASE by default, not
+# the moving main — an external user proved the old contract shipped red,
+# unreleased main while still reporting the last release's version number.
+#
+# Extracts resolve_delivery_ref() out of the real update.sh (same technique as
+# scripts/tests/lib/extract-update-download-batch.sh) and drives it with a
+# stubbed curl: no network, each case asserts what RAW_BASE gets pinned to.
+#
+# Bash 3.2 compatible. Usage: bash setup/test-update-release-channel.sh
+
+set -uo pipefail
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SELF_DIR")"
+UPDATE_SH="$REPO_ROOT/update.sh"
+
+FAIL_COUNT=0
+PASS_COUNT=0
+fail() { echo "  ❌ FAIL: $*" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "  ✅ PASS: $*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+
+FUNCS=$(mktemp)
+trap 'rm -f "$FUNCS"' EXIT
+awk '
+    /^resolve_delivery_ref\(\) \{$/ { found=1 }
+    found { print }
+    found && /^\}$/ { exit }
+' "$UPDATE_SH" > "$FUNCS"
+[ -s "$FUNCS" ] || { echo "FATAL: resolve_delivery_ref extraction is empty — marker no longer matches update.sh" >&2; exit 2; }
+
+TAG_SHA="1111111111111111111111111111111111111111"
+MAIN_SHA="2222222222222222222222222222222222222222"
+
+# run_case CHANNEL HAS_RELEASES HAS_PY -> prints resulting RAW_BASE + output
+run_case() {
+    local channel="$1" has_releases="$2" has_py="$3"
+    (
+        set -uo pipefail
+        REPO="owner/tmpl"
+        BRANCH="main"
+        API_BASE="https://api.github.com/repos/$REPO"
+        RAW_BASE="https://raw.githubusercontent.com/$REPO/$BRANCH"
+        CURL_BASE_OPTS="--max-time 2"
+        _CURL_SSL_OPT=""
+        UPDATE_CHANNEL="$channel"
+        PY_BIN="$(command -v python3 || echo python3)"
+        HAS_RELEASES="$has_releases"
+        HAS_PY="$has_py"
+        py_available() { [ "$HAS_PY" = "yes" ]; }
+        curl() {
+            local url=""
+            for a in "$@"; do case "$a" in http*) url="$a" ;; esac; done
+            case "$url" in
+                */releases/latest)
+                    [ "$HAS_RELEASES" = "yes" ] || return 22
+                    printf '{"tag_name": "v9.9.9", "name": "v9.9.9"}\n' ;;
+                */commits/v9.9.9) printf '{"sha": "%s"}\n' "$TAG_SHA" ;;
+                */commits/main)   printf '{"sha": "%s"}\n' "$MAIN_SHA" ;;
+                *) return 22 ;;
+            esac
+        }
+        # shellcheck disable=SC1090
+        . "$FUNCS"
+        resolve_delivery_ref
+        echo "RAW_BASE=$RAW_BASE"
+    )
+}
+
+echo "=== 1. release channel (default): pinned to the release tag's SHA ==="
+OUT=$(run_case release yes yes)
+echo "$OUT" | grep -q "RAW_BASE=.*/$TAG_SHA$" && pass "RAW_BASE pinned to release SHA" || fail "expected release SHA pin, got: $OUT"
+echo "$OUT" | grep -q "релиз v9.9.9" && pass "announces the release tag" || fail "no release announcement: $OUT"
+
+echo "=== 2. release channel, no releases published: explicit fallback to main ==="
+OUT=$(run_case release no yes)
+echo "$OUT" | grep -q "RAW_BASE=.*/$MAIN_SHA$" && pass "falls back to pinned main SHA" || fail "expected main fallback, got: $OUT"
+echo "$OUT" | grep -q "Не удалось определить последний релиз" && pass "fallback is announced, not silent" || fail "silent fallback: $OUT"
+
+echo "=== 3. IWE_UPDATE_CHANNEL=main: the old moving-branch contract, pinned ==="
+OUT=$(run_case main yes yes)
+echo "$OUT" | grep -q "RAW_BASE=.*/$MAIN_SHA$" && pass "main channel pins main SHA" || fail "expected main pin, got: $OUT"
+echo "$OUT" | grep -q "релиз" && fail "main channel must not consult releases: $OUT" || pass "releases API not consulted on main channel"
+
+echo "=== 4. release channel without python3: pinned to the tag itself ==="
+OUT=$(run_case release yes no)
+echo "$OUT" | grep -q "RAW_BASE=.*/v9.9.9$" && pass "RAW_BASE pinned to tag without python" || fail "expected tag pin, got: $OUT"
+
+echo
+echo "Result: $PASS_COUNT PASS, $FAIL_COUNT FAIL"
+[ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1

--- a/setup/validate-template.sh
+++ b/setup/validate-template.sh
@@ -291,7 +291,7 @@ elif [ "$MODE" = "staged" ]; then
     # scripts/lib/find-python3.sh: sanctioned exception (WP-529 F6, #453/#463) —
     # the resolver's whole job is enumerating STANDARD system python locations
     # (/opt/homebrew is stock macOS Apple Silicon), not an author-machine leak.
-    count=$(hardcode_scan_staged '/opt/homebrew' 'README\.md|PLATFORM-COMPAT\.md|validate-template\.yml|/usr/local/bin.*:/opt/homebrew' "$TMPDIR_CHECK3_HITS_FILE" '^scripts/lib/find-python3\.sh$|^scripts/tests/test_issue_463_setup_reuses_resolved_python3\.sh$')
+    count=$(hardcode_scan_staged '/opt/homebrew' 'README\.md|PLATFORM-COMPAT\.md|validate-template\.yml|/usr/local/bin.*:/opt/homebrew' "$TMPDIR_CHECK3_HITS_FILE" '^scripts/lib/find-python3\.sh$|^seed/strategy/scripts/lib/find-python3\.sh$|^scripts/tests/test_issue_463_setup_reuses_resolved_python3\.sh$')
     if [ "$count" -gt 0 ]; then
         echo "FAIL ($count hits)"
         head -3 "$TMPDIR_CHECK3_HITS_FILE" || true

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2621,7 +2621,7 @@
     },
     {
       "path": "setup/validate-template.sh",
-      "sha256": "16e556c6ca58ef0bcd138f71a76569c161e498278cd649c58113dddf95163d64"
+      "sha256": "c681cd7ce3217b466e578608b855ac50ad352b8c5542a8847fd36ec1aeea93dc"
     },
     {
       "path": "shared/rubrics/form-089.yaml",

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2641,7 +2641,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "a0e1a18ef40ca37c54b9897bff7cd83475232e2abd6b5ea808d14cee486bcd99"
+      "sha256": "2ffe40bd30d55c5816a4e65cf6b288ca04fcb087f30bcde794865bf5e94bdab7"
     }
   ],
   "excluded_paths": [
@@ -2723,6 +2723,7 @@
     "setup/test-detectors.sh",
     "setup/test-update-edge-cases.sh",
     "setup/test-update-issue-226.sh",
+    "setup/test-update-release-channel.sh",
     "setup/ux-walkthrough-prompt.md"
   ],
   "deprecated_files": [

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -657,7 +657,7 @@
     },
     {
       "path": "CHANGELOG.md",
-      "sha256": "9e14f11e65d250442261d94cd181c41cdc97b6b02173b36d257d793c7648240f"
+      "sha256": "00fcd62b44a3436cdf16f81d9fce2f5333d656882ea294454c0895d2c1cfe124"
     },
     {
       "path": "CLAUDE.md",
@@ -1984,6 +1984,10 @@
       "sha256": "1356efd3881354be0417024145922259752c741a6445531d24a73c24a2ecb333"
     },
     {
+      "path": "scripts/day-open-bottleneck-patch.sh",
+      "sha256": "9050b6df2664f3683b71be868b2c17a0c85e36ccb64d1d847b09ea7a0934e4d7"
+    },
+    {
       "path": "scripts/day-open-budget-patch.py",
       "sha256": "c02cc64e6c108eca4aaed8e7fecd7d6da36b81ac5ef2a27a70ba61a9a28720cc"
     },
@@ -1992,16 +1996,28 @@
       "sha256": "81bbf1810e8e34c710d9bc9b28a93d5cbae7640feb66ded888bfdae1c20b0abd"
     },
     {
+      "path": "scripts/day-open-close-error-patch.py",
+      "sha256": "83d32007bd512f80032471eebff89adace920625e689980c0e847271176b13a6"
+    },
+    {
+      "path": "scripts/day-open-ledger-render-patch.py",
+      "sha256": "395224010927ec5dd5a2625b6c99f58c27045a5dd6bd7090acc0919c4841b90b"
+    },
+    {
       "path": "scripts/day-open-llm-fill.py",
       "sha256": "ace948428d1e5f797c9fc70333971541394fee9646b389b3548d51b78fa9eb0f"
     },
     {
       "path": "scripts/day-open-pipeline.sh",
-      "sha256": "94dbb4cae8ca368d640d66f3f429ede706229f951fe6f9cbb4cd9891825c4b4c"
+      "sha256": "dd1f1c5bdd8bf14106ba1de7063dd4bb9a8f97c1c1b0d7c9a574f1f2ea346189"
     },
     {
       "path": "scripts/day-open-preflight.sh",
       "sha256": "ff38d44cfb2aad74a7b4b675443a630234eb0fe12cbcceacca1ae8ce47f564d1"
+    },
+    {
+      "path": "scripts/day-open-priorities-patch.py",
+      "sha256": "65b036a83e164a0bbeb9b8cc421c4c00f1646d7284bdc0879ae551fc0338a872"
     },
     {
       "path": "scripts/day-open-scaffold.sh",
@@ -2014,6 +2030,10 @@
     {
       "path": "scripts/day-open-smoke.sh",
       "sha256": "fc7780833a9aacb15cc104c61f8e2ca974577a0f70e35fdeb0d037cebce771a7"
+    },
+    {
+      "path": "scripts/day-open-version-check-patch.py",
+      "sha256": "4324e682ec690e2ef565f7c99ba580e5d80556bccb73d36ca39b8ee096a2decf"
     },
     {
       "path": "scripts/external-tracker.py",
@@ -2074,6 +2094,10 @@
     {
       "path": "scripts/hot-files.list",
       "sha256": "19780ebdac77af24e345d17a1e9799e5dd3db56c97cd50dd53001860d0e3cfe2"
+    },
+    {
+      "path": "scripts/install-hooks.sh",
+      "sha256": "426472dc6b3e6a0999b075b8ffc64b33bbc3dd68d08a06df7eecc035703c2ad9"
     },
     {
       "path": "scripts/iwe-agent-dispatcher.py",
@@ -2180,6 +2204,10 @@
       "sha256": "0e4ebc302e7a8819af2e71c8643887bdc887fb87d06d865d27258c7c5482fece"
     },
     {
+      "path": "scripts/lib/ledger_path.py",
+      "sha256": "864b0352e097e767b8ed27001b1750cfb507b191aeff04f9063318e821068bc4"
+    },
+    {
       "path": "scripts/lib/network-wait.sh",
       "sha256": "beefa7845cd7d386a0b272bc147a01c0223211cf574dfc95054533461d191ea4"
     },
@@ -2190,6 +2218,10 @@
     {
       "path": "scripts/lib/telegram.sh",
       "sha256": "4c5c0546b87a7bbe6dbff6af7ca011c561a1c2f5a2e5db4c4fedcd183bc9de3e"
+    },
+    {
+      "path": "scripts/lib/wp_inbox.py",
+      "sha256": "c22ac737ed5a35131f0ed45518f071deaa3c89c0e100a85d8b9114250210ec6d"
     },
     {
       "path": "scripts/llm-proxy-launcher.sh",
@@ -2686,6 +2718,7 @@
     "setup/promote-fixtures/sample-skill/scripts/sample-tool.sh",
     "setup/release-audit-prompt.md",
     "setup/smoke-test-fresh-install.sh",
+    "setup/test-day-open-delivery-closure.sh",
     "setup/test-delivery-route-label.sh",
     "setup/test-detectors.sh",
     "setup/test-update-edge-cases.sh",

--- a/update.sh
+++ b/update.sh
@@ -30,6 +30,12 @@ trap 'echo "ОШИБКА: update.sh прервался на строке ${LINEN
 VERSION="2.4.1"  # fix (WP-401): deprecated-file removal now checks is_protected_user_file() — a protected file (e.g. sessions/00-index.md) listed in deprecated_files by mistake could previously be deleted despite the "Не затрагиваются" report claiming otherwise; fix #229: repair-pass no longer stale-repairs memory files with owner: user in frontmatter; fix #228: hot-budget validator warns when memory/*.md horizon:hot lines exceed threshold
 REPO="TserenTserenov/FMT-exocortex-template" # UPSTREAM-CONST: do not substitute
 BRANCH="main"
+# Delivery channel (WP-529 F7, pilot decision 2026-08-21, prompted by an
+# external user's report): "release" (default) pins the delivery to the last
+# published release tag — users must not receive unreleased, possibly red,
+# main. IWE_UPDATE_CHANNEL=main opts back into the moving branch (author/dev
+# workflow, and the automatic fallback when no release exists yet).
+UPDATE_CHANNEL="${IWE_UPDATE_CHANNEL:-release}"
 RAW_BASE="https://raw.githubusercontent.com/$REPO/$BRANCH"
 API_BASE="https://api.github.com/repos/$REPO"
 
@@ -703,7 +709,32 @@ exit_clean() {
 # that immutable commit, so a push between manifest and file requests cannot mix
 # hashes from one revision with content from another (issue #398).
 resolve_delivery_ref() {
-    local resolved_ref
+    local resolved_ref release_tag
+    if [ "$UPDATE_CHANNEL" = "release" ]; then
+        # sed, not python: the tag must be resolvable even on installs where
+        # py_available fails — a release tag is already an immutable-enough
+        # pin, unlike the moving branch the no-python path degrades to below.
+        # shellcheck disable=SC2086
+        release_tag=$(curl $CURL_BASE_OPTS $_CURL_SSL_OPT -sSfL "$API_BASE/releases/latest" 2>/dev/null | \
+            sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+        if [ -n "$release_tag" ]; then
+            if py_available && resolved_ref=$(curl $CURL_BASE_OPTS $_CURL_SSL_OPT -sSfL "$API_BASE/commits/$release_tag" 2>/dev/null | \
+                "$PY_BIN" -c '
+import json, re, sys
+sha = json.load(sys.stdin).get("sha", "")
+if not re.fullmatch(r"[0-9a-f]{40}", sha):
+    raise SystemExit(1)
+print(sha)'); then
+                RAW_BASE="https://raw.githubusercontent.com/$REPO/$resolved_ref"
+                echo "  Канал поставки: релиз $release_tag (снимок ${resolved_ref:0:12})"
+            else
+                RAW_BASE="https://raw.githubusercontent.com/$REPO/$release_tag"
+                echo "  Канал поставки: релиз $release_tag (закреплён по тегу)"
+            fi
+            return 0
+        fi
+        echo "  ⚠ Не удалось определить последний релиз (нет релизов или API недоступен) — откат на ветку $BRANCH."
+    fi
     if ! py_available; then
         echo "  ⚠ Нет python3: поставка проверяется по подвижной ветке $BRANCH."
         return 0


### PR DESCRIPTION
## WP-529 Ф7 — контракт доставки Day Open графа + un-red main (Ф4 debt)

**Коммит 1 (Ф7):** closure-таблица из пир-сессий 2026-08-20-42 / 2026-08-21-17 закрыта:
- 7 скриптов промотированы (включая `lib/wp_inbox.py` — живой баг импорта `day-open-llm-fill.py` на любой неавторской установке), `install-hooks.sh` добавлен на update-путь
- Слоты 4.55-4.57 портированы в шаблонную копию pipeline точечно (не синком — копии форкнуты: `--scaffold-only`, python-резолвер существуют только в FMT-версии): вызовы через резолвер, 4.57 под guard'ом «нет origin/main → skip в stderr, exit 0»
- Seed-зеркала всех файлов closure (+SNAPSHOT-заголовки), манифест регенерирован
- Новый приёмочный тест `setup/test-day-open-delivery-closure.sh` (bash 3.2-safe): динамическая выборка ссылок из pipeline, транзитивный closure, foreign-cwd smoke, манифест ровно 1 раз, строгий xfail extension-графа до АрхГейт-1 (XPASS = громкий FAIL), инвентаризация `$IWE`-ссылок (АрхГейт-2). Подключён в CI.
- Cold review ×2: 2 Critical + 1 High + 4 Medium — найдены и исправлены до PR

**Коммит 2 (un-red main):** тесты Ф4 падали на main (`USE_PARALLEL_DOWNLOAD: unbound variable`, run 32470798303 — независимо репортнуто внешним пользователем в тот же день): переключатель серийного/параллельного режима живёт в теле update.sh, извлечённая функция его не имеет. Все 3 теста пришпиливают серийный режим; cleanup-trap'ы переведены на `${arr[@]+...}` (пустой массив под set -u на Bash 3.2 — unbound, trap умирал и маскировал реальный отказ).

**Не входит (открыто, в карточке РП):** АрхГейт-вопросы 1-2 (extension-граф; доставка корневых `$IWE/scripts/` — стратег ищет pipeline в `$WORKSPACE/scripts/`, куда не доставляет ни один канал); класс «bash-подстановка в Python-строке» в 5 pre-existing файлах; форк root↔FMT pipeline (вход РП-485); контракт релиз-канала update.sh (BRANCH=main — вопрос пилоту).

Проверки: acceptance 59 PASS / 0 FAIL / 1 XFAIL (ожидаемый), seed-drift 16/16, python-resolver contract, verify-manifest, delivery-route-label 4/4, issue-tests 8/8, три Ф4-теста зелёные локально.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
