### PR TITLE
fix(scripts): ke-queue-stats.sh age from report frontmatter, not file mtime

### DIFF
--- a/scripts/ke-queue-stats.sh
+++ b/scripts/ke-queue-stats.sh
@@ -61,11 +61,32 @@ if [ "$COUNT" -eq 0 ]; then
   exit 0
 fi
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  OLDEST_TS=$(echo "$PENDING_FILES" | xargs -I{} stat -f "%m" "{}" 2>/dev/null | sort -n | head -1)
-else
-  OLDEST_TS=$(echo "$PENDING_FILES" | tr '\n' '\0' | xargs -0 stat -c "%Y" 2>/dev/null | sort -n | head -1)
-fi
+# Age comes from the report's frontmatter `date:` — file mtime lies after any
+# clone/checkout/history rewrite (a fresh `git clone` resets every mtime to
+# checkout time, so a 13-day-old pending report reads as "0 days" right after
+# a restore or a machine move — found 2026-08-30, WP-170). mtime is the
+# fallback for reports without a parsable date.
+oldest_report_ts() {
+  local ts best=""
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    local fm_date
+    fm_date=$(awk '/^---/{if(seen)exit;seen=1;next} seen && /^date:/{gsub(/["'\'' ]/,"",$2);print $2;exit}' "$f")
+    if [[ "$fm_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+      ts=$(date -d "$fm_date" +%s 2>/dev/null || date -j -f "%Y-%m-%d" "$fm_date" +%s 2>/dev/null)
+    else
+      if [[ "$(uname -s)" == "Darwin" ]]; then
+        ts=$(stat -f "%m" "$f" 2>/dev/null)
+      else
+        ts=$(stat -c "%Y" "$f" 2>/dev/null)
+      fi
+    fi
+    [ -n "$ts" ] && { [ -z "$best" ] || [ "$ts" -lt "$best" ]; } && best="$ts"
+  done <<<"$1"
+  echo "$best"
+}
+
+OLDEST_TS=$(oldest_report_ts "$PENDING_FILES")
 NOW_TS=$(date +%s)
 if [ -z "$OLDEST_TS" ]; then
   OLDEST_DAYS=-1

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2265,7 +2265,7 @@
     },
     {
       "path": "scripts/ke-queue-stats.sh",
-      "sha256": "dca248d321a3737fe9b0afc9a623036de290bcbaa343cbc1f6bbcb3dbd3eb143"
+      "sha256": "5428c6cc329add702e5d2ff91ba7af2114a8cd023f9cb5c921a9f6b1720e89df"
     },
     {
       "path": "scripts/kimi-auto-heartbeat.sh",


### PR DESCRIPTION
## Что и зачем

Найдено при аудите шаблона на предмет проблем, похожих на те, что сломали конвейер знаний в РП170 (личная инсталляция пилота).

`scripts/ke-queue-stats.sh` (используется утренним открытием дня для показа возраста очереди находок) брал возраст самого старого отчёта по времени последнего изменения файла на диске. Это ломается на **любом** свежем `git clone`/чекауте — восстановление из бэкапа, переезд на новую машину, перезапись истории — все они сбрасывают mtime на текущий момент. Реально 13-дневный отчёт после такой операции читается как «0 дней, всё в порядке» и прячет настоящий backlog от пилота.

Скрипт шипится всем пользователям шаблона (`scripts/ke-queue-stats.sh`, не governance-репо-специфичный файл) — это платформенный баг, не личная особенность одной инсталляции.

## Изменения

- Возраст теперь берётся из `date:` во frontmatter отчёта; mtime — только fallback для отчётов без парсящейся даты
- `update-manifest.json` пересчитан

## Проверки

- `bash -n` чисто
- Смоук: синтетический отчёт с `date: 2026-08-17` и только что обновлённым mtime (`touch`) → скрипт возвращает `oldest_age_days: 13`, не 0 — воспроизводит и закрывает ровно тот сценарий, что ломался

Тот же паттерн уже применён и живьём проверен в личном хранилище пилота (DS-my-strategy) в рамках починки конвейера РП170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)