### PR TITLE
docs(changelog): record personal-guide rename (#585) in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,11 @@ Refs: WP-NNN
 
 ## [Unreleased]
 
+### Fixed
+
+- `f896701` fix(skills): personal-guide -> DS-personal-guide в шаблонных скиллах (#585)
+  - `personal-guide-start`, `personal-guide-render`, `lesson-close`, `week-close-pilot` — литеральное имя личного репозитория новых пользователей переведено на канон `DS-personal-guide`; `docs/SETUP-GUIDE.md` и её тест-контракт обновлены вместе с манифестом
+
 ## [0.39.1] — 2026-08-30
 
 Hotfix on top of v0.39.0: the cold-context review follow-up (PR #575,

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -749,7 +749,7 @@
     },
     {
       "path": "CHANGELOG.md",
-      "sha256": "f4ba3ac01f36d1897956ec596f173944e12d0561783fce54d5affb7b088fab63"
+      "sha256": "60a3b423a021e51e607ddf941eb409475541f781b561901cc1470fa89065c0b2"
     },
     {
       "path": "CLAUDE.md",


### PR DESCRIPTION
## Summary
- PR #585 (personal-guide rename) landed without a CHANGELOG entry, so the next Sunday auto-bump would not have picked it up or triggered the adversarial audit.
- Added an Unreleased entry, regenerated update-manifest.json (only the CHANGELOG.md checksum — no other files touched).

Refs: WP-559