### PR TITLE
chore: release v0.39.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,25 @@ Refs: WP-NNN
 
 ## [Unreleased]
 
+## [0.39.1] — 2026-08-30
+
+Hotfix on top of v0.39.0: the cold-context review follow-up (PR #575,
+`084a381`) merged one commit after the v0.39.0 release cut and did not make
+the tag — v0.39.0 ships a known regression it fixes.
+
+### Fixed
+
+- `084a381` fix: cold-review follow-up — wire skip status, restore seed marker, 3 corrections
+  - **regression fix (#559):** day-close mapped a skipped optional step to
+    `fail` with exit 1 on installs without linear-sync/DS-MCP/pyyaml —
+    v0.39.0 fails every automated Day Close on such installs; now `skip`, rc 0
+  - seed snapshot day-open-scaffold.sh re-gains its SNAPSHOT marker (was
+    silently outside check-seed-drift coverage)
+  - peer-conversation declares `--close-path peer-session` at open (the
+    session-guard bypass was dead code in the template flow)
+  - kimi-peer-writer calls the real delivered preflight via `${IWE_SCRIPTS:-...}`
+  - wp-new consent path uses `IWE_ROOT` (the variable create-wp.sh reads)
+
 ## [0.39.0] — 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # IWE — Intellectual Work Environment
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.39.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.39.1-blue.svg)](CHANGELOG.md)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(Git%20Bash)-lightgrey.svg)]()
 [![EN sync](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/TserenTserenov/FMT-exocortex-template/en-draft/badge-data.json)](https://github.com/TserenTserenov/FMT-exocortex-template/tree/en-draft)
 

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "Манифест платформенных файлов FMT-exocortex-template. Используется update.sh для доставки обновлений.",
   "files": [
     {
@@ -745,7 +745,7 @@
     },
     {
       "path": "CHANGELOG.md",
-      "sha256": "bea81c2b021233f7f471511bf3c8e5c882dcca8200b133cecf85f21bc306b033"
+      "sha256": "f4ba3ac01f36d1897956ec596f173944e12d0561783fce54d5affb7b088fab63"
     },
     {
       "path": "CLAUDE.md",


### PR DESCRIPTION
Hotfix release. v0.39.0 was tagged one commit before PR #575 (cold-review follow-up) merged — the tag ships the #559 regression: day-close maps skipped optional steps to fail with exit 1 on installs lacking linear-sync/DS-MCP/pyyaml. v0.39.1 = current main (v0.39.0 + that one commit). CHANGELOG section, README badge, manifest version stamp.

Pre-release layer-5/6 audit run (iwe-platform-redteam, self-run authorized by the pilot) in progress — verdict lands in #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)