### PR TITLE
fix(session-guard): audit resolves MC-sessions like open/close

### DIFF
--- a/scripts/session-guard.sh
+++ b/scripts/session-guard.sh
@@ -962,6 +962,13 @@ if [ "$CMD" = "renew" ]; then
 fi
 
 if [ "$CMD" = "audit" ]; then
+  # WP-526 Ф2 fix (29.08, peer-session 2026-08-29-06-wp526-worktree-guard-continue):
+  # open (line ~482) and close (line ~668) already re-resolve ORZ_DIR through
+  # resolve_orz_sessions_dir() before using it -- audit never did, so it kept
+  # reading the top-level legacy default (line 110) even on an install that
+  # already migrated to MC-sessions. Same one-line fix, same place in the
+  # command, as the other two commands.
+  ORZ_DIR="$(resolve_orz_sessions_dir)"
   if [ "$CLEANUP_ORPHANS" -eq 1 ]; then
     sweep_orphaned_semaphores
     echo

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2437,7 +2437,7 @@
     },
     {
       "path": "scripts/session-guard.sh",
-      "sha256": "f1026ff6cebb294a1afa22b355db4fda8163a37f25cedbcd6267b19850c67249"
+      "sha256": "4863651162cedf2a91eb596a361bec930490c7ef25b78a3e926595dd76a927fa"
     },
     {
       "path": "scripts/settings-promote.sh",


### PR DESCRIPTION
## Что

`audit` в `scripts/session-guard.sh` до этой правки читал глобальную `ORZ_DIR` (жёсткий legacy-путь `$GOV_REPO/sessions`) — `open`/`close` уже переприсваивают её через `resolve_orz_sessions_dir()` (сегодняшний фикс, PR #567), `audit` пропустили. На мигрированной установке `audit` сканировал бы пустой legacy-каталог вместо `MC-sessions`.

## Проверено

- `bash -n` + `shellcheck -S warning` — чисто.
- 3 изолированные фикстуры (`env -i`, отдельные `HOME`/`IWE_ROOT`, реальные git-репозитории): MC-sessions есть → выбран тихо; только legacy → WARN + fallback; ничего нет → тот же WARN + fallback, не падает.
- `--cleanup-orphans` (`sweep_orphaned_semaphores()`) работает над `$SESSION_DIR`, не над `$ORZ_DIR` — подтверждено чтением кода, фикс её не затрагивает.

## Откуда

Пир-сессия `2026-08-29-06-wp526-worktree-guard-continue` (Kimi — скептик безопасности, Codex — верификатор), оба CONSENSUS. РП526.

🤖 Generated with peer-session (Claude + Kimi + Codex)