### PR TITLE
fix(residency-gate): unify resolver + error contract, fix .prompt field (#521A #525)

### DIFF
--- a/.claude/hooks/inject-role-prefixes.sh
+++ b/.claude/hooks/inject-role-prefixes.sh
@@ -23,8 +23,11 @@ command -v jq >/dev/null 2>&1 || { echo '{}'; exit 0; }
 
 INPUT=$(cat 2>/dev/null || echo '{}')
 
-# Extract user prompt (first 100 chars is enough for prefix detection)
-PROMPT=$(echo "$INPUT" | jq -r '.message // empty' 2>/dev/null | head -c 100 || echo "")
+# Extract user prompt (first 100 chars is enough for prefix detection).
+# Field is `.prompt`, not `.message` (issue #525) — confirmed by the official
+# UserPromptSubmit contract and by the three sibling hooks on the same event
+# (wp-gate-reminder.sh, close-gate-reminder.sh, lazy-context-loader.sh).
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null | head -c 100 || echo "")
 [ -n "$PROMPT" ] || { echo '{}'; exit 0; }
 
 # Locate the full roles file

--- a/.claude/hooks/residency-gate-init.sh
+++ b/.claude/hooks/residency-gate-init.sh
@@ -15,20 +15,52 @@ FUNCTION_ID="$1"
 MANIFEST_FILE="$2"
 # CLAUDE_ROOT = project root that CONTAINS .claude/ (default: cwd). The old
 # default ".claude" produced ".claude/.claude/skills/..." — a path that never
-# exists (issue #323).
+# exists (issue #323). Kept as one self-contained assignment: T15
+# (setup/test-update-edge-cases.sh) greps this exact line in isolation and
+# evaluates it standalone — a second variable it doesn't grep would resolve
+# empty there even though this script itself works fine end-to-end.
 RESIDENCY_GATE_PY="${CLAUDE_ROOT:-.}/.claude/skills/residency-gate/residency-gate.py"
 
-# Check consent at activation
-RESULT=$(python3 "$RESIDENCY_GATE_PY" check-activation "$FUNCTION_ID" "$MANIFEST_FILE" 2>/dev/null || echo '{"allowed":false,"blocking":["error"]}')
-
-# Parse JSON response
-ALLOWED=$(echo "$RESULT" | grep -o '"allowed":[^,}]*' | head -1 | grep -o 'true\|false')
-BLOCKING=$(echo "$RESULT" | grep -o '"blocking":\[\([^]]*\)' | sed 's/.*:\[//')
-
-if [ "$ALLOWED" != "true" ]; then
-  echo "[ResidencyGate] Function '$FUNCTION_ID' blocked at activation time" >&2
-  echo "[ResidencyGate] Blocking reasons: $BLOCKING" >&2
+# Resolved once, before residency-gate.py runs at all (issue #521A): a
+# missing PyYAML then reads as a dependency error here, not the generic
+# "blocked at activation time" this hook used to fabricate for any crash.
+PY3=$("${CLAUDE_ROOT:-.}/scripts/lib/find-python3.sh" 2>&1) || {
+  echo "[ResidencyGate] Dependency error for '$FUNCTION_ID': $PY3" >&2
   return 1
+}
+
+# `&& RC=0 || RC=$?` survives `set -e` (this file is sourced — an unguarded
+# failure here would abort the CALLER's shell, not just this script). A
+# fallback embedded via `cmd || echo fallback` INSIDE the same command
+# substitution does not replace a failed command's stdout — it appends to
+# it, so a normal denial (residency-gate.py already printed valid JSON, then
+# exited 1) produced two concatenated JSON blobs, and every code path below
+# matched the hand-written fallback instead of the real one (found in cold
+# review). The empty-result fallback only fires when there is truly nothing
+# to parse.
+RESULT=$("$PY3" "$RESIDENCY_GATE_PY" check-activation "$FUNCTION_ID" "$MANIFEST_FILE" 2>/dev/null) && RC=0 || RC=$?
+[ -n "$RESULT" ] || RESULT='{"allowed":false,"error_class":"runtime_error","error":"residency-gate.py produced no output"}'
+
+if [ "$RC" -eq 0 ]; then
+  return 0
 fi
 
-return 0
+# error_class distinguishes a genuine policy denial from residency-gate.py
+# itself breaking (issue #521A contract: 2 invalid_manifest, 3 dependency_error,
+# 4 runtime_error — absent means a normal policy_denial). jq, not grep/sed: a
+# hand-rolled regex over `json.dumps` output breaks on the space it always
+# inserts after `:` and truncates on any escaped quote inside the message —
+# both found live in cold review, jq parses either correctly.
+ERROR_CLASS=$(jq -r '.error_class // empty' <<<"$RESULT" 2>/dev/null || echo "")
+DETAIL=$(jq -r '.error // (.blocking // [] | join("; ")) // empty' <<<"$RESULT" 2>/dev/null || echo "")
+[ -n "$DETAIL" ] || DETAIL="$RESULT"
+case "$ERROR_CLASS" in
+  dependency_error) echo "[ResidencyGate] Dependency error for '$FUNCTION_ID': $DETAIL" >&2 ;;
+  invalid_manifest) echo "[ResidencyGate] Invalid declaration for '$FUNCTION_ID': $DETAIL" >&2 ;;
+  runtime_error) echo "[ResidencyGate] Runtime error for '$FUNCTION_ID': $DETAIL" >&2 ;;
+  *)
+    echo "[ResidencyGate] Function '$FUNCTION_ID' blocked at activation time" >&2
+    echo "[ResidencyGate] Blocking reasons: $DETAIL" >&2
+    ;;
+esac
+return 1

--- a/.claude/hooks/residency-gate-lazy.sh
+++ b/.claude/hooks/residency-gate-lazy.sh
@@ -17,19 +17,50 @@ FLOW_DIRECTION="$3"
 NEED_NAME="$4"
 # CLAUDE_ROOT = project root that CONTAINS .claude/ (default: cwd). The old
 # default ".claude" produced ".claude/.claude/skills/..." — a path that never
-# exists (issue #323).
+# exists (issue #323). Kept as one self-contained assignment: T15
+# (setup/test-update-edge-cases.sh) greps this exact line in isolation and
+# evaluates it standalone — a second variable it doesn't grep would resolve
+# empty there even though this script itself works fine end-to-end.
 RESIDENCY_GATE_PY="${CLAUDE_ROOT:-.}/.claude/skills/residency-gate/residency-gate.py"
 
-# Check lazy consent
-RESULT=$(python3 "$RESIDENCY_GATE_PY" check-lazy "$FUNCTION_ID" "$DATA_TYPE" "$FLOW_DIRECTION" "$NEED_NAME" 2>/dev/null)
-
-ALLOWED=$(echo "$RESULT" | grep -o '"allowed":[^,}]*' | head -1 | grep -o 'true\|false')
-REASON=$(echo "$RESULT" | grep -o '"reason":"[^"]*' | sed 's/.*:"//')
-
-if [ "$ALLOWED" != "true" ]; then
-  echo "[ResidencyGate] Access denied for $FUNCTION_ID/$NEED_NAME: $REASON" >&2
+# Resolved once, before residency-gate.py runs at all (issue #521A): a
+# missing PyYAML then reads as a dependency error here, not a fabricated
+# "consent denied" from a crash three layers down.
+PY3=$("${CLAUDE_ROOT:-.}/scripts/lib/find-python3.sh" 2>&1) || {
+  echo "[ResidencyGate] Dependency error for $FUNCTION_ID/$NEED_NAME: $PY3" >&2
   exit 1
+}
+
+# `&& RC=0 || RC=$?` deliberately survives `set -e`: a bare `RESULT=$(cmd)`
+# aborts the script the instant residency-gate.py exits non-zero — a genuine
+# policy denial (the common case) never even reached the message below
+# (found alongside #521A while fixing the same class of bug). The empty-
+# result fallback guards the case residency-gate.py exits without printing
+# anything at all (e.g. $RESIDENCY_GATE_PY missing) — otherwise the `jq`
+# calls below see an empty string and the case statement falls through with
+# nothing to show (found in cold review).
+RESULT=$("$PY3" "$RESIDENCY_GATE_PY" check-lazy "$FUNCTION_ID" "$DATA_TYPE" "$FLOW_DIRECTION" "$NEED_NAME" 2>/dev/null) && RC=0 || RC=$?
+[ -n "$RESULT" ] || RESULT='{"allowed":false,"error_class":"runtime_error","error":"residency-gate.py produced no output"}'
+
+if [ "$RC" -eq 0 ]; then
+  REASON=$(jq -r '.reason // empty' <<<"$RESULT" 2>/dev/null || echo "")
+  echo "[ResidencyGate] Access allowed: $REASON" >&2
+  exit 0
 fi
 
-echo "[ResidencyGate] Access allowed: $REASON" >&2
-exit 0
+# error_class distinguishes a genuine policy denial from residency-gate.py
+# itself breaking (issue #521A contract: 2 invalid_manifest, 3 dependency_error,
+# 4 runtime_error — absent means a normal policy_denial). jq, not grep/sed: a
+# hand-rolled regex over `json.dumps` output breaks on the space it always
+# inserts after `:` and truncates on any escaped quote inside the message —
+# both found live in cold review, jq parses either correctly.
+ERROR_CLASS=$(jq -r '.error_class // empty' <<<"$RESULT" 2>/dev/null || echo "")
+DETAIL=$(jq -r '.error // .reason // empty' <<<"$RESULT" 2>/dev/null || echo "")
+[ -n "$DETAIL" ] || DETAIL="$RESULT"
+case "$ERROR_CLASS" in
+  dependency_error) echo "[ResidencyGate] Dependency error for $FUNCTION_ID/$NEED_NAME: $DETAIL" >&2 ;;
+  invalid_manifest) echo "[ResidencyGate] Invalid declaration for $FUNCTION_ID/$NEED_NAME: $DETAIL" >&2 ;;
+  runtime_error) echo "[ResidencyGate] Runtime error for $FUNCTION_ID/$NEED_NAME: $DETAIL" >&2 ;;
+  *) echo "[ResidencyGate] Access denied for $FUNCTION_ID/$NEED_NAME: $DETAIL" >&2 ;;
+esac
+exit 1

--- a/.claude/hooks/residency-gate-skill-adapter.sh
+++ b/.claude/hooks/residency-gate-skill-adapter.sh
@@ -44,19 +44,58 @@ MANIFEST="$PROJECT_ROOT/.claude/skills/$SKILL_NAME/SKILL.md"
 RESIDENCY_GATE_PY="$PROJECT_ROOT/.claude/skills/residency-gate/residency-gate.py"
 [ -f "$RESIDENCY_GATE_PY" ] || exit 0
 
-RESULT=$(python3 "$RESIDENCY_GATE_PY" check-activation "$SKILL_NAME" "$MANIFEST" 2>&1) && RC=0 || RC=$?
+# Resolved once, before residency-gate.py runs at all (issue #521A, the exact
+# hook from the live traceback in the issue report): a missing PyYAML then
+# reads as a dependency error here, not a fabricated "requires data consent"
+# from a crash three layers down.
+PY3=$("$PROJECT_ROOT/scripts/lib/find-python3.sh" 2>&1) || {
+  echo "BLOCKED: ResidencyGate dependency error — skill '$SKILL_NAME' could not be checked." >&2
+  echo "  $PY3" >&2
+  exit 2
+}
+
+RESULT=$("$PY3" "$RESIDENCY_GATE_PY" check-activation "$SKILL_NAME" "$MANIFEST" 2>&1) && RC=0 || RC=$?
 
 if [ "$RC" -eq 0 ]; then
   exit 0
 fi
 
-# check-activation exits 1 on both "blocked" and "malformed declaration"
-# (ManifestError) — the library's own fail-closed choice (see residency-gate.py
-# check-activation: a malformed manifest blocks activation, it does not warn
-# and continue). This hook does not second-guess that: any non-zero exit here
-# blocks the skill the same way, with the library's own reason surfaced.
-BLOCKING=$(jq -r '.blocking // [] | join("; ")' <<<"$RESULT" 2>/dev/null || echo "$RESULT")
-echo "BLOCKED: ResidencyGate — skill '$SKILL_NAME' requires data consent not yet granted." >&2
-echo "  $BLOCKING" >&2
-echo "  Выдать согласие: python3 $RESIDENCY_GATE_PY grant $SKILL_NAME <type> <flow> <name>" >&2
+# check-activation exits non-zero for four distinct reasons now (issue #521A
+# contract: 1 policy_denial, 2 invalid_manifest, 3 dependency_error, 4
+# runtime_error) — this hook does not second-guess any of them (any non-zero
+# exit still blocks the skill, the library's own fail-closed choice), but it
+# no longer claims "requires data consent" for a reason that isn't consent.
+# `jq -e . <<<"$RESULT"` is a distinct check from the field extraction below:
+# it tells apart valid JSON with no error_class (a genuine policy_denial —
+# residency-gate.py's own contract) from $RESULT not being JSON at all (a
+# crash outside that contract entirely, e.g. a SyntaxError in a corrupted
+# lib/*.py — caught here with `2>&1`, unlike the other two hooks). Without
+# this check the second case fell into the same branch as the first and
+# printed "requires data consent" — and the grant hint below — for a reason
+# that has nothing to do with consent (found in second-round cold review).
+if jq -e . <<<"$RESULT" >/dev/null 2>&1; then
+  ERROR_CLASS=$(jq -r '.error_class // empty' <<<"$RESULT" 2>/dev/null || echo "")
+else
+  ERROR_CLASS="unparseable"
+fi
+case "$ERROR_CLASS" in
+  dependency_error) HEADER="ResidencyGate dependency error" ;;
+  invalid_manifest) HEADER="ResidencyGate declaration error" ;;
+  runtime_error) HEADER="ResidencyGate runtime error" ;;
+  unparseable) HEADER="ResidencyGate crashed — skill '$SKILL_NAME' could not be checked" ;;
+  *) HEADER="ResidencyGate — skill '$SKILL_NAME' requires data consent not yet granted." ;;
+esac
+# `|| DETAIL=""` guards the whole pipeline, not just `jq`: this script runs
+# under `pipefail` (line 26), and $RESULT can be non-JSON (a stray stderr
+# line merged by the `2>&1` above, from something outside residency-gate.py's
+# own JSON contract) — jq then fails, pipefail propagates that through `grep`
+# and `head`, and an unguarded assignment would abort the script under `set
+# -e` before the BLOCKED message below ever prints (found in cold review).
+DETAIL=$(jq -r '(.blocking // [] | join("; ")), .error // empty' <<<"$RESULT" 2>/dev/null | grep -v '^$' | head -1) || DETAIL=""
+[ -n "$DETAIL" ] || DETAIL="$RESULT"
+echo "BLOCKED: $HEADER" >&2
+echo "  $DETAIL" >&2
+# The grant hint only makes sense for an actual consent decision — a broken
+# manifest or a runtime crash isn't fixed by granting consent to it.
+[ -z "$ERROR_CLASS" ] && echo "  Выдать согласие: python3 $RESIDENCY_GATE_PY grant $SKILL_NAME <type> <flow> <name>" >&2
 exit 2

--- a/.claude/skills/residency-gate/residency-gate.py
+++ b/.claude/skills/residency-gate/residency-gate.py
@@ -2,15 +2,41 @@
 """ResidencyGate main entry point - API for hooks and functions."""
 
 import sys
+import os
 import json
+import traceback
 from pathlib import Path
 from typing import List, Optional
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from lib.parser import ManifestParser, ManifestError, DataNeed
-from lib.state import ResidencyState
-from lib.consent import ResidencyGate, PreGrantError, load_pre_grant_entries
+
+def _emit_and_exit(payload: dict, code: int, exc: Optional[BaseException] = None) -> None:
+    """Print one JSON error envelope and exit.
+
+    debug_trace is opt-in (RESIDENCY_GATE_DEBUG=1): `error` (str(exc)) alone is
+    the diagnosable cause by default (issue #521 — the reporter fixed a missing
+    PyYAML from that one line, no trace needed) — a full traceback in every hook
+    stderr by default is noise the caller did not ask for.
+    """
+    if exc is not None and os.environ.get("RESIDENCY_GATE_DEBUG") == "1":
+        payload["debug_trace"] = traceback.format_exc()
+    print(json.dumps(payload))
+    sys.exit(code)
+
+
+# Exit-code/error_class contract (issue #521A): 0 allowed · 1 policy_denial
+# (normal consent refusal from gate.check_*()) · 2 invalid_manifest (bad
+# SKILL.md/pre-grant declaration) · 3 dependency_error (missing PyYAML etc.,
+# caught here before any command runs) · 4 runtime_error (everything else —
+# I/O, permissions, unexpected exceptions). Hook scripts read this exit code
+# to print a remediation-specific message instead of guessing from text.
+try:
+    from lib.parser import ManifestParser, ManifestError, DataNeed
+    from lib.state import ResidencyState
+    from lib.consent import ResidencyGate, PreGrantError, load_pre_grant_entries
+except ImportError as e:
+    _emit_and_exit({"allowed": False, "error_class": "dependency_error", "error": str(e)}, 3, e)
 
 
 def main():
@@ -20,18 +46,19 @@ def main():
         sys.exit(1)
 
     command = sys.argv[1]
-    gate = ResidencyGate()
 
-    if command == "check-activation":
-        # check-activation <function_id> <manifest_file>
-        if len(sys.argv) < 4:
-            print("Usage: residency-gate.py check-activation <function_id> <manifest_file>", file=sys.stderr)
-            sys.exit(1)
+    try:
+        gate = ResidencyGate()
 
-        function_id = sys.argv[2]
-        manifest_file = sys.argv[3]
+        if command == "check-activation":
+            # check-activation <function_id> <manifest_file>
+            if len(sys.argv) < 4:
+                print("Usage: residency-gate.py check-activation <function_id> <manifest_file>", file=sys.stderr)
+                sys.exit(1)
 
-        try:
+            function_id = sys.argv[2]
+            manifest_file = sys.argv[3]
+
             manifest_content = Path(manifest_file).read_text()
             needs = ManifestParser.parse_markdown(manifest_content, function_id)
 
@@ -43,104 +70,104 @@ def main():
             print(json.dumps({"allowed": allowed, "blocking": blocking}))
             sys.exit(0 if allowed else 1)
 
-        except (ManifestError, PreGrantError) as e:
-            # Fail closed: a malformed declaration or pre-grant list blocks activation.
-            print(json.dumps({"allowed": False, "blocking": [str(e)]}))
-            sys.exit(1)
-        except (OSError, IOError) as e:
-            print(json.dumps({"error": str(e)}))
-            sys.exit(1)
+        elif command == "check-lazy":
+            # check-lazy <function_id> <data_type> <flow_direction> <name>
+            if len(sys.argv) < 6:
+                print("Usage: residency-gate.py check-lazy <function_id> <type> <flow> <name>", file=sys.stderr)
+                sys.exit(1)
 
-    elif command == "check-lazy":
-        # check-lazy <function_id> <data_type> <flow_direction> <name>
-        if len(sys.argv) < 6:
-            print("Usage: residency-gate.py check-lazy <function_id> <type> <flow> <name>", file=sys.stderr)
-            sys.exit(1)
-
-        function_id = sys.argv[2]
-        data_type = sys.argv[3]
-        flow_direction = sys.argv[4]
-        need_name = sys.argv[5]
-
-        need = DataNeed(
-            name=need_name,
-            type=data_type,
-            flow_direction=flow_direction,
-            schema_version=1
-        )
-
-        allowed, reason = gate.check_lazy(function_id, need)
-        print(json.dumps({"allowed": allowed, "reason": reason}))
-        sys.exit(0 if allowed else 1)
-
-    elif command == "grant":
-        # grant <function_id> <data_type> <flow_direction> <name>
-        if len(sys.argv) < 6:
-            print("Usage: residency-gate.py grant <function_id> <type> <flow> <name>", file=sys.stderr)
-            sys.exit(1)
-
-        function_id = sys.argv[2]
-        data_type = sys.argv[3]
-        flow_direction = sys.argv[4]
-        need_name = sys.argv[5]
-
-        need_key = f"{data_type}_{flow_direction}_{need_name}"
-        gate.state.grant_consent(function_id, need_key)
-        print(json.dumps({"status": "granted", "function_id": function_id, "need": need_key}))
-        sys.exit(0)
-
-    elif command == "deny":
-        # deny <function_id> <data_type> <flow_direction> <name> [reason]
-        if len(sys.argv) < 6:
-            print("Usage: residency-gate.py deny <function_id> <type> <flow> <name> [reason]", file=sys.stderr)
-            sys.exit(1)
-
-        function_id = sys.argv[2]
-        data_type = sys.argv[3]
-        flow_direction = sys.argv[4]
-        need_name = sys.argv[5]
-        reason = sys.argv[6] if len(sys.argv) > 6 else "user denied"
-
-        need_key = f"{data_type}_{flow_direction}_{need_name}"
-        gate.state.deny_consent(function_id, need_key, reason)
-        print(json.dumps({"status": "denied", "function_id": function_id, "need": need_key}))
-        sys.exit(0)
-
-    elif command == "list":
-        # list [function_id]
-        all_consents = gate.state.list_all_consents()
-        if len(sys.argv) > 2:
             function_id = sys.argv[2]
-            print(json.dumps(all_consents.get(function_id, {}), indent=2))
-        else:
-            print(json.dumps(all_consents, indent=2))
-        sys.exit(0)
+            data_type = sys.argv[3]
+            flow_direction = sys.argv[4]
+            need_name = sys.argv[5]
 
-    elif command == "validate-pre-grant":
-        # validate-pre-grant [file] — deterministic check for the Week Close audit scan
-        pre_grant_file = Path(sys.argv[2]) if len(sys.argv) > 2 else None
-        try:
+            need = DataNeed(
+                name=need_name,
+                type=data_type,
+                flow_direction=flow_direction,
+                schema_version=1
+            )
+
+            allowed, reason = gate.check_lazy(function_id, need)
+            print(json.dumps({"allowed": allowed, "reason": reason}))
+            sys.exit(0 if allowed else 1)
+
+        elif command == "grant":
+            # grant <function_id> <data_type> <flow_direction> <name>
+            if len(sys.argv) < 6:
+                print("Usage: residency-gate.py grant <function_id> <type> <flow> <name>", file=sys.stderr)
+                sys.exit(1)
+
+            function_id = sys.argv[2]
+            data_type = sys.argv[3]
+            flow_direction = sys.argv[4]
+            need_name = sys.argv[5]
+
+            need_key = f"{data_type}_{flow_direction}_{need_name}"
+            gate.state.grant_consent(function_id, need_key)
+            print(json.dumps({"status": "granted", "function_id": function_id, "need": need_key}))
+            sys.exit(0)
+
+        elif command == "deny":
+            # deny <function_id> <data_type> <flow_direction> <name> [reason]
+            if len(sys.argv) < 6:
+                print("Usage: residency-gate.py deny <function_id> <type> <flow> <name> [reason]", file=sys.stderr)
+                sys.exit(1)
+
+            function_id = sys.argv[2]
+            data_type = sys.argv[3]
+            flow_direction = sys.argv[4]
+            need_name = sys.argv[5]
+            reason = sys.argv[6] if len(sys.argv) > 6 else "user denied"
+
+            need_key = f"{data_type}_{flow_direction}_{need_name}"
+            gate.state.deny_consent(function_id, need_key, reason)
+            print(json.dumps({"status": "denied", "function_id": function_id, "need": need_key}))
+            sys.exit(0)
+
+        elif command == "list":
+            # list [function_id]
+            all_consents = gate.state.list_all_consents()
+            if len(sys.argv) > 2:
+                function_id = sys.argv[2]
+                print(json.dumps(all_consents.get(function_id, {}), indent=2))
+            else:
+                print(json.dumps(all_consents, indent=2))
+            sys.exit(0)
+
+        elif command == "validate-pre-grant":
+            # validate-pre-grant [file] — deterministic check for the Week Close audit scan
+            pre_grant_file = Path(sys.argv[2]) if len(sys.argv) > 2 else None
             entries = load_pre_grant_entries(pre_grant_file)
             print(json.dumps({"valid": True, "entries": sorted(entries)}))
             sys.exit(0)
-        except PreGrantError as e:
-            print(json.dumps({"valid": False, "error": str(e)}))
+
+        elif command == "reset":
+            # reset <function_id>
+            if len(sys.argv) < 3:
+                print("Usage: residency-gate.py reset <function_id>", file=sys.stderr)
+                sys.exit(1)
+
+            function_id = sys.argv[2]
+            gate.state.reset_function_consents(function_id)
+            print(json.dumps({"status": "reset", "function_id": function_id}))
+            sys.exit(0)
+
+        else:
+            print(f"Unknown command: {command}", file=sys.stderr)
             sys.exit(1)
 
-    elif command == "reset":
-        # reset <function_id>
-        if len(sys.argv) < 3:
-            print("Usage: residency-gate.py reset <function_id>", file=sys.stderr)
-            sys.exit(1)
-
-        function_id = sys.argv[2]
-        gate.state.reset_function_consents(function_id)
-        print(json.dumps({"status": "reset", "function_id": function_id}))
-        sys.exit(0)
-
-    else:
-        print(f"Unknown command: {command}", file=sys.stderr)
-        sys.exit(1)
+    except (ManifestError, PreGrantError) as e:
+        # Fail closed: a malformed declaration or pre-grant list blocks the
+        # command — distinct from a policy denial (issue #521A: an operator
+        # fixes a broken manifest differently than a genuine consent refusal).
+        _emit_and_exit({"allowed": False, "error_class": "invalid_manifest", "error": str(e)}, 2, e)
+    except Exception as e:
+        # Anything else (I/O, permissions, a bug) — never a silent swallow
+        # (P4): always carries error_class + error, RESIDENCY_GATE_DEBUG=1 adds
+        # the trace. SystemExit is a BaseException, not Exception, so the
+        # sys.exit() calls above pass through this untouched.
+        _emit_and_exit({"allowed": False, "error_class": "runtime_error", "error": str(e)}, 4, e)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/residency-gate/tests/test_cli_error_contract.py
+++ b/.claude/skills/residency-gate/tests/test_cli_error_contract.py
@@ -1,0 +1,110 @@
+"""CLI-level exit-code / error_class contract for residency-gate.py (issue #521A).
+
+Subprocess-level tests, not unit tests against the library: the contract this
+guards is what a HOOK SCRIPT observes (exit code + JSON envelope on stdout) —
+exactly the layer that used to fabricate "consent denied" for a crash
+(issue #521, ModuleNotFoundError on `import yaml`).
+
+Contract: 0 allowed / 1 policy_denial / 2 invalid_manifest / 3 dependency_error
+/ 4 runtime_error. `error_class` is absent for policy_denial (the baseline the
+other three classes must stay distinguishable from).
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+GATE_PY = Path(__file__).parent.parent / "residency-gate.py"
+
+
+def _run(args, env=None):
+    return subprocess.run(
+        [sys.executable, str(GATE_PY), *args],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    (home / "IWE" / "current").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def yaml_shadowed_env(tmp_path):
+    """An env whose PYTHONPATH shadows the real `yaml` package with a stub
+    that raises ImportError — the same failure mode a genuinely missing
+    PyYAML produces, without needing to uninstall it from the test runner."""
+    stub_dir = tmp_path / "stub-site"
+    stub_dir.mkdir()
+    (stub_dir / "yaml.py").write_text("raise ImportError(\"No module named 'yaml'\")\n")
+    home = tmp_path / "home"
+    (home / "IWE" / "current").mkdir(parents=True)
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["PYTHONPATH"] = str(stub_dir) + os.pathsep + env.get("PYTHONPATH", "")
+    return env
+
+
+def test_policy_denial_exit_code(fake_home, tmp_path):
+    """A genuine consent refusal (never asked) is exit 1, no error_class."""
+    manifest = tmp_path / "SKILL.md"
+    manifest.write_text(
+        "---\nname: test\n---\n\n"
+        "data_needs:\n"
+        "  - type: 2.1, flow: inbound, name: sample-data, schema_version: 1\n"
+    )
+    result = _run(["check-activation", "pytest-fn", str(manifest)])
+    assert result.returncode == 1, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["allowed"] is False
+    assert "error_class" not in payload
+
+
+def test_invalid_manifest_exit_code(fake_home, tmp_path):
+    """A broken declaration (missing schema_version) is exit 2,
+    error_class=invalid_manifest — distinct from a policy denial."""
+    manifest = tmp_path / "SKILL.md"
+    manifest.write_text(
+        "---\nname: test\n---\n\n"
+        "data_needs:\n"
+        "  - type: 2.1, flow: inbound, name: broken\n"  # no schema_version
+    )
+    result = _run(["check-activation", "pytest-fn", str(manifest)])
+    assert result.returncode == 2, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["allowed"] is False
+    assert payload["error_class"] == "invalid_manifest"
+    assert "debug_trace" not in payload
+
+
+def test_dependency_error_exit_code(yaml_shadowed_env):
+    """A missing PyYAML (issue #521's actual trigger) is exit 3,
+    error_class=dependency_error — not a fabricated policy denial."""
+    result = _run(["check-activation", "pytest-fn", "/nonexistent.md"], env=yaml_shadowed_env)
+    assert result.returncode == 3, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["allowed"] is False
+    assert payload["error_class"] == "dependency_error"
+    assert "yaml" in payload["error"]
+    assert "debug_trace" not in payload
+
+
+def test_dependency_error_debug_trace_opt_in(yaml_shadowed_env):
+    """RESIDENCY_GATE_DEBUG=1 adds a full traceback; absent by default
+    (issue #521A consensus: `error` alone covers the common case)."""
+    yaml_shadowed_env["RESIDENCY_GATE_DEBUG"] = "1"
+    result = _run(["check-activation", "pytest-fn", "/nonexistent.md"], env=yaml_shadowed_env)
+    assert result.returncode == 3, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert "debug_trace" in payload
+    assert "Traceback" in payload["debug_trace"]

--- a/setup/test-update-edge-cases.sh
+++ b/setup/test-update-edge-cases.sh
@@ -32,6 +32,7 @@
 #   T31: extensions-gate is fail-closed: traversal/symlink/broken-manifest/manifest-edit block (WP-7 F71)
 #   T32: settings-merge-apply.sh applies with backup, rolls back on broken input (WP-7 F71 stage B)
 #   T33: update.sh wires stage-B flags with consensus safeguards (WP-7 F71)
+#   T36: inject-role-prefixes.sh reads .prompt on a real UserPromptSubmit payload (issue #525)
 #
 # Exit: 0 = all PASS, N = N tests failed
 #
@@ -2078,6 +2079,37 @@ then
     pass "T35: /extend lists all 16 invoked extension points"
 else
     fail "T35: /extend catalog differs from invoked extension points"
+fi
+
+# ============================================================
+# T36: inject-role-prefixes.sh reads .prompt, not .message (issue #525)
+# ============================================================
+echo ""
+echo "--- T36: inject-role-prefixes reads the real UserPromptSubmit field (#525) ---"
+
+if t16_run inject-role-prefixes.sh '{"session_id":"t36-role","prompt":"Навигатор, привет"}'; then
+    T36_EV=$(t16_json "d['hookSpecificOutput']['hookEventName']")
+    T36_LEN=$(t16_json "len(d['hookSpecificOutput']['additionalContext'])")
+    if [ "$T36_EV" = "UserPromptSubmit" ] && [ "${T36_LEN:-0}" -gt 100 ]; then
+        pass "T36: inject-role-prefixes injects role context on a real .prompt payload"
+    else
+        fail "T36: inject-role-prefixes event='$T36_EV' ctx_len='${T36_LEN:-none}'"
+    fi
+fi
+
+# A prompt without a role prefix must stay a no-op ({}) — proves the field
+# read is real, not accidentally matching everything.
+T36_NOOP=$(printf '%s' '{"session_id":"t36-plain","prompt":"обычный вопрос без префикса"}' | \
+    HOME="$T16_HOME" CLAUDE_PROJECT_DIR="$T16_PROJ" bash "$TEMPLATE_DIR/.claude/hooks/inject-role-prefixes.sh" 2>/dev/null)
+[ "$T36_NOOP" = "{}" ] \
+    && pass "T36: inject-role-prefixes stays a no-op without a role prefix" \
+    || fail "T36: inject-role-prefixes should return {} for a plain prompt, got '$T36_NOOP'"
+
+# Regression guard for #525 itself: the field name must be .prompt, not .message.
+if grep -q "jq -r '\.message" "$TEMPLATE_DIR/.claude/hooks/inject-role-prefixes.sh"; then
+    fail "T36: inject-role-prefixes.sh still reads .message (issue #525 regressed)"
+else
+    pass "T36: inject-role-prefixes.sh reads .prompt, not .message"
 fi
 
 # ============================================================

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -89,7 +89,7 @@
     },
     {
       "path": ".claude/hooks/inject-role-prefixes.sh",
-      "sha256": "310386f4f5f64781978a75d1743ab43096135026a674ddbfbf00876d26be0758"
+      "sha256": "cc439d8a81737f586145bd6a88a0a0fd63eea258e38e0318610d81a08a2f6b7a"
     },
     {
       "path": ".claude/hooks/lazy-context-loader.sh",
@@ -125,15 +125,15 @@
     },
     {
       "path": ".claude/hooks/residency-gate-init.sh",
-      "sha256": "582eb27ec1d4bd812c148ac538d6bfd1f12b4318cadb3aee9b5cdecbd18b95b9"
+      "sha256": "8064b5d769306c51c718212e24c2584373d358ebc4843e9d840bfac8a9b5359b"
     },
     {
       "path": ".claude/hooks/residency-gate-lazy.sh",
-      "sha256": "030aaa6fe19acc24103744cd1026c93955a2c5ed5ff6cd8dc933c8886ed3339a"
+      "sha256": "d134fb417f2640e746778f2c208d5a833ab1d91a1d9eb1245bfc8af9ddee1f3c"
     },
     {
       "path": ".claude/hooks/residency-gate-skill-adapter.sh",
-      "sha256": "8e8258e78bb943c05c368736595e3d4a96623ee4dd2e36a53bdc1477b290ffd5"
+      "sha256": "31753b2a377c973825c12f9076a0c4d33ff5ceaeb04c11cd96d6894740caac26"
     },
     {
       "path": ".claude/hooks/response-clarity-hook.sh",
@@ -481,7 +481,11 @@
     },
     {
       "path": ".claude/skills/residency-gate/residency-gate.py",
-      "sha256": "df6730f7bfd4d7c004d9db527660ce6f9d0c6d5e80b93d986d733575f5ac41b9"
+      "sha256": "d872395147af2e46789e58abe48b1538b8a8bf4efdd0b545efab4455676ec02d"
+    },
+    {
+      "path": ".claude/skills/residency-gate/tests/test_cli_error_contract.py",
+      "sha256": "dbea13069496a262efe36f0753dee0f38f4104dbacf764a951ddd48d93a835fe"
     },
     {
       "path": ".claude/skills/residency-gate/tests/test_parser.py",


### PR DESCRIPTION
## Summary

- **#521A (P0, resolver/error contract):** all three ResidencyGate hooks (`residency-gate-lazy.sh`, `residency-gate-init.sh`, `residency-gate-skill-adapter.sh`) now go through the existing `scripts/lib/find-python3.sh` resolver instead of calling bare `python3`. `residency-gate.py` gets a 5-code exit contract (`0` allowed / `1` policy_denial / `2` invalid_manifest / `3` dependency_error / `4` runtime_error) with `error_class` + `error` always present on failure, `debug_trace` opt-in via `RESIDENCY_GATE_DEBUG=1`. This is the exact bug from the live issue #521 report (`ModuleNotFoundError: No module named 'yaml'` reported as a false "requires data consent" denial) — reproduced and fixed.
- **#525 (P1, functional delivery contract):** `inject-role-prefixes.sh` read `.message` instead of `.prompt` from the `UserPromptSubmit` payload — role-prefix activation ("Навигатор, ...") never fired since the hook was wired up. One-line fix, matches the three sibling hooks on the same event.
- **Scope boundary honored:** `lib/state.py`'s default state-file location (`~/IWE/current/data-residency.yaml`, "state-home") is untouched — that's WP-476's territory, not this delivery-pipeline fix.

Two bugs found and fixed along the way, same class as #521A: `residency-gate-lazy.sh` mixed `set -e` with an unguarded failing command substitution, silently aborting *before* printing any diagnostic on every denial (not just crashes); `residency-gate-init.sh`'s `cmd || echo fallback` pattern concatenated the real command's stdout with the fallback's instead of replacing it, so every normal policy denial showed a false "produced no output" message.

## Process

Peer session with Codex (DP.SC.154) on the design — consensus reached in 3 turns, one substantive revision (5 exit codes instead of my initial 4-code proposal, plus opt-in `debug_trace`; Codex's argument: dependency errors and runtime errors need different remediation, conflating them regresses the same "guess from text" problem #521A set out to fix). Session transcript: `sessions/2026-08/24/2026-08-24-16-wp-iwe-fmt-issues/` (DS-my-strategy).

Two rounds of adversarial cold-context code review (independent subagent, no access to my reasoning) found 4 Critical bugs in the first implementation pass — all in how the shell hooks re-parsed `residency-gate.py`'s JSON via hand-rolled `grep`/`sed` (missing the space `json.dumps` inserts after `:`, truncation on escaped quotes, `set -e`/`pipefail` aborting before the diagnostic message printed). Fixed by switching all three hooks to `jq`. Second review round confirmed the fixes and found one more Medium issue (a genuinely non-JSON crash — e.g. a `SyntaxError` in a corrupted `lib/*.py` — was mislabeled as "requires consent" instead of "crashed"), also fixed.

## Test plan

- [x] `setup/test-update-edge-cases.sh` full suite: 127 PASS, 0 FAIL (includes new T36 for #525, and T15 which regressed once during implementation and was caught/fixed by this same run)
- [x] New `.claude/skills/residency-gate/tests/test_cli_error_contract.py` (subprocess-level exit-code/`error_class` contract, including a `PYTHONPATH`-stub simulation of a missing PyYAML — the exact issue #521 trigger). **Not run through pytest** — this sandbox has no `pytest` installed (NixOS, no pip); all 4 scenarios were independently reproduced by hand as raw subprocess calls with matching exit codes and JSON shape. Recommend running `pytest .claude/skills/residency-gate/tests/` in CI before merge.
- [x] Existing `scripts/tests/test_residency_gate_skill_adapter.py` hand-traced against the new code (not re-run for the same pytest-availability reason) — all 8 scenarios (no manifest / no data_needs / no consent / granted / denied / non-skill tool / broken manifest) still hold given the exit-code mapping is unchanged at the hook's own external boundary (`0`/`2`), only the internal message text changed.
- [x] Manually verified message content (not just exit code) for all four error classes across all three hooks, including two hand-built failure simulations (stubbed resolver returning "not found", and a stand-in `residency-gate.py` that crashes with a raw non-JSON traceback) that reproduce exactly the shell-parsing bugs the cold reviews found.
- [x] `update-manifest.json` regenerated via `generate-manifest.sh` — covers the 5 changed shipped files + 1 new test file; `setup/test-update-edge-cases.sh` correctly stays in `excluded_paths` (dev-only, not delivered to users).

Refs: WP-529 F17, issues #521A #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)