### PR TITLE
fix(extractor): teach KE pipeline the monthly captures rotation (WP-526/WP-170)

### DIFF
--- a/roles/extractor/prompts/git-diff-feed.md
+++ b/roles/extractor/prompts/git-diff-feed.md
@@ -1,11 +1,11 @@
 # Git-Diff Feeder
 
 > Source-of-truth: WP-247 Ф-MULTI-SOURCE.2.
-> Запускается cron 06:00 / 21:00. Извлекает кандидатов из git коммитов за окно и пишет ###-блоки в captures.md.
+> Запускается cron 06:00 / 21:00. Извлекает кандидатов из git коммитов за окно и пишет ###-блоки в текущий помесячный `inbox/captures/YYYY-MM.md` (при включённой ротации; без неё — в `inbox/captures.md`).
 
 ## Роль
 
-Ты — Knowledge Feeder в git-diff режиме. Анализируешь свежие коммиты во всех `~/IWE/*` репо и формируешь ###-блоки в captures.md для тем, которые НЕ попали в обычный inbox-check.
+Ты — Knowledge Feeder в git-diff режиме. Анализируешь свежие коммиты во всех `~/IWE/*` репо и формируешь ###-блоки в целевом captures-файле для тем, которые НЕ попали в обычный inbox-check.
 
 ## Когда вызывается
 
@@ -16,7 +16,8 @@
 ## Конфигурация
 
 Читай:
-1. `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/captures.md` — текущий inbox (для де-дупликации)
+1. `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/captures/YYYY-MM.md` (текущий месяц) — целевой файл (куда писать); нет папки `inbox/captures/` → писать в легаси `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/captures.md`
+1b. Легаси `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/captures.md` + прошлый помесячный файл — для де-дупликации
 2. `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/feedback-log.md` — паттерны reject
 
 ## Алгоритм
@@ -55,7 +56,7 @@ done
 - Тест универсальности: «можно ли использовать в другом проекте?» — нет → пропустить
 - **Лимит:** ≤8 кандидатов на запуск
 
-### Шаг 4: Запись в captures.md
+### Шаг 4: Запись в целевой captures-файл
 
 Для каждого кандидата — добавить ###-блок:
 
@@ -74,13 +75,13 @@ done
 
 ### Шаг 5: Идемпотентность
 
-Перед записью проверить наличие capture с тем же sha-short в captures.md за окно. Если есть — пропустить.
+Перед записью проверить наличие capture с тем же sha-short за окно — в целевом файле, прошлом месяце и легаси `captures.md`. Если есть — пропустить.
 
 ### Шаг 6: Коммит
 
 ```bash
 cd {{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}
-git add inbox/captures.md
+git add inbox/captures/YYYY-MM.md   # или inbox/captures.md без ротации
 git commit -m "feed(git-diff): N capture-кандидатов из коммитов SINCE=$SINCE"
 ```
 

--- a/roles/extractor/prompts/inbox-check.md
+++ b/roles/extractor/prompts/inbox-check.md
@@ -27,11 +27,12 @@
 
 ### Шаг 1: Проверить inbox (WP-247 Ф-MULTI-SOURCE.3 — два канала)
 
-1. Прочитай `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/captures.md` — основной inbox
+1. Прочитай `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/captures.md` — легаси-inbox (после ротации помесячных файлов не растёт, но может держать старые pending)
+1b. Прочитай все файлы `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/captures/YYYY-MM.md` по возрастанию месяца — **только** имена вида `2026-08.md` (`^[0-9]{4}-[0-9]{2}\.md$`); другие файлы в этой папке (`pattern_*.md`, `lesson_*.md` и т.п.) НЕ читать. Папка может отсутствовать (ротация не включена) — пропусти.
 2. Прочитай `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/fleeting-notes.md` — secondary inbox (быстрые мысли пользователя). Файл может отсутствовать — пропусти.
 3. Найди все pending записи в обоих файлах: секции `### ...` БЕЗ любого из 4 маркеров статуса на той же строке (`[analyzed]`, `[processed]`, `[duplicate]`, `[defer]`). Если стоит хоть один — capture уже в workflow, пропускай.
 
-   **Источники различай:** при формализации в Шаге 2 укажи в кандидате `source_file: captures.md` или `source_file: fleeting-notes.md`. Это нужно R15 для пометки правильного файла маркером `[analyzed]` после accept.
+   **Источники различай:** при формализации в Шаге 2 укажи в кандидате `source_file: captures.md`, `source_file: captures/YYYY-MM.md` или `source_file: fleeting-notes.md`. Это нужно R15 для пометки правильного файла маркером `[analyzed]` после accept.
 
 4. Если pending записей нет → сообщение `No pending captures in inbox` выводи через stdout (его поймает `extractor.sh` и запишет в `{{HOME_DIR}}/logs/extractor/YYYY-MM-DD.log`). **НЕ создавай отдельный лог-файл** в `{{GOVERNANCE_REPO}}/` или где-либо ещё. Заверши работу.
 5. Если pending > 5 → возьми первые 5 (по порядку: сначала captures.md, потом fleeting-notes.md)

--- a/roles/extractor/prompts/session-close-feed.md
+++ b/roles/extractor/prompts/session-close-feed.md
@@ -5,11 +5,11 @@
 
 ## Роль
 
-Ты — Knowledge Feeder (R2 в feeder-режиме). Твоя задача: извлечь capture-кандидатов из транскрипта сессии + git diff и **записать их в `captures.md` как ###-блоки**.
+Ты — Knowledge Feeder (R2 в feeder-режиме). Твоя задача: извлечь capture-кандидатов из транскрипта сессии + git diff и **записать их ###-блоками в текущий помесячный файл `inbox/captures/YYYY-MM.md`** (при включённой ротации помесячных файлов; без ротации — в `inbox/captures.md`).
 
 **Ключевое отличие от `session-close.md` (interactive):**
 - `session-close.md` создаёт Extraction Report и ждёт одобрения пользователя
-- `session-close-feed.md` (этот) **молча пишет в `captures.md`** — пользователь увидит при следующем `/apply-captures`
+- `session-close-feed.md` (этот) **молча пишет в помесячный файл captures** — пользователь увидит при следующем `/apply-captures`
 
 ## Когда вызывается
 
@@ -18,7 +18,7 @@
 ## Конфигурация
 
 Читай:
-1. `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/captures.md` — целевой файл (куда писать)
+1. `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/captures/YYYY-MM.md` (текущий месяц) — целевой файл (куда писать); нет файла → создай с заголовком `# Captures YYYY-MM`. Папки `inbox/captures/` нет вовсе (ротация не включена) → писать в легаси `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/captures.md`. Легаси-файл при включённой ротации — только для де-дупликации.
 2. `{{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}/inbox/feedback-log.md` — паттерны reject (не предлагай похожее)
 3. Транскрипт сессии (передаётся через `--extra-args` или путь в env)
 4. `git log --since="<session start timestamp>"` всех `~/IWE/*` репо
@@ -41,9 +41,9 @@
 
 **НЕ делай** полную формализацию (frontmatter, готовый текст файла) — это работа `inbox-check.md` потом.
 
-### Шаг 3: Запись в captures.md
+### Шаг 3: Запись в целевой captures-файл
 
-Для каждого кандидата — добавить ###-блок в **конец** `captures.md` (после существующих записей):
+Для каждого кандидата — добавить ###-блок в **конец** целевого файла (после существующих записей):
 
 ```markdown
 ### {Краткое название мысли} [feed:session-close YYYY-MM-DD]
@@ -66,7 +66,7 @@
 После записи всех ###-блоков:
 ```bash
 cd {{WORKSPACE_DIR}}/{{GOVERNANCE_REPO}}
-git add inbox/captures.md
+git add inbox/captures/YYYY-MM.md   # или inbox/captures.md без ротации
 git commit -m "feed(session-close): N capture-кандидатов из сессии YYYY-MM-DD"
 ```
 
@@ -76,7 +76,7 @@ git commit -m "feed(session-close): N capture-кандидатов из сесс
 
 - **НЕ создавай Extraction Report** — это работа `inbox-check.md` потом
 - **НЕ ждать одобрения** — feed-режим silent
-- **НЕ записывай в Pack** — только в `captures.md`
+- **НЕ записывай в Pack** — только в целевой captures-файл
 - **НЕ дублируй** ручные capture'ы за сегодня (проверяй до записи)
 - **НЕ экстрагируй governance** (план, статус, прогресс) — только переносимое знание
 - **НЕ помечай feed-блоки** маркерами `[analyzed]`/`[processed]`/`[duplicate]`/`[defer]` — они должны остаться pending для inbox-check цикла

--- a/roles/extractor/prompts/session-close.md
+++ b/roles/extractor/prompts/session-close.md
@@ -321,9 +321,9 @@ epistemic_stage: emerging
 
 ### Шаг 8a: Пометка captures
 
-> После применения accept-кандидатов — пометить обработанные captures в `{{GOVERNANCE_REPO}}/inbox/captures.md`.
+> После применения accept-кандидатов — пометить обработанные captures в том файле, где найден capture: помесячный `{{GOVERNANCE_REPO}}/inbox/captures/YYYY-MM.md` (при включённой ротации) или легаси `{{GOVERNANCE_REPO}}/inbox/captures.md`.
 
-1. Для каждого accept-кандидата, который был взят из `captures.md`:
+1. Для каждого accept-кандидата, который был взят из captures-файла:
    - Добавить `[processed YYYY-MM-DD]` к заголовку записи
    - `[processed]` ставится **ТОЛЬКО** после подтверждённой записи в Pack (не при чтении)
 2. Для reject-кандидатов из captures.md — добавить `[rejected YYYY-MM-DD]` с причиной

--- a/roles/extractor/scripts/extractor.sh
+++ b/roles/extractor/scripts/extractor.sh
@@ -240,14 +240,14 @@ commit_extractor_changes() {
     # Не трогаем файлы экстрактора, если их уже подготовил другой процесс.
     # `commit --only` сохраняет staging всех остальных путей без ручного reset.
     if ! git -C "$strategy_dir" diff --cached --quiet -- \
-        inbox/captures.md inbox/extraction-reports/; then
+        inbox/captures.md inbox/captures/ inbox/extraction-reports/; then
         log "SKIP: extractor paths are already staged; skipping commit"
         EXTRACTOR_COMMIT_RESULT="blocked"
         return 0
     fi
 
     target_changes=$(git -C "$strategy_dir" status --porcelain --untracked-files=all -- \
-        inbox/captures.md inbox/extraction-reports/)
+        inbox/captures.md inbox/captures/ inbox/extraction-reports/)
     if [ -z "$target_changes" ]; then
         log "No new changes to commit in $repo_name"
         EXTRACTOR_COMMIT_RESULT="no_changes"
@@ -264,7 +264,7 @@ commit_extractor_changes() {
 
     # `git commit --only` does not discover a brand-new report directory. Stage only
     # extractor-owned paths; `--only` below still leaves every foreign staged path intact.
-    if ! git -C "$strategy_dir" add -- inbox/captures.md inbox/extraction-reports/ >> "$LOG_FILE" 2>&1; then
+    if ! git -C "$strategy_dir" add -- inbox/captures.md inbox/captures/ inbox/extraction-reports/ >> "$LOG_FILE" 2>&1; then
         log "WARN: cannot stage extractor changes for $repo_name"
         EXTRACTOR_COMMIT_RESULT="failed"
         return 1
@@ -272,7 +272,7 @@ commit_extractor_changes() {
 
     if ! git -C "$strategy_dir" commit --only \
         -m "inbox-check: extraction report $DATE" -- \
-        inbox/captures.md inbox/extraction-reports/ >> "$LOG_FILE" 2>&1; then
+        inbox/captures.md inbox/captures/ inbox/extraction-reports/ >> "$LOG_FILE" 2>&1; then
         log "WARN: git commit failed for $repo_name"
         EXTRACTOR_COMMIT_RESULT="failed"
         return 1
@@ -369,8 +369,7 @@ cleanup_isolated_inbox_worktree() {
 }
 
 pending_capture_count() {
-    local captures_file="$1"
-
+    # Accepts one or more capture files; awk accumulates pending across all.
     awk '
       /^### / && !/\[(analyzed|processed|duplicate|defer)/ {
         found = 0
@@ -383,7 +382,19 @@ pending_capture_count() {
         if (found) pending++
       }
       END { print pending+0 }
-    ' "$captures_file" 2>/dev/null
+    ' "$@" 2>/dev/null
+}
+
+# WP-526 rotation: capture sources = legacy captures.md + monthly
+# inbox/captures/YYYY-MM.md files (whitelist by name, other files in the
+# directory are not inbox material).
+capture_source_files() {
+    local inbox_dir="$1"
+    [ -f "$inbox_dir/captures.md" ] && printf '%s\n' "$inbox_dir/captures.md"
+    if [ -d "$inbox_dir/captures" ]; then
+        find "$inbox_dir/captures" -maxdepth 1 -type f \
+            -name '[0-9][0-9][0-9][0-9]-[0-9][0-9].md' | sort
+    fi
 }
 
 run_inbox_check_isolated() {
@@ -445,7 +456,14 @@ run_inbox_check_isolated() {
         return 1
     fi
 
-    actual_pending=$(pending_capture_count "$worktree/inbox/captures.md")
+    local capture_sources=()
+    while IFS= read -r src; do
+        capture_sources+=("$src")
+    done < <(capture_source_files "$worktree/inbox")
+    actual_pending=0
+    if [ "${#capture_sources[@]}" -gt 0 ]; then
+        actual_pending=$(pending_capture_count "${capture_sources[@]}")
+    fi
     actual_pending=${actual_pending:-0}
     if [ "$actual_pending" -le 0 ]; then
         log "SKIP: No pending captures in refreshed inbox"
@@ -534,16 +552,17 @@ case "$1" in
     "session-close-feed")
         # WP-247 Ф-MULTI-SOURCE.1: feeder-режим (non-interactive).
         # Извлекает кандидатов из транскрипта + git diff,
-        # пишет ###-блоки в captures.md с маркером [feed:session-close YYYY-MM-DD].
+        # пишет ###-блоки в помесячный inbox/captures/YYYY-MM.md (ротация
+        # WP-526; без ротации — в captures.md) с маркером [feed:session-close].
         # Не создаёт extraction-report — это работа inbox-check потом.
-        log "Running session-close FEED (non-interactive, writes to captures.md)"
+        log "Running session-close FEED (non-interactive, writes to captures inbox)"
         run_claude "session-close-feed" "${2:-}"
         notify_telegram "session-close-feed"
         ;;
 
     "git-diff-feed")
         # WP-247 Ф-MULTI-SOURCE.2: git-diff feeder (cron 06:00/21:00).
-        # Извлекает кандидатов из git log за окно и пишет ###-блоки в captures.md.
+        # Извлекает кандидатов из git log за окно и пишет ###-блоки в captures-inbox.
         # Окно: $2 (по умолчанию "12 hours ago").
         SINCE="${2:-12 hours ago}"
         log "Running git-diff FEED (since: $SINCE)"

--- a/roles/synchronizer/scripts/templates/extractor.sh
+++ b/roles/synchronizer/scripts/templates/extractor.sh
@@ -38,6 +38,31 @@ build_message() {
             printf "<b>🔍 Knowledge Audit завершён</b>\n\n📅 %s\n\nПроверьте лог: ~/logs/extractor/%s.log" "$DATE" "$DATE"
             ;;
 
+        "session-close-feed"|"git-diff-feed")
+            # Feed scenarios append ###-blocks to the captures inbox (monthly
+            # file under the WP-526 rotation, flat captures.md without it).
+            # Count today's blocks by the feed marker so the pilot sees intake
+            # volume, not just "the feed ran".
+            local feed_marker="feed:${process%-feed}"
+            local inbox_dir="${IWE_WORKSPACE:-$HOME/IWE}/${IWE_GOVERNANCE_REPO:-DS-strategy}/inbox"
+            local captures_target="$inbox_dir/captures/$(date +%Y-%m).md"
+            [ -f "$captures_target" ] || captures_target="$inbox_dir/captures.md"
+            local captured=0
+            if [ -f "$captures_target" ]; then
+                captured=$(grep -c "\[${feed_marker} ${DATE}\]" "$captures_target" 2>/dev/null || true)
+                captured=${captured:-0}
+            fi
+
+            printf "<b>🔍 Knowledge Feeder: %s</b>\n\n" "$process"
+            printf "📅 %s\n\n" "$DATE"
+            if [ "$captured" -gt 0 ]; then
+                printf "Захвачено кандидатов за сегодня: %s\n" "$captured"
+                printf "Файл: <code>%s</code>" "${captures_target#"$inbox_dir/"}"
+            else
+                printf "Новых кандидатов нет."
+            fi
+            ;;
+
         *)
             echo ""
             ;;

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1589,11 +1589,11 @@
     },
     {
       "path": "roles/extractor/prompts/git-diff-feed.md",
-      "sha256": "5a090cdf87b6fd8c8b4fa33aca5d46ac707a69760208d3853e1035d8f5827330"
+      "sha256": "b51365aedcd3c3fcc726e6077dd68b2241770b230bc72df7caff2dffb4781b89"
     },
     {
       "path": "roles/extractor/prompts/inbox-check.md",
-      "sha256": "e0d869263a97a5541d5a24635572490e2e9f37a59ac62ea36d387284cfcd9074"
+      "sha256": "ffd1faf3ca2ba625fab9fe491a430f3ecb0a724c6364cabb9fd00dfe76dd48cb"
     },
     {
       "path": "roles/extractor/prompts/knowledge-audit.md",
@@ -1605,11 +1605,11 @@
     },
     {
       "path": "roles/extractor/prompts/session-close-feed.md",
-      "sha256": "ab7c3c62f9a155e9f99e4998d228b7fbfaf64b1cf85eb5b8c820abc94980ecc4"
+      "sha256": "e3d4517e09b60a99a81f25ea2cc734770d453cd1ba66e825d883744157bf8e28"
     },
     {
       "path": "roles/extractor/prompts/session-close.md",
-      "sha256": "72ec9ae9d9553d1b00a0b8b5011291ce1438c3e1a300739d5a019d2b56f9a68a"
+      "sha256": "5721090b978bb0a5f1273a43c2bac938002d77671932f514d4cc923cc1222dc9"
     },
     {
       "path": "roles/extractor/role.yaml",
@@ -1617,7 +1617,7 @@
     },
     {
       "path": "roles/extractor/scripts/extractor.sh",
-      "sha256": "a63006b35ff917c73853c7db1bce5ce91dcc1c791d43e55b16f790e02a77aa38"
+      "sha256": "9905bcac0889bca52c461330ba0cbdc35df6d236a1ff35e207fd93998a41dc28"
     },
     {
       "path": "roles/extractor/scripts/launchd/com.extractor.inbox-check.plist",
@@ -1869,7 +1869,7 @@
     },
     {
       "path": "roles/synchronizer/scripts/templates/extractor.sh",
-      "sha256": "e1753f1e5f38b10f5b115882ed85a8fe7d820985136988e8d118d03662181b8e"
+      "sha256": "b06348f4b90945d739974f470f92614164a271188513d64c0aa4ddd39e78eacd"
     },
     {
       "path": "roles/synchronizer/scripts/templates/strategist.sh",


### PR DESCRIPTION
## Что и зачем

После ротации captures (WP-526, 29.08) новые находки пишутся в помесячные `inbox/captures/YYYY-MM.md`, но читатель конвейера знаний (inbox-check) и оба сборщика (session-close-feed, git-diff-feed) знали только плоский `inbox/captures.md`. Итог: конвейер вечно рапортует «inbox пуст», а сборщики пишут в замороженный архив.

## Изменения

- **inbox-check.md**: помесячные файлы — полноправный источник находок (белый список `^[0-9]{4}-[0-9]{2}\.md$`, прочие файлы в папке игнорируются)
- **extractor.sh**: `pending_capture_count` по всем источникам через новый `capture_source_files()`; commit-scope включает `inbox/captures/`
- **session-close-feed.md / git-diff-feed.md**: запись в текущий помесячный файл при включённой ротации, легаси-fallback без неё
- **session-close.md** Шаг 8a: пометки `[processed]`/`[rejected]` — в том файле, где живёт capture
- **notify-шаблон synchronizer**: сообщения для обоих feed-сценариев (раньше возвращал пустоту — оповещение молча пропускалось)
- `update-manifest.json` пересчитан (`verify-manifest.sh` зелёный)

## Проверки

- `bash -n` оба скрипта
- pre-check прогнан на синтетическом дереве: 2 источника (легаси + месяц), pattern_*-файл проигнорирован, pending=1 из 3 записей — совпало с ожиданием
- notify-шаблон: build_message для обоих фидов возвращает валидное сообщение

Живая копия DS-ai-systems уже обновлена теми же правками (4d83ca1, 161676f) — пир-сессия 2026-08-30-01-ke-pipeline-repair-review (WP-170, консенсус с Codex за 3 хода).

🤖 Generated with [Claude Code](https://claude.com/claude-code)