### PR TITLE
fix(session-guard): close honors close_path=peer-session (WP-484 F118 port)

### DIFF
--- a/scripts/session-guard.sh
+++ b/scripts/session-guard.sh
@@ -703,7 +703,7 @@ if [ "$CMD" = "close" ]; then
   # 4.5.1/4.5.2) прямой git commit, не раннер. Без этого обхода close требовал
   # у пир-сессии карточку чужого ритуала (живой отказ 30.08). close_path
   # записан этим же скриптом при open — достаточное свидетельство.
-  if [ -z "$RUNNER_OK" ] && grep -q '^close_path: peer-session$' "$SEM_FILE" 2>/dev/null; then
+  if [ -z "$RUNNER_OK" ] && grep -q '^close_path: peer-session$' "${SEM_FILE:-}" 2>/dev/null; then
     RUNNER_OK="declared-peer-session:$SLUG"
     echo "Session CLOSE: close_path=peer-session объявлен при open — раннер не требуется (WP-484 Ф118)." >&2
   fi

--- a/scripts/session-guard.sh
+++ b/scripts/session-guard.sh
@@ -697,6 +697,17 @@ if [ "$CMD" = "close" ]; then
     break
   done
 
+  # WP-484 Ф118 / WP-530 Ф18 (порт из авторского source, 30.08.2026): сессия,
+  # открытая с "open --close-path peer-session", по определению никогда не
+  # создаёт RUN-quick-close-*.md — её протокол закрытия (DP.SC.154 Шаг
+  # 4.5.1/4.5.2) прямой git commit, не раннер. Без этого обхода close требовал
+  # у пир-сессии карточку чужого ритуала (живой отказ 30.08). close_path
+  # записан этим же скриптом при open — достаточное свидетельство.
+  if [ -z "$RUNNER_OK" ] && grep -q '^close_path: peer-session$' "$SEM_FILE" 2>/dev/null; then
+    RUNNER_OK="declared-peer-session:$SLUG"
+    echo "Session CLOSE: close_path=peer-session объявлен при open — раннер не требуется (WP-484 Ф118)." >&2
+  fi
+
   # --force-no-reflection (WP-484, 08.08, пилот): рефлексия про настроение дня
   # блокирует close, даже когда содержательная работа (commit+push) уже
   # подтверждена картой раннера — живой разбор показал, что вопрос рефлексии

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2437,7 +2437,7 @@
     },
     {
       "path": "scripts/session-guard.sh",
-      "sha256": "4863651162cedf2a91eb596a361bec930490c7ef25b78a3e926595dd76a927fa"
+      "sha256": "774c090e0602186f277eba6d05286a336b952b1a1f7e5777c8fd5ef258909a45"
     },
     {
       "path": "scripts/settings-promote.sh",

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2437,7 +2437,7 @@
     },
     {
       "path": "scripts/session-guard.sh",
-      "sha256": "774c090e0602186f277eba6d05286a336b952b1a1f7e5777c8fd5ef258909a45"
+      "sha256": "e517ac9bc3ff4a902a6b4f170e8b85f5831bd7cd1f4ea34d22d32f202fb1d86a"
     },
     {
       "path": "scripts/settings-promote.sh",


### PR DESCRIPTION
A session opened with `open --close-path peer-session` never creates a RUN-quick-close card by design — its close protocol (DP.SC.154 step 4.5) commits directly, no runner. The template copy wrote `close_path` into the semaphore at open but never read it at close, so peer sessions could not close their semaphore (live failure 2026-08-30). Ports the author-source bypass (WP-484 F118) verbatim: if no terminal runner card AND the semaphore declares `close_path: peer-session`, the runner requirement is waived.

Verify: bash -n clean; isolated fixture matrix (semaphore with/without the line, anchored-suffix negative, missing file); independent subagent verification PASS.

Refs: peer-session 2026-08-30-01-wp530-systemic-race-solution (WP-530 F18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)