### PR TITLE
chore(release): наполнить [Unreleased] точным интервалом перед v0.38.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,11 @@ Refs: WP-NNN
 
 
 
+
+## [Unreleased]
+### Fixed
+- `6c4f52b` fix(template): batch of nine small user-reported defects (#515 #514 #513 #503 #499 #507 #512 #511 + flush) — WP-529 F14, peer session with Kimi (#520)
+
 ## [0.38.8] — 2026-08-23
 ### Fixed
 - `8364a30` fix(update,setup): fail-closed release channel (#501), Step 0 double negative control, resolver-baseline delivery, IWE_RUNTIME isolation (WP-529 F13, v0.38.7 matrix) (#519)

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -657,7 +657,7 @@
     },
     {
       "path": "CHANGELOG.md",
-      "sha256": "4e95705bf3606c4d63027a9f2b30a6ebbc7d141410e736a478afa5bbfd849d82"
+      "sha256": "3ef584d326534510979f7f8e149d0ed051b6017e544b68dc8c54dff411d70707"
     },
     {
       "path": "CLAUDE.md",


### PR DESCRIPTION
changelog-append.sh фильтрует по дате, не по тегу — на релизных коммитах того же дня подхватывает уже выпущенное. Секция собрана вручную точным git-интервалом v0.38.8..main (один новый коммит — squash Ф14, #520). Follow-up: переключить сборщик на git log <last-tag>..HEAD, отдельной фазой.

🤖 Generated with [Claude Code](https://claude.com/claude-code)