### PR TITLE
fix(update,setup): fail-closed канал (#501), двойной контроль шага 0, поставка baseline, изоляция IWE_RUNTIME (WP-529 Ф13)

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -601,6 +601,12 @@ jobs:
       - name: Run update.sh self-overwrite regression test
         run: bash setup/test-update-self-overwrite.sh
 
+      # v0.38.7 matrix finding 6: a foreign exported IWE_RUNTIME redirected
+      # setup's hot-files generation into another workspace. Invariant with a
+      # discriminating control (the old call shape must still leak).
+      - name: Run setup runtime-isolation invariant test
+        run: bash scripts/tests/test_setup_runtime_isolation.sh
+
       # issue #505 residual (Codex peer-review 2026-08-22): the test above
       # deliberately makes Step 0 a no-op, so the replacement itself had no
       # coverage. This one serves a DIFFERENT update.sh to the self-update

--- a/generate-manifest.sh
+++ b/generate-manifest.sh
@@ -131,6 +131,10 @@ SETUP_EXPLICIT_INCLUDE=(
 # real release would have shipped a template without its own test gate and
 # nobody would have noticed until a user hit the bug the gate exists to catch.
 SCRIPT_CONTRACT_EXPLICIT_INCLUDE=(
+    # 2026-08-23 (v0.38.7 матрица, находка 4): check-python-resolver-contract.sh
+    # доставляется, а его обязательный baseline сидел в excluded — на установке
+    # строго из манифеста сторож падал rc=2. Ratchet-снимок — часть поставки.
+    "scripts/tests/fixtures/python-resolver-baseline.txt"
     "scripts/tests/test_create_wp_registry_coherence.sh"
     "scripts/tests/test_check_orphan_hooks.sh"
     "scripts/tests/test_capture_bus_detector_timeout.sh"

--- a/scripts/tests/test_setup_runtime_isolation.sh
+++ b/scripts/tests/test_setup_runtime_isolation.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# test_setup_runtime_isolation.sh — v0.38.7 matrix finding 6 (external user,
+# reproduced with a negative control): setting up workspace B with a foreign
+# exported IWE_RUNTIME (from workspace A) wrote hot-files.list into A's
+# runtime. setup.sh step 4f passes IWE_ROOT but did not pin IWE_RUNTIME, and
+# generate-hot-files-list.sh prefers the inherited env value.
+#
+# Invariant under test: with the FIXED call shape (explicit IWE_RUNTIME, the
+# policy comment at step 4f), a poisoned environment cannot redirect the
+# write. The discriminating control shows the OLD call shape still leaks —
+# so this test fails against the pre-fix behaviour, not vacuously.
+#
+# Bash 3.2 compatible. Usage: bash scripts/tests/test_setup_runtime_isolation.sh
+
+set -uo pipefail
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SELF_DIR/../.." && pwd)"
+GEN="$REPO_ROOT/scripts/generate-hot-files-list.sh"
+
+FAIL_COUNT=0
+PASS_COUNT=0
+fail() { echo "  ❌ FAIL: $*" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "  ✅ PASS: $*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+TEST_ROOT="/tmp/iwe-runtime-isolation-test-$$"
+trap 'rm -rf "$TEST_ROOT"' EXIT INT TERM
+
+WS_A="$TEST_ROOT/workspace-A"; WS_B="$TEST_ROOT/workspace-B"
+mkdir -p "$WS_A/.iwe-runtime" "$WS_B"
+mkdir -p "$WS_B/DS-strategy"  # generator's governance-repo probe target
+
+echo "=== 1. Fixed call shape: poisoned env must NOT redirect the write ==="
+OUT=$(IWE_RUNTIME="$WS_A/.iwe-runtime" \
+      env IWE_RUNTIME="$WS_A/.iwe-runtime" IWE_ROOT="$WS_B" IWE_GOVERNANCE_REPO="DS-strategy" \
+      bash -c 'IWE_ROOT="$IWE_ROOT" IWE_RUNTIME="$IWE_ROOT/.iwe-runtime" IWE_GOVERNANCE_REPO="$IWE_GOVERNANCE_REPO" bash "'"$GEN"'"' 2>&1) || true
+if [ -f "$WS_B/.iwe-runtime/hot-files.list" ]; then
+  pass "hot-files.list written into the TARGET workspace B"
+else
+  fail "target workspace B got nothing; output: $OUT"
+fi
+if [ -f "$WS_A/.iwe-runtime/hot-files.list" ]; then
+  fail "poisoned workspace A received the write — isolation broken"
+else
+  pass "poisoned workspace A untouched"
+fi
+
+echo "=== 2. Discriminating control: the OLD call shape (no explicit IWE_RUNTIME) leaks ==="
+rm -rf "$WS_A/.iwe-runtime" "$WS_B/.iwe-runtime"; mkdir -p "$WS_A/.iwe-runtime"
+OUT=$(env IWE_RUNTIME="$WS_A/.iwe-runtime" bash -c 'IWE_ROOT="'"$WS_B"'" IWE_GOVERNANCE_REPO="DS-strategy" bash "'"$GEN"'"' 2>&1) || true
+if [ -f "$WS_A/.iwe-runtime/hot-files.list" ] && [ ! -f "$WS_B/.iwe-runtime/hot-files.list" ]; then
+  pass "control: inherited IWE_RUNTIME redirects the old shape (test can tell the difference)"
+else
+  fail "control did not leak — either the generator changed contract or the test is blind; output: $OUT"
+fi
+
+echo "=== 3. setup.sh call sites carry the explicit pin (policy is wired, not just documented) ==="
+if grep -q 'IWE_ROOT="\$WORKSPACE_DIR" IWE_RUNTIME="\$IWE_RUNTIME_PATH"' "$REPO_ROOT/setup.sh"; then
+  pass "step 4f passes IWE_RUNTIME explicitly"
+else
+  fail "step 4f call no longer pins IWE_RUNTIME"
+fi
+if grep -q 'export IWE_RUNTIME="\$IWE_RUNTIME_PATH"' "$REPO_ROOT/setup.sh"; then
+  pass "role-install loop pins IWE_RUNTIME explicitly"
+else
+  fail "role-install loop no longer pins IWE_RUNTIME"
+fi
+
+echo
+echo "Result: $PASS_COUNT PASS, $FAIL_COUNT FAIL"
+[ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1

--- a/scripts/tests/test_update_build_runtime_fail_closed.sh
+++ b/scripts/tests/test_update_build_runtime_fail_closed.sh
@@ -105,7 +105,7 @@ chmod +x "$SHIM_DIR/curl"
 
 echo "--- Scenario A: build-runtime fails during a real update ---"
 set +e
-PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-a.log" 2>&1
+PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-a.log" 2>&1
 RC_A=$?
 set -e
 
@@ -136,7 +136,7 @@ echo "--- Scenario A2: --check must not clear the marker left by the failed run 
 # next step after a failure — update.sh --check — silently cleared the marker
 # without repair or build-runtime, disarming the contract it now carries.
 set +e
-PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-a2.log" 2>&1
+PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-a2.log" 2>&1
 RC_A2=$?
 set -e
 
@@ -160,7 +160,7 @@ EOF
 chmod +x "$SCRIPT_DIR/setup/build-runtime.sh"
 
 set +e
-PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-b.log" 2>&1
+PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-b.log" 2>&1
 RC_B=$?
 set -e
 
@@ -200,7 +200,7 @@ if [ -f "$SCRIPT_DIR/.update-incomplete" ]; then
 fi
 
 set +e
-PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-c.log" 2>&1
+PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-c.log" 2>&1
 RC_C=$?
 set -e
 

--- a/scripts/verify-manifest.sh
+++ b/scripts/verify-manifest.sh
@@ -89,6 +89,34 @@ if [ -n "$DEP_CONFLICTS" ]; then
     exit 1
 fi
 
+# 2026-08-23 (v0.38.7 матрица, находка 4): сторож, который доставляется без
+# своего обязательного файла данных, на установке из манифеста падает — CI
+# этого не видел, потому что работает в полном чекауте. Парные поставки
+# объявлены явно; каждая пара либо доставляется целиком, либо целиком нет.
+PAIRED_DELIVERY="scripts/check-python-resolver-contract.sh=scripts/tests/fixtures/python-resolver-baseline.txt"
+for pair in $PAIRED_DELIVERY; do
+    tool="${pair%%=*}"; datafile="${pair#*=}"
+    # Обе стороны пары считаем по files[] (доставляемое), не по всему JSON:
+    # инструмент, осознанно выведенный из поставки, делает пару вакуумной,
+    # а не ложно-нарушенной.
+    t=$(python3 - "$MANIFEST" "$tool" <<'PYCHK'
+import json, sys
+m = json.load(open(sys.argv[1]))
+print(sum(1 for e in m.get('files', []) if e['path'] == sys.argv[2]))
+PYCHK
+)
+    d=$(python3 - "$MANIFEST" "$datafile" <<'PYCHK'
+import json, sys
+m = json.load(open(sys.argv[1]))
+print(sum(1 for e in m.get('files', []) if e['path'] == sys.argv[2]))
+PYCHK
+)
+    if [ "$t" -ge 1 ] && [ "$d" -eq 0 ]; then
+        echo "❌ manifest-verify: $tool доставляется без обязательного $datafile (парная поставка нарушена)"
+        exit 1
+    fi
+done
+
 # Сравниваем backup с сгенерированным
 if diff -q "$BACKUP" "$TMP_MANIFEST" >/dev/null 2>&1; then
     echo "✅ manifest-verify: update-manifest.json синхронизирован с git tree"

--- a/setup.sh
+++ b/setup.sh
@@ -742,7 +742,12 @@ if $DRY_RUN; then
     echo "[DRY RUN] Would regenerate hot-files.list (IWE_GOVERNANCE_REPO=$GOVERNANCE_REPO)"
 else
     echo "[4f] Regenerating hot-files.list..."
-    if HOTFILES_OUTPUT=$(IWE_ROOT="$WORKSPACE_DIR" IWE_GOVERNANCE_REPO="$GOVERNANCE_REPO" bash "$TEMPLATE_DIR/scripts/generate-hot-files-list.sh" 2>&1); then
+    # POLICY (2026-08-23, матрица v0.38.7 находка 6, консенсус с codex):
+    # критичные IWE_*-переменные передаются генераторам ЯВНО из переменных
+    # самого setup — унаследованный env другого workspace не должен решать,
+    # куда пишет установка. Живой случай: exported IWE_RUNTIME workspace A
+    # побеждал переданный IWE_ROOT, и hot-files.list уезжал в чужой runtime.
+    if HOTFILES_OUTPUT=$(IWE_ROOT="$WORKSPACE_DIR" IWE_RUNTIME="$IWE_RUNTIME_PATH" IWE_GOVERNANCE_REPO="$GOVERNANCE_REPO" bash "$TEMPLATE_DIR/scripts/generate-hot-files-list.sh" 2>&1); then
         echo "$HOTFILES_OUTPUT" | sed 's/^/  /'
     else
         echo "$HOTFILES_OUTPUT" | sed 's/^/  /'
@@ -765,6 +770,13 @@ else
     # в env для role install.sh (тот же паттерн что в update.sh:836).
     # Без этого install.sh падает в legacy fallback и видит {{плейсхолдеры}}.
     [ -f "$WORKSPACE_DIR/.iwe-paths" ] && . "$WORKSPACE_DIR/.iwe-paths"
+    # Same isolation policy as step 4f: role install.sh scripts read
+    # IWE_RUNTIME/IWE_WORKSPACE from env — pin them to THIS install's targets
+    # explicitly, so a foreign exported value (or a missing .iwe-paths) can
+    # never redirect a role install into another workspace.
+    export IWE_WORKSPACE="$WORKSPACE_DIR"
+    export IWE_RUNTIME="$IWE_RUNTIME_PATH"
+    export IWE_TEMPLATE="$TEMPLATE_DIR"
 
     MANUAL_ROLES=()
 

--- a/setup/test-update-issue-226.sh
+++ b/setup/test-update-issue-226.sh
@@ -244,7 +244,7 @@ chmod +x "$SHIM_DIR/curl"
 echo "--- Scenario A: CLAUDE.md conflict + non-default branch ---"
 HEAD_A_BEFORE=$(git -C "$SCRIPT_DIR" rev-parse HEAD)
 set +e
-PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-a.log" 2>&1
+PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-a.log" 2>&1
 RC_A=$?
 set -e
 
@@ -319,7 +319,7 @@ cp "$UPSTREAM/CLAUDE.md" "$WORKSPACE_DIR/.claude.md.base"
 git -C "$SCRIPT_DIR" add -A; git -C "$SCRIPT_DIR" commit -q -m "simulate: already at upstream version"
 
 set +e
-PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-b.log" 2>&1
+PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-b.log" 2>&1
 RC_B=$?
 set -e
 
@@ -369,7 +369,7 @@ with open(manifest_path, "w", encoding="utf-8") as handle:
     json.dump(manifest, handle)
 PY
 
-PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --check --fast > "$TEST_ROOT/out-c-fast.log" 2>&1
+PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --check --fast > "$TEST_ROOT/out-c-fast.log" 2>&1
 if grep -q "Состав манифеста изменился" "$TEST_ROOT/out-c-fast.log"; then
     pass "C: --check --fast detects a content-only change at the same version/path"
 else
@@ -389,7 +389,7 @@ with open(path, "w", encoding="utf-8") as handle:
     json.dump(manifest, handle)
 PY
 
-PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-c-integrity.log" 2>&1 || true
+PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-c-integrity.log" 2>&1 || true
 if grep -q "sha256 не совпадает" "$TEST_ROOT/out-c-integrity.log" && \
    grep -q "Проверка неполная" "$TEST_ROOT/out-c-integrity.log"; then
     pass "C: full check rejects a downloaded file that does not match manifest sha256"
@@ -426,7 +426,7 @@ owner: user
 Pilot-owned content that intentionally differs.
 EOF
 
-PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-d.log" 2>&1 || true
+PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-d.log" 2>&1 || true
 if grep -q "owner: user, НЕ обновлён, но шаблонная версия отличается" "$TEST_ROOT/out-d.log" && \
    grep -q 'Сверьте: diff' "$TEST_ROOT/out-d.log"; then
     pass "D: owner:user drift is visible with a comparison command on an unchanged run"
@@ -465,7 +465,7 @@ MEMO_BEFORE=$(cat "$SCRIPT_DIR/memory/dummy-memo.md")
 MANIFEST_HASH_BEFORE=$(sha256sum "$SCRIPT_DIR/update-manifest.json" | cut -d' ' -f1)
 
 set +e
-PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-e.log" 2>&1
+PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-e.log" 2>&1
 RC_E=$?
 set -e
 
@@ -519,7 +519,7 @@ with open(manifest_path, 'w') as f:
     json.dump(manifest, f)
 "
 rm -f "$TEST_ROOT/shim-trace.log"
-CURL_SHIM_PARALLEL_SUPPORTED=1 PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-f.log" 2>&1
+CURL_SHIM_PARALLEL_SUPPORTED=1 PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-f.log" 2>&1
 RC_F=$?
 
 if [ "$RC_F" -eq 0 ]; then
@@ -561,7 +561,7 @@ with open(manifest_path, 'w') as f:
     json.dump(manifest, f)
 "
 rm -f "$TEST_ROOT/shim-trace.log"
-CURL_SHIM_PARALLEL_SUPPORTED=0 PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-g.log" 2>&1
+CURL_SHIM_PARALLEL_SUPPORTED=0 PATH="$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --yes > "$TEST_ROOT/out-g.log" 2>&1
 RC_G=$?
 
 if [ "$RC_G" -eq 0 ]; then
@@ -623,7 +623,7 @@ EOF
 
 rm -f "$TEST_ROOT/shim-trace.log"
 set +e
-PATH="$NO_PY_DIR:$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-h.log" 2>&1
+PATH="$NO_PY_DIR:$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-h.log" 2>&1
 RC_H=$?
 set -e
 
@@ -672,7 +672,7 @@ cat > "$UPSTREAM/update-manifest.json" <<'EOF'
 }
 EOF
 set +e
-PATH="$NO_PY_DIR:$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-h-normal.log" 2>&1
+PATH="$NO_PY_DIR:$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-h-normal.log" 2>&1
 RC_H_NORMAL=$?
 set -e
 
@@ -694,7 +694,7 @@ cat > "$UPSTREAM/update-manifest.json" <<'EOF'
 {"schema_version": 2, "version": "0.99.0-test-226", "files": [{"path": "single.md", "sha256": "0"}], "deprecated_files": []}
 EOF
 set +e
-PATH="$NO_PY_DIR:$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-h-singlefile.log" 2>&1
+PATH="$NO_PY_DIR:$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-h-singlefile.log" 2>&1
 RC_H_SINGLEFILE=$?
 set -e
 
@@ -717,7 +717,7 @@ cat > "$UPSTREAM/update-manifest.json" <<'EOF'
 {"schema_version": 2, "version": "0.99.0-test-226", "files": [], "deprecated_files": []}
 EOF
 set +e
-PATH="$NO_PY_DIR:$SHIM_DIR:$PATH" HOME="$FAKE_HOME" bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-h-nopath.log" 2>&1
+PATH="$NO_PY_DIR:$SHIM_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main bash "$SCRIPT_DIR/update.sh" --check > "$TEST_ROOT/out-h-nopath.log" 2>&1
 RC_H_NOPATH=$?
 set -e
 

--- a/setup/test-update-release-channel.sh
+++ b/setup/test-update-release-channel.sh
@@ -43,6 +43,7 @@ run_case() {
         RAW_BASE="https://raw.githubusercontent.com/$REPO/$BRANCH"
         CURL_BASE_OPTS="--max-time 2"
         _CURL_SSL_OPT=""
+        EXIT_NETWORK=2
         UPDATE_CHANNEL="$channel"
         PY_BIN="$(command -v python3 || echo python3)"
         HAS_RELEASES="$has_releases"
@@ -72,10 +73,15 @@ OUT=$(run_case release yes yes)
 echo "$OUT" | grep -q "RAW_BASE=.*/$TAG_SHA$" && pass "RAW_BASE pinned to release SHA" || fail "expected release SHA pin, got: $OUT"
 echo "$OUT" | grep -q "релиз v9.9.9" && pass "announces the release tag" || fail "no release announcement: $OUT"
 
-echo "=== 2. release channel, no releases published: explicit fallback to main ==="
-OUT=$(run_case release no yes)
-echo "$OUT" | grep -q "RAW_BASE=.*/$MAIN_SHA$" && pass "falls back to pinned main SHA" || fail "expected main fallback, got: $OUT"
-echo "$OUT" | grep -q "Не удалось определить последний релиз" && pass "fallback is announced, not silent" || fail "silent fallback: $OUT"
+echo "=== 2. release channel, no releases published: FAIL-CLOSED abort (#501) ==="
+# no errexit here: the harness runs under `set -uo pipefail` WITHOUT -e —
+# enabling it after this case would abort cases 3-4 on any non-zero and
+# swallow the final Result line (cold review, Medium 4)
+OUT=$(run_case release no yes 2>&1)
+RC2=$?
+[ "$RC2" -ne 0 ] && pass "resolver aborts non-zero instead of falling back (#501)" || fail "expected non-zero abort, got rc=0: $OUT"
+echo "$OUT" | grep -q "IWE_UPDATE_CHANNEL=main" && pass "abort message carries the explicit main-channel hint" || fail "no actionable hint in abort: $OUT"
+echo "$OUT" | grep -q "RAW_BASE=" && fail "fallback still resolved a RAW_BASE: $OUT" || pass "no delivery base resolved on failed release lookup"
 
 echo "=== 3. IWE_UPDATE_CHANNEL=main: the old moving-branch contract, pinned ==="
 OUT=$(run_case main yes yes)

--- a/setup/test-update-self-overwrite.sh
+++ b/setup/test-update-self-overwrite.sh
@@ -195,6 +195,80 @@ else
   fail "$BAKED sandbox path(s) baked into update.sh — {{KEY}} templates substituted"
 fi
 
+# --- Scenario 2: Step 0 self-update — inode + behavioural negative control ---
+# The v0.38.7 matrix (external user) proved scenario 1 blind to Step 0: it
+# serves the CURRENT update.sh at the *.new fetch, so self-update never runs.
+# Here the shim serves the MARKED update.sh EVERYWHERE: Step 0 must replace
+# the running script via staged rename (inode CHANGES — a cp keeps the inode
+# and is exactly the #505 class), re-exec the marked copy, and that copy must
+# carry the whole update to a clean finish (behavioural control, codex В2).
+echo "--- Scenario 2: Step 0 self-update (inode + re-exec survival) ---"
+SCRIPT_DIR2="$TEST_ROOT/repo2/FMT-exocortex-template"
+mkdir -p "$SCRIPT_DIR2/.claude/hooks" "$SCRIPT_DIR2/.claude/lib" "$SCRIPT_DIR2/scripts/lib"
+cp "$UPDATE_SH_REAL" "$SCRIPT_DIR2/update.sh"
+cp "$SELF_DIR/../.claude/lib/frontmatter.sh" "$SCRIPT_DIR2/.claude/lib/frontmatter.sh"
+cp "$SELF_DIR/../scripts/lib/common.sh" "$SCRIPT_DIR2/scripts/lib/common.sh"
+chmod +x "$SCRIPT_DIR2/update.sh"
+cp "$UPSTREAM/CLAUDE.md" "$SCRIPT_DIR2/CLAUDE.md"
+cp "$UPSTREAM/CLAUDE.md" "$SCRIPT_DIR2/.claude.md.base"
+WORKSPACE_DIR2="$TEST_ROOT/repo2"
+cp "$UPSTREAM/CLAUDE.md" "$WORKSPACE_DIR2/CLAUDE.md"
+cp "$UPSTREAM/CLAUDE.md" "$WORKSPACE_DIR2/.claude.md.base"
+git -C "$SCRIPT_DIR2" init -q
+git -C "$SCRIPT_DIR2" config user.email t@t; git -C "$SCRIPT_DIR2" config user.name t
+git -C "$SCRIPT_DIR2" add -A; git -C "$SCRIPT_DIR2" commit -q -m init
+git -C "$SCRIPT_DIR2" branch -M main
+git -C "$SCRIPT_DIR2" remote add origin "$REMOTE_GIT"
+git -C "$SCRIPT_DIR2" fetch -q origin
+git -C "$SCRIPT_DIR2" branch -q -u origin/main main
+
+SHIM2_DIR="$TEST_ROOT/shim2"
+mkdir -p "$SHIM2_DIR"
+# The shim was written through an UNQUOTED heredoc: sandbox paths inside it
+# are already literal. The only line serving the CURRENT update.sh is the
+# *.new branch — repoint it at the marked copy.
+sed "s|$SCRIPT_DIR/update.sh|$UPSTREAM/update.sh|" "$SHIM_DIR/curl" > "$SHIM2_DIR/curl"
+if diff -q "$SHIM_DIR/curl" "$SHIM2_DIR/curl" >/dev/null 2>&1; then
+  echo "FATAL: shim2 rewrite changed nothing — serve anchor moved" >&2; exit 2
+fi
+chmod +x "$SHIM2_DIR/curl"
+
+inode_of() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1"; }
+INODE_BEFORE=$(inode_of "$SCRIPT_DIR2/update.sh")
+set +e
+PATH="$SHIM2_DIR:$PATH" HOME="$FAKE_HOME" IWE_UPDATE_CHANNEL=main \
+    bash "$SCRIPT_DIR2/update.sh" --yes > "$TEST_ROOT/out2.log" 2>&1
+RC2=$?
+set -e
+INODE_AFTER=$(inode_of "$SCRIPT_DIR2/update.sh")
+
+if [ "$RC2" -eq 0 ]; then
+  pass "S2: self-updated run finishes cleanly (rc=0)"
+else
+  fail "S2: rc=$RC2; tail: $(tail -3 "$TEST_ROOT/out2.log" | tr '\n' ' ')"
+fi
+if grep -q "Перезапуск" "$TEST_ROOT/out2.log"; then
+  pass "S2: Step 0 actually replaced and re-exec'ed the updater"
+else
+  fail "S2: self-update path never ran — scenario is blind again"
+fi
+if [ "$INODE_BEFORE" != "$INODE_AFTER" ]; then
+  pass "S2: inode changed — staged rename semantics (a cp would keep it: #505 class)"
+else
+  fail "S2: inode unchanged — Step 0 overwrote the running inode (cp semantics)"
+fi
+if grep -q "self-overwrite-regression-marker issue-505" "$SCRIPT_DIR2/update.sh"; then
+  pass "S2: final update.sh is the manifest-bound (marked) version"
+else
+  fail "S2: final update.sh is not the fetched version"
+fi
+if grep -q "command not found" "$TEST_ROOT/out2.log"; then
+  fail "S2: mid-flight corruption in output"
+else
+  pass "S2: no mid-flight corruption"
+fi
+[ -f "$SCRIPT_DIR2/.update-incomplete" ] && fail "S2: stale .update-incomplete left" || pass "S2: no stale incomplete marker"
+
 echo
 echo "Result: $PASS_COUNT PASS, $FAIL_COUNT FAIL"
 [ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -985,7 +985,7 @@
     },
     {
       "path": "generate-manifest.sh",
-      "sha256": "36d9944bcdd9e207b9af4789951f2f85731e1ac00fb01d0b95776503e7c3ebc6"
+      "sha256": "08dab8e3387acc51f14d8d1f02ba1f86ade86970700e5367e442423042a54a70"
     },
     {
       "path": "guide-kit/.gitignore",
@@ -2392,6 +2392,10 @@
       "sha256": "f2ae015d394a447778e1ed75ecfa16d80fe98e1164655b3431940c7e783d206c"
     },
     {
+      "path": "scripts/tests/fixtures/python-resolver-baseline.txt",
+      "sha256": "6f1c7bd4afdcc899d875cc162e66b418bcacdbe356836ce56676e0b541afc94f"
+    },
+    {
       "path": "scripts/tests/lib/capture_fixture.sh",
       "sha256": "edf6eba925d890e2aa52541be8fff27fb48ab11f5c7c69a8a3b1b001408978cd"
     },
@@ -2525,7 +2529,7 @@
     },
     {
       "path": "scripts/tests/test_update_build_runtime_fail_closed.sh",
-      "sha256": "cf3d6a0132c4265691f22adfb49f405e378161ee3029c41d5ce59d2d7139fc73"
+      "sha256": "69cb3b529071b3612e9a9224c4a2ac5698e35aa2e1ce78a26241c7da9c9ac926"
     },
     {
       "path": "scripts/tests/test_update_delivers_python_resolver_before_roles.sh",
@@ -2577,7 +2581,7 @@
     },
     {
       "path": "scripts/verify-manifest.sh",
-      "sha256": "07b2a7317edc1c17ec52fd3d2e0a3f62fd80217cd8bcea437338143efd3444ee"
+      "sha256": "224777b7b735b0b1be3048957b10738cd4eefb88dd30fbced42322c7d223747d"
     },
     {
       "path": "scripts/week-draft-append.sh",
@@ -2605,7 +2609,7 @@
     },
     {
       "path": "setup.sh",
-      "sha256": "e73a22e88b5f4150a43938d48e6b5024fddfb7fa7e9c640e9d9dee02c42c1a70"
+      "sha256": "0b1a77f34d84bba032b11875e3de043dd49b37b2b1bfb231bb13081f31d60090"
     },
     {
       "path": "setup/build-runtime.sh",
@@ -2645,7 +2649,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "591665153c549c89eb73c4e9eadf6d1c9a8d6298c27f310cd18ab9f5702ec429"
+      "sha256": "084f5b44c007db2f5dfb75bf4c47dc2667bf942fa8fd522a7b4d080613616cff"
     }
   ],
   "excluded_paths": [
@@ -2670,7 +2674,6 @@
     "scripts/iwe-trace.py",
     "scripts/session-dispatcher-tsekh.py",
     "scripts/tests/conftest.py",
-    "scripts/tests/fixtures/python-resolver-baseline.txt",
     "scripts/tests/lib/extract-update-download-batch.sh",
     "scripts/tests/test_agent_dashboard.py",
     "scripts/tests/test_copy_to_aisystant.py",
@@ -2687,6 +2690,7 @@
     "scripts/tests/test_pending_phases_sweep.sh",
     "scripts/tests/test_release_receipt.sh",
     "scripts/tests/test_residency_gate_skill_adapter.py",
+    "scripts/tests/test_setup_runtime_isolation.sh",
     "scripts/tests/test_skill_promote.py",
     "scripts/tests/test_translate_delta.py",
     "scripts/tests/test_translate_parse.py",

--- a/update.sh
+++ b/update.sh
@@ -33,8 +33,9 @@ BRANCH="main"
 # Delivery channel (WP-529 F7, pilot decision 2026-08-21, prompted by an
 # external user's report): "release" (default) pins the delivery to the last
 # published release tag — users must not receive unreleased, possibly red,
-# main. IWE_UPDATE_CHANNEL=main opts back into the moving branch (author/dev
-# workflow, and the automatic fallback when no release exists yet).
+# main. IWE_UPDATE_CHANNEL=main is the ONLY way onto the moving branch
+# (author/dev workflow) — a failed release lookup aborts fail-closed (#501),
+# it never falls back to main automatically.
 UPDATE_CHANNEL="${IWE_UPDATE_CHANNEL:-release}"
 RAW_BASE="https://raw.githubusercontent.com/$REPO/$BRANCH"
 API_BASE="https://api.github.com/repos/$REPO"
@@ -733,7 +734,15 @@ print(sha)'); then
             fi
             return 0
         fi
-        echo "  ⚠ Не удалось определить последний релиз (нет релизов или API недоступен) — откат на ветку $BRANCH."
+        # #501 (fail-closed, матрица внешнего пользователя по v0.38.7): молчаливый
+        # откат на подвижную ветку превращал сбой резолва релиза в тихую доставку
+        # непроверенного main — ровно то, от чего release-канал защищает. Явный
+        # main-канал остаётся единственной дорогой к подвижной ветке.
+        echo "ОШИБКА: не удалось определить последний релиз (нет релизов или API недоступен)." >&2
+        echo "  Release-канал работает только от опубликованного релиза (fail-closed, #501)." >&2
+        echo "  Повторите позже, либо осознанно выберите подвижную ветку:" >&2
+        echo "    IWE_UPDATE_CHANNEL=main bash update.sh" >&2
+        exit "$EXIT_NETWORK"
     fi
     if ! py_available; then
         echo "  ⚠ Нет python3: поставка проверяется по подвижной ветке $BRANCH."


### PR DESCRIPTION
Четыре условия снятия предупреждения из контрольной матрицы v0.38.7 внешнего пользователя + дефект изоляции (находка 6). Консенсус пир-сессии с codex 2026-08-23-01.

1. **#501:** сбой резолва релиза = abort с подсказкой IWE_UPDATE_CHANNEL=main; тихий откат на main убран. Обвязки (issue-226: 12 вызовов, build-runtime: 4 — блокер холодного ревью) пришпилены к явному main-каналу.
2. **Шаг 0:** сценарий 2 self-overwrite E2E — реальное самообновление с двойным контролем (inode обязан смениться + re-exec доводит обновление); чувствительность доказана probe'ом с cp-вариантом.
3. **Baseline резолвер-сторожа** переехал из excluded в поставку; verify-manifest получил парную проверку «инструмент+данные» (fail-closed).
4. **IWE_RUNTIME:** явный пин в шаге 4f + export'ы перед установкой ролей (политика: критичные IWE_* только явно); тест-инвариант с различающим контролем в CI.

Сюиты: release-channel 8/8, self-overwrite 14/14, isolation 5/5, build-runtime 13/13, closure 62/0/1, edge-cases 124/0, issue-226 35/0, seed-drift 16/16, verify-manifest, resolver-contract.

После мерджа — релиз v0.38.8 (включит также #517/#518) и повторная матрица внешнего пользователя.

🤖 Generated with [Claude Code](https://claude.com/claude-code)