### PR TITLE
fix(update): шаг 0 заменяет работающий скрипт через staged rename, не cp (остаток #505)

### DIFF
--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2645,7 +2645,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "632590a53e7e297d62ef687eac310c8ce9fca7ed67f088bc9f8202da595d1f12"
+      "sha256": "591665153c549c89eb73c4e9eadf6d1c9a8d6298c27f310cd18ab9f5702ec429"
     }
   ],
   "excluded_paths": [

--- a/update.sh
+++ b/update.sh
@@ -799,8 +799,16 @@ if curl $CURL_BASE_OPTS $_CURL_SSL_OPT -sSfL "$RAW_BASE/update.sh" -o "$REMOTE_U
             echo "  ⚠ Новая версия update.sh доступна. Запустите без --check для обновления."
         else
             echo "  Найдена новая версия update.sh — обновляю..."
-            cp "$REMOTE_UPDATE" "$SCRIPT_DIR/update.sh"
-            chmod +x "$SCRIPT_DIR/update.sh"
+            # issue #505 class (residual, found in the same sweep): replace
+            # the RUNNING script via sibling tmp + mv — rename swaps the
+            # directory entry and this process keeps its old inode; a plain cp
+            # truncates the very file bash is executing. Historically survived
+            # only because the few remaining commands sat in bash's read
+            # buffer.
+            _boot_staged="$SCRIPT_DIR/.update.sh.staged.$$"
+            cp "$REMOTE_UPDATE" "$_boot_staged"
+            chmod +x "$_boot_staged"
+            mv -f "$_boot_staged" "$SCRIPT_DIR/update.sh"
             echo "  Перезапуск..."
             exec bash "$SCRIPT_DIR/update.sh" "$@"
         fi


### PR DESCRIPTION
Тот же класс, что закрыт в #516 для шага 5: шаг 0 самообновления делал cp по исполняемому inode. Заменено на tmp+mv. Self-overwrite тест 8/8, манифест пересобран.

🤖 Generated with [Claude Code](https://claude.com/claude-code)