### PR TITLE
feat(hooks): self-installing SessionStart hook for .githooks activation (WP-559 Ф2)

### DIFF
--- a/.claude/hooks/session-start-hooks-bootstrap.sh
+++ b/.claude/hooks/session-start-hooks-bootstrap.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# SessionStart — idempotent, best-effort activation of .githooks/ (WP-559 Ф2).
+#
+# GitHub's "generate from template" API copies repository files but not
+# .git/config — so a repository forked through fork_platform_template ships
+# .githooks/ present on disk but inactive until core.hooksPath points at it.
+# This hook closes that gap the first time the repo is opened in Claude Code.
+#
+# Safety contract (round-loop design, Codex + Kimi, ArchGate passed 2026-08-30):
+#   - never overwrite an already-configured core.hooksPath (could be the
+#     user's own hooks, or another tool's);
+#   - read the EFFECTIVE value (`git config --get`, not just --local) so a
+#     global/worktree setting is respected too;
+#   - best-effort only — any failure (read-only .git/config, sandboxed
+#     checkout, no git repo at all) prints a note and exits 0, never blocks
+#     SessionStart;
+#   - visible outcome always: success, conflict, and failure all print a line.
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+GITHOOKS_DIR="$REPO_ROOT/.githooks"
+[ -d "$GITHOOKS_DIR" ] || exit 0
+
+CURRENT_HOOKSPATH=$(git config --get core.hooksPath 2>/dev/null || true)
+
+if [ "$CURRENT_HOOKSPATH" = ".githooks" ]; then
+  exit 0
+fi
+
+if [ -n "$CURRENT_HOOKSPATH" ]; then
+  # Braces are required here, not stylistic: on this bash/locale combination,
+  # a bare $VAR immediately followed by a non-ASCII byte (» below) gets
+  # misparsed as part of the variable name — "unbound variable" under set -u
+  # instead of the intended message (found by direct testing, WP-559 Ф2).
+  echo "⚠️ [hooks-bootstrap] core.hooksPath уже установлен в «${CURRENT_HOOKSPATH}» — не переопределяю. Чтобы включить .githooks/ этого репозитория вручную: git config --local core.hooksPath .githooks" >&2
+  exit 0
+fi
+
+if git config --local core.hooksPath .githooks 2>/dev/null; then
+  echo "✅ [hooks-bootstrap] core.hooksPath настроен на .githooks — проверки перед коммитом активны."
+  exit 0
+fi
+
+echo "⚠️ [hooks-bootstrap] не удалось настроить core.hooksPath (только чтение .git/config?). Вручную: git config --local core.hooksPath .githooks" >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -222,6 +222,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-trash.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-hooks-bootstrap.sh"
           }
         ]
       }

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -148,6 +148,10 @@
       "sha256": "07b157c5d7614939f027aa50080cabe4531aba4ebae8886038f167620daba6b9"
     },
     {
+      "path": ".claude/hooks/session-start-hooks-bootstrap.sh",
+      "sha256": "9ced3b69e749eef98bf2ccdc5a666f11064d62eb3b2dd5c20d837ef7e5a453d3"
+    },
+    {
       "path": ".claude/hooks/wp-gate-reminder.sh",
       "sha256": "a6dfaee3ebc87432236f63b33a047c52fa1a117b4d44803689cf96ba2559a84d"
     },
@@ -281,7 +285,7 @@
     },
     {
       "path": ".claude/settings.json",
-      "sha256": "3540ae0f183610eb87f987c20d13b4262078b5c5f2454f598c5ee22f501aaf0b"
+      "sha256": "280fa18d9d5e4188569c1a30e3dfe31e992975e295c9817e438dca3c66ae4b81"
     },
     {
       "path": ".claude/skills-catalog.yaml",


### PR DESCRIPTION
## Summary
- New `.claude/hooks/session-start-hooks-bootstrap.sh`, registered in `SessionStart`: activates `core.hooksPath` the first time a repository is opened in Claude Code — needed because GitHub's generate-from-template API (used by the new `fork_platform_template` MCP tool) copies `.githooks/` but not `.git/config`.
- Idempotent, best-effort: never overwrites an existing `core.hooksPath`, never blocks `SessionStart`, always prints a visible outcome (success/conflict/failure).
- Manifest regenerated via `generate-manifest.sh`, not hand-edited.

## Test plan
- [x] `tsc`/type-check not applicable (bash)
- [x] `shellcheck` clean
- [x] Live smoke test, 4 branches, in an isolated scratch directory: fresh install sets `core.hooksPath`; idempotent rerun is silent; a pre-existing conflicting value is preserved with a visible warning; no `.githooks/` dir and "not a git repo" both exit cleanly
- [x] Found and fixed a real bug via that testing: a bare `$VAR` immediately adjacent to a non-ASCII character (`»`) misparsed as part of the variable name on this bash/locale combination — fixed with `${VAR}`

Refs: peer-session `2026-08-30-10-wp559-finish-fork-rename-toctou`, ArchGate passed