### PR TITLE
fix(release,manifest): pin release tag to validated SHA; fail-closed manifest verification (post-v0.38.7 peer review)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ on:
         description: "Version to release (e.g. 0.35.5). Leave empty to read from manifest."
         required: false
         default: ""
+      sha:
+        description: "Commit to tag (the validated bump commit). Leave empty to tag the dispatch ref tip."
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -51,9 +55,12 @@ jobs:
         with:
           # workflow_run: pin to the exact commit Validate Template just
           # verified — this is what makes the gate actually mean something.
-          # workflow_dispatch (manual override): github.sha is the ref that
-          # was dispatched against, same as before this change.
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          # workflow_dispatch with explicit sha (weekly-release.yml closes the
+          # chain this way): pin to that validated commit — a bare ref tip
+          # could have moved past what Validate saw.
+          # workflow_dispatch without sha (manual override): github.sha is the
+          # ref that was dispatched against, same as before this change.
+          ref: ${{ github.event.inputs.sha || (github.event_name == 'workflow_run' && github.event.workflow_run.head_sha) || github.sha }}
           fetch-depth: 0  # full history to check existing tags
 
       - name: Determine version

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -601,6 +601,14 @@ jobs:
       - name: Run update.sh self-overwrite regression test
         run: bash setup/test-update-self-overwrite.sh
 
+      # issue #505 residual (Codex peer-review 2026-08-22): the test above
+      # deliberately makes Step 0 a no-op, so the replacement itself had no
+      # coverage. This one serves a DIFFERENT update.sh to the self-update
+      # fetch: Step 0 must stage+rename it over the running script, re-exec,
+      # and finish cleanly (#517: staged rename instead of cp).
+      - name: Run update.sh Step 0 staged-rename test
+        run: bash setup/test-update-step0-staged-rename.sh
+
       # PR #385: cloud install paths may occur legitimately in old tracked text;
       # only additions made by the current updater run are publication blockers.
       - name: Test staged install-path guard

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -123,4 +123,10 @@ jobs:
           done
           [ -n "$RUN_ID" ] || { echo "Validate run for bump commit $BUMP_SHA never appeared"; exit 1; }
           gh run watch "$RUN_ID" --exit-status
-          gh workflow run release.yml --ref main -f version="${{ steps.bump.outputs.version }}"
+          # 2026-08-22 (Codex peer-review of the v0.38.7 post-mortem): pass the
+          # validated SHA explicitly — a bare `--ref main` dispatch would tag
+          # whatever main's tip is when release.yml starts, so a commit landing
+          # between the green Validate and the dispatch would ride into the
+          # release unvalidated. release.yml pins checkout (and therefore the
+          # tag) to this SHA.
+          gh workflow run release.yml --ref main -f version="${{ steps.bump.outputs.version }}" -f sha="$BUMP_SHA"

--- a/generate-manifest.sh
+++ b/generate-manifest.sh
@@ -313,9 +313,15 @@ delivered_now = {e['path'] for e in data['files']}
 # git HEAD ships with every fresh clone — deprecating it makes update.sh
 # delete what the canon still distributes, leaving clones with tracked
 # deletions. Deprecated may only list paths git no longer carries.
-tracked_now = set(subprocess.run(
+# 2026-08-22 (Codex peer-review): git ls-files без проверки кода возврата —
+# при сбое git tracked_now молча становился пустым, и фильтр «deprecated ∩
+# дерево» деградировал fail-open. Сбой git = отказ генерации (fail-closed).
+_ls = subprocess.run(
     ['git', 'ls-files'], capture_output=True, text=True, cwd='$SCRIPT_DIR'
-).stdout.splitlines())
+)
+if _ls.returncode != 0:
+    sys.exit('generate-manifest: git ls-files failed: ' + _ls.stderr.strip())
+tracked_now = set(_ls.stdout.splitlines())
 kept, dropped = [], []
 for entry in data['deprecated_files']:
     (dropped if entry.get('path') in delivered_now or entry.get('path') in tracked_now else kept).append(entry)

--- a/scripts/verify-manifest.sh
+++ b/scripts/verify-manifest.sh
@@ -34,8 +34,16 @@ CURRENT_VERSION=$(python3 -c "import json; print(json.load(open('$MANIFEST'))['v
 TMP_MANIFEST=$(mktemp)
 trap 'rm -f "$BACKUP" "$TMP_MANIFEST"' EXIT
 
-# Генерируем новый манифест во временный файл
-bash "$GENERATOR" >/dev/null 2>&1 || true
+# Генерируем новый манифест во временный файл.
+# 2026-08-22 (Codex peer-review): было `|| true` — падение генератора
+# глоталось, и сравнение ниже могло пройти на СТАРОМ манифесте (fail-open в
+# проверке, заявленной fail-closed). Теперь любой отказ генератора = ошибка
+# проверки; оригинальный манифест восстанавливаем перед выходом.
+if ! bash "$GENERATOR" >/dev/null 2>&1; then
+    cp "$BACKUP" "$MANIFEST"
+    echo "❌ manifest-verify: generate-manifest.sh завершился с ошибкой — проверка невозможна (fail-closed)"
+    exit 1
+fi
 
 # Копируем сгенерированный манифест во временный файл
 cp "$MANIFEST" "$TMP_MANIFEST"
@@ -62,7 +70,13 @@ DEP_CONFLICTS=$(python3 - "$MANIFEST" <<'PYCHECK'
 import json, subprocess, sys
 m = json.load(open(sys.argv[1]))
 delivered = {e['path'] for e in m.get('files', [])}
-tracked = set(subprocess.run(['git', 'ls-files'], capture_output=True, text=True).stdout.splitlines())
+# 2026-08-22 (Codex peer-review): git ls-files без проверки кода возврата —
+# при сбое git множество tracked молча становилось пустым, и проверка
+# «deprecated ∩ дерево» деградировала fail-open. Теперь сбой git = сбой проверки.
+r = subprocess.run(['git', 'ls-files'], capture_output=True, text=True)
+if r.returncode != 0:
+    sys.exit('git ls-files failed: ' + r.stderr.strip())
+tracked = set(r.stdout.splitlines())
 bad = [e['path'] for e in m.get('deprecated_files', []) if e.get('path') in delivered or e.get('path') in tracked]
 print('\n'.join(bad))
 PYCHECK

--- a/setup/test-update-step0-staged-rename.sh
+++ b/setup/test-update-step0-staged-rename.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# test-update-step0-staged-rename.sh — issue #505 residual, full-run E2E.
+#
+# Codex peer-review of the v0.38.7 post-mortem (2026-08-22): the #516
+# regression test deliberately makes Step 0 a no-op (it serves the CURRENT
+# update.sh to the self-update fetch), so the dangerous replacement itself —
+# Step 0 overwriting the RUNNING script — had no E2E coverage. #517 switched
+# that replacement from `cp` (truncates the inode bash is still executing) to
+# sibling-tmp + mv (atomic rename, the process keeps its old inode). This test
+# exercises exactly that path: the self-update fetch is served a DIFFERENT
+# update.sh, Step 0 must stage+rename it, re-exec, and the run must complete
+# cleanly.
+#
+# Usage: bash setup/test-update-step0-staged-rename.sh
+
+set -uo pipefail
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+UPDATE_SH_REAL="$(dirname "$SELF_DIR")/update.sh"
+TEST_ROOT="/tmp/iwe-step0-rename-test-$$"
+FAKE_HOME="$TEST_ROOT/fake-home"
+
+FAIL_COUNT=0
+PASS_COUNT=0
+fail() { echo "  ❌ FAIL: $*" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "  ✅ PASS: $*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+cleanup() { local rc=$?; [ "${KEEP:-0}" = "1" ] || rm -rf "$TEST_ROOT"; exit "$rc"; }
+trap cleanup EXIT INT TERM
+mkdir -p "$TEST_ROOT" "$FAKE_HOME"
+
+# --- Fixture: upstream tree ---------------------------------------------------
+UPSTREAM="$TEST_ROOT/upstream"
+mkdir -p "$UPSTREAM/.claude/hooks"
+printf '# Template CLAUDE.md\n\nSame content both sides.\n' > "$UPSTREAM/CLAUDE.md"
+printf '#!/bin/bash\necho "hook v2"\n' > "$UPSTREAM/.claude/hooks/dummy-hook.sh"
+
+# The marked update.sh — what upstream "published" (differs from the running
+# copy by a trailing comment, same behaviour otherwise).
+cp "$UPDATE_SH_REAL" "$UPSTREAM/update.sh"
+printf '\n# step0-staged-rename-marker issue-505-residual\n' >> "$UPSTREAM/update.sh"
+
+python3 - "$UPSTREAM" <<'PYEOF'
+import hashlib, json, sys
+from pathlib import Path
+root = Path(sys.argv[1])
+def entry(p):
+    return {'path': p, 'sha256': hashlib.sha256((root / p).read_bytes()).hexdigest()}
+manifest = {
+    'schema_version': 2,
+    'version': '0.99.0-test-505-residual',
+    'files': [entry('CLAUDE.md'), entry('.claude/hooks/dummy-hook.sh'), entry('update.sh')],
+    'deprecated_files': [],
+}
+(root / 'update-manifest.json').write_text(json.dumps(manifest))
+PYEOF
+
+# --- Fixture: sandboxed SCRIPT_DIR (old local state: UNMARKED update.sh) ------
+SCRIPT_DIR="$TEST_ROOT/repo/FMT-exocortex-template"
+mkdir -p "$SCRIPT_DIR/.claude/hooks" "$SCRIPT_DIR/.claude/lib" "$SCRIPT_DIR/scripts/lib"
+cp "$UPDATE_SH_REAL" "$SCRIPT_DIR/update.sh"
+cp "$SELF_DIR/../.claude/lib/frontmatter.sh" "$SCRIPT_DIR/.claude/lib/frontmatter.sh"
+cp "$SELF_DIR/../scripts/lib/common.sh" "$SCRIPT_DIR/scripts/lib/common.sh"
+chmod +x "$SCRIPT_DIR/update.sh"
+cp "$UPSTREAM/CLAUDE.md" "$SCRIPT_DIR/CLAUDE.md"
+cp "$UPSTREAM/CLAUDE.md" "$SCRIPT_DIR/.claude.md.base"
+WORKSPACE_DIR="$TEST_ROOT/repo"
+cp "$UPSTREAM/CLAUDE.md" "$WORKSPACE_DIR/CLAUDE.md"
+cp "$UPSTREAM/CLAUDE.md" "$WORKSPACE_DIR/.claude.md.base"
+git -C "$SCRIPT_DIR" init -q
+git -C "$SCRIPT_DIR" config user.email t@t; git -C "$SCRIPT_DIR" config user.name t
+git -C "$SCRIPT_DIR" add -A; git -C "$SCRIPT_DIR" commit -q -m init
+git -C "$SCRIPT_DIR" branch -M main
+
+# Provenance for the install-path guard (same mechanics as the #505 test):
+# the marked update.sh must exist in @{upstream} history.
+REMOTE_GIT="$TEST_ROOT/remote.git"
+git init -q --bare "$REMOTE_GIT"
+git -C "$SCRIPT_DIR" remote add origin "$REMOTE_GIT"
+git -C "$SCRIPT_DIR" push -q -u origin main
+PROV_CLONE="$TEST_ROOT/prov-clone"
+git clone -q "$REMOTE_GIT" "$PROV_CLONE"
+git -C "$PROV_CLONE" config user.email t@t; git -C "$PROV_CLONE" config user.name t
+cp "$UPSTREAM/update.sh" "$PROV_CLONE/update.sh"
+git -C "$PROV_CLONE" add update.sh; git -C "$PROV_CLONE" commit -q -m "upstream v2"
+git -C "$PROV_CLONE" push -q origin main
+git -C "$SCRIPT_DIR" fetch -q origin
+
+# --- curl shim ----------------------------------------------------------------
+# Unlike the #505 test, the self-update fetch (*.new) is served the MARKED
+# update.sh too — Step 0 must actually replace the running script and re-exec.
+# After the replacement the re-executed copy fetches the same marked content
+# again: hashes match, no second replacement, no re-exec loop.
+SHIM_DIR="$TEST_ROOT/shim"
+mkdir -p "$SHIM_DIR"
+cat > "$SHIM_DIR/curl" <<SHIMEOF
+#!/bin/bash
+serve() {
+    local u="\$1" o="\$2" rel
+    rel="\${u##*githubusercontent.com/}"; rel="\${rel#*/}"; rel="\${rel#*/}"; rel="\${rel#*/}"
+    case "\$rel" in
+        update.sh) cp "$UPSTREAM/update.sh" "\$o" ;;
+        update-manifest.json) cp "$UPSTREAM/update-manifest.json" "\$o" ;;
+        *) [ -f "$UPSTREAM/\$rel" ] && cp "$UPSTREAM/\$rel" "\$o" || return 22 ;;
+    esac
+}
+if [ "\$1" = "--help" ] && [ "\$2" = "all" ]; then
+    printf -- '  -o, --output <file>\n  -f, --fail\n'
+    exit 0
+fi
+url="" out="" cfgfile=""
+args=("\$@")
+for ((i=0; i<\${#args[@]}; i++)); do
+    case "\${args[i]}" in
+        http*) url="\${args[i]}" ;;
+        -o) out="\${args[i+1]}" ;;
+        -K) cfgfile="\${args[i+1]}" ;;
+    esac
+done
+if [ -n "\$cfgfile" ]; then
+    had_error=0; pending_url=""
+    while IFS= read -r line; do
+        case "\$line" in
+            url*) pending_url="\${line#*\\"}"; pending_url="\${pending_url%\\"}" ;;
+            output*) o="\${line#*\\"}"; o="\${o%\\"}"; serve "\$pending_url" "\$o" || had_error=1; pending_url="" ;;
+        esac
+    done < "\$cfgfile"
+    exit "\$had_error"
+fi
+[ -z "\$url" ] && exit 22
+[ -z "\$out" ] && exit 0
+serve "\$url" "\$out"
+SHIMEOF
+chmod +x "$SHIM_DIR/curl"
+
+# --- Run the REAL update.sh: Step 0 must replace+re-exec itself ---------------
+echo "--- full run: Step 0 self-update replaces the running script ---"
+set +e
+PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main \
+    bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out.log" 2>&1
+RC=$?
+set -e
+
+if [ "$RC" -eq 0 ]; then
+  pass "update.sh finished cleanly (rc=0) through the Step 0 replace+re-exec"
+else
+  fail "update.sh exited rc=$RC; tail: $(tail -3 "$TEST_ROOT/out.log" | tr '\n' ' ')"
+fi
+if grep -q "step0-staged-rename-marker issue-505-residual" "$SCRIPT_DIR/update.sh"; then
+  pass "running update.sh was replaced by the upstream copy"
+else
+  fail "Step 0 did not replace update.sh (marker missing)"
+fi
+if grep -q "Перезапуск" "$TEST_ROOT/out.log"; then
+  pass "re-exec happened after the replacement"
+else
+  fail "no re-exec after Step 0 replacement"
+fi
+if grep -q "command not found" "$TEST_ROOT/out.log"; then
+  fail "output contains 'command not found' — the running script read garbage mid-flight"
+else
+  pass "no mid-flight corruption in the output"
+fi
+if [ -f "$SCRIPT_DIR/.update-incomplete" ]; then
+  fail ".update-incomplete marker left behind"
+else
+  pass "no stale .update-incomplete marker"
+fi
+if compgen -G "$SCRIPT_DIR/.update.sh.staged.*" > /dev/null; then
+  fail "staged tmp file(s) left behind: $(ls "$SCRIPT_DIR"/.update.sh.staged.* 2>/dev/null | tr '\n' ' ')"
+else
+  pass "no staged tmp files left behind"
+fi
+
+echo
+echo "Result: $PASS_COUNT PASS, $FAIL_COUNT FAIL"
+[ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -985,7 +985,7 @@
     },
     {
       "path": "generate-manifest.sh",
-      "sha256": "dcb50518ecd9a13491d87f8f2bf060f1e8b2f84007e7c753aad0764c710cc961"
+      "sha256": "36d9944bcdd9e207b9af4789951f2f85731e1ac00fb01d0b95776503e7c3ebc6"
     },
     {
       "path": "guide-kit/.gitignore",
@@ -2577,7 +2577,7 @@
     },
     {
       "path": "scripts/verify-manifest.sh",
-      "sha256": "613546c9b12201bd1bac9fef97c159586bdf08cb7fd947d93ed50856196c557a"
+      "sha256": "07b2a7317edc1c17ec52fd3d2e0a3f62fd80217cd8bcea437338143efd3444ee"
     },
     {
       "path": "scripts/week-draft-append.sh",
@@ -2723,6 +2723,7 @@
     "setup/test-update-issue-226.sh",
     "setup/test-update-release-channel.sh",
     "setup/test-update-self-overwrite.sh",
+    "setup/test-update-step0-staged-rename.sh",
     "setup/ux-walkthrough-prompt.md"
   ],
   "deprecated_files": [


### PR DESCRIPTION
## Что

Пост-релизное пир-ревью v0.38.7 (Kimi + Codex, 2026-08-22) нашло три остаточных дефекта после #516/#517 — все воспроизведены в коде до правки:

1. **Релизный тег не был пришпилен к проверенному коммиту.** weekly-release диспатчил release.yml голым `--ref main` — тег вставал на вершину main на момент старта прогона, а не на коммит, который Validate только что проверил. Теперь release.yml принимает вход `sha` и пингует checkout (а значит и тег) на него; weekly-release передаёт ровно тот `BUMP_SHA`, чей прогон Validate он дождался.
2. **`verify-manifest.sh` глотал падение генератора** (`|| true`): если generate-manifest.sh умирал до записи, сравнение могло пройти на СТАРОМ манифесте — fail-open в проверке, заявленной fail-closed. Теперь отказ генератора = отказ проверки (оригинал манифеста восстанавливается перед выходом).
3. **`git ls-files` без проверки кода возврата** в generate-manifest.sh и verify-manifest.sh: сбой git молча опустошал множество tracked, деградируя инвариант «deprecated ∩ дерево» тем же fail-open путём. Оба места теперь падают громко.

Плюс закрыт пробел в покрытии, на который указало ревью: регрессионный тест #505 намеренно делает Шаг 0 холостым, поэтому staged-rename из #517 остался без E2E. Новый `setup/test-update-step0-staged-rename.sh` подаёт самообновлению ДРУГОЙ update.sh — Шаг 0 обязан заменить работающий скрипт, перезапуститься и чисто финишировать (6 проверок, подключён в Validate).

## Сознательно НЕ сделано

Ревью предлагало расширить runtime-предохранитель deprecated в update.sh до git-дерева. Отклонено: в СТАРОЙ установке deprecated-файл ещё отслеживается локальным git (например, шесть стенограмм из #516) — предохранитель по дереву запретил бы их законное удаление навсегда. Пересечение с деревом проверяемо только там, где каноническое дерево существует: в генераторе и в CI — оба слоя теперь fail-closed.

## Проверки

- `setup/test-update-step0-staged-rename.sh`: 6/6 локально (macOS)
- `setup/test-update-self-overwrite.sh`: 8/8 локально
- `scripts/verify-manifest.sh`: зелёный
- shellcheck (`-S warning`, строже CI-шного `-S error`): чисто
- YAML трёх workflow: валиден

Changelog-Tag: behavior
Refs: WP-529, peer-review of #516/#517
Analyzed-by: Codex <noreply@openai.com>
Co-Authored-By: Kimi <noreply@moonshot.ai>
