### PR TITLE
fix: day-open.checks.md YAML-frontmatter false positive + build-runtime Unreleased stamp

### DIFF
--- a/extensions/day-open.checks.md
+++ b/extensions/day-open.checks.md
@@ -22,7 +22,8 @@
 
 ```bash
 [ -s "$FILE" ] || { echo "  ❌ DayPlan пуст или отсутствует: $FILE"; exit 1; }
-head -1 "$FILE" | grep -q '^# ' || { echo "  ❌ DayPlan не начинается с '# '-заголовка: $(head -1 "$FILE")"; exit 1; }
+FIRST_H1=$(grep -m1 '^# ' "$FILE" || true)
+[ -n "$FIRST_H1" ] || { echo "  ❌ В DayPlan нет ни одного '# '-заголовка первого уровня"; exit 1; }
 LINES=$(wc -l < "$FILE" | tr -d ' ')
 [ "$LINES" -ge 5 ] || { echo "  ❌ DayPlan подозрительно короткий ($LINES строк) — похоже на оборванную генерацию"; exit 1; }
 echo "  ✅ DayPlan существует, заголовок на месте, $LINES строк"
@@ -37,7 +38,8 @@ echo "  ✅ DayPlan существует, заголовок на месте, $L
 ```bash
 FNAME_DATE=$(basename "$FILE" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1)
 [ -n "$FNAME_DATE" ] || { echo "  ✅ Имя файла без даты — проверка неприменима"; exit 0; }
-H1_DATE=$(head -1 "$FILE" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1)
+FIRST_H1=$(grep -m1 '^# ' "$FILE" || true)
+H1_DATE=$(printf '%s\n' "$FIRST_H1" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1 || true)
 if [ -n "$H1_DATE" ] && [ "$H1_DATE" != "$FNAME_DATE" ]; then
   echo "  ❌ Дата в заголовке ($H1_DATE) не совпадает с именем файла ($FNAME_DATE) — проверяется не тот план?"
   exit 1

--- a/scripts/tests/test_issue_583_dayopen_yaml.sh
+++ b/scripts/tests/test_issue_583_dayopen_yaml.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #583: extensions/day-open.checks.md blocked
+# every DayPlan generated with a YAML frontmatter, because both default
+# blocks read the physical first line ("head -1") instead of the first
+# '# '-heading, and the date-match block died silently under `set -e` when
+# the header search came up empty (no message, just "N/3 failed").
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf -- "$TMP_ROOT"' EXIT
+
+pass_count=0
+pass() { echo "  ✅ PASS: $*"; pass_count=$((pass_count + 1)); }
+fail() { echo "  ❌ FAIL: $*" >&2; exit 1; }
+
+# Shell out to the real entrypoint (day-open-checks-runner.sh), not a
+# sourced lib call: that script deliberately runs under `set -uo pipefail`
+# WITHOUT `-e` (day-open-hooks.sh's per-block `( set -e; eval "$block" )`
+# isolation relies on the caller not already having errexit on) — sourcing
+# the lib into this test's own `set -e` shell breaks that isolation and
+# aborts the whole run the instant a block is meant to fail.
+CHECKS_RUNNER_OUT=""
+CHECKS_RUNNER_RC=0
+run_checks() {
+  local dayplan="$1"
+  if CHECKS_RUNNER_OUT=$(IWE_ROOT="$ROOT" bash "$ROOT/scripts/day-open-checks-runner.sh" "$dayplan" 2>&1); then
+    CHECKS_RUNNER_RC=0
+  else
+    CHECKS_RUNNER_RC=$?
+  fi
+}
+
+echo "--- YAML-frontmatter DayPlan, date matches filename (real scaffold shape) ---"
+plan="$TMP_ROOT/DayPlan 2026-08-30.md"
+cat > "$plan" <<'EOF'
+---
+type: daily-plan
+date: 2026-08-30
+---
+
+# Day Plan: 30 августа 2026 (Воскресенье)
+
+## Требует внимания
+
+- нет
+EOF
+run_checks "$plan"
+if [ "$CHECKS_RUNNER_RC" -eq 0 ]; then
+  pass "YAML-frontmatter DayPlan with matching date passes all default checks"
+else
+  echo "$CHECKS_RUNNER_OUT" >&2
+  fail "YAML-frontmatter DayPlan still blocked — issue #583 not fixed"
+fi
+
+echo "--- YAML-frontmatter DayPlan, H1 date mismatched (negative control) ---"
+# Real scaffold output writes the H1 in human Russian ("30 августа 2026"),
+# which never contains an ISO date, so this block's comparison is normally
+# a no-op (documented as "if the date is even there"). Use an explicit ISO
+# date in H1 to actually exercise the comparison logic itself.
+mismatch="$TMP_ROOT/DayPlan 2026-08-30.md"
+cat > "$mismatch" <<'EOF'
+---
+type: daily-plan
+date: 2026-08-29
+---
+
+# Day Plan: 2026-08-29 (Суббота)
+EOF
+run_checks "$mismatch"
+if [ "$CHECKS_RUNNER_RC" -ne 0 ] && printf '%s' "$CHECKS_RUNNER_OUT" | grep -q "не совпадает с именем файла"; then
+  pass "date mismatch between filename and H1 is still caught (fix did not remove the real check)"
+else
+  echo "$CHECKS_RUNNER_OUT" >&2
+  fail "date-mismatch negative control passed — the fix silently disabled the check, not just the false positive"
+fi
+
+echo "--- YAML-frontmatter DayPlan with no '# '-heading anywhere (must fail loudly, not silently) ---"
+noheading="$TMP_ROOT/DayPlan 2026-08-28.md"
+cat > "$noheading" <<'EOF'
+---
+type: daily-plan
+date: 2026-08-28
+---
+
+Просто текст без заголовка первого уровня.
+EOF
+run_checks "$noheading"
+if [ "$CHECKS_RUNNER_RC" -ne 0 ] && printf '%s' "$CHECKS_RUNNER_OUT" | grep -q "нет ни одного"; then
+  pass "DayPlan without any H1 heading is blocked with a visible failure, not a silent set -e death"
+else
+  echo "$CHECKS_RUNNER_OUT" >&2
+  fail "DayPlan without H1 either passed, or failed silently — checks are not fail-closed with a message"
+fi
+
+echo "issue-583 day-open.checks.md YAML fix: $pass_count checks passed"

--- a/scripts/tests/test_issue_584_build_version.sh
+++ b/scripts/tests/test_issue_584_build_version.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #584: setup/build-runtime.sh always stamped
+# the runtime version as "Unreleased" — grep -m1 took the FIRST '## [...]'
+# heading in CHANGELOG.md, which under Keep a Changelog is always
+# "## [Unreleased]" when that section is present.
+#
+# The exact parse command is extracted from build-runtime.sh at test time
+# (not copy-pasted) so this test tracks the real shipped line instead of a
+# duplicate that could silently drift from it.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf -- "$TMP_ROOT"' EXIT
+
+pass_count=0
+pass() { echo "  ✅ PASS: $*"; pass_count=$((pass_count + 1)); }
+fail() { echo "  ❌ FAIL: $*" >&2; exit 1; }
+
+PARSE_LINE=$(grep '^FMT_VERSION=' "$ROOT/setup/build-runtime.sh")
+[ -n "$PARSE_LINE" ] || fail "could not find FMT_VERSION= line in setup/build-runtime.sh — has it moved?"
+
+parse_version() {
+  local template_dir="$1"
+  ( TEMPLATE_DIR="$template_dir"; eval "$PARSE_LINE"; echo "$FMT_VERSION" )
+}
+
+echo "--- Unreleased section present above the latest real version (real repo shape) ---"
+cat > "$TMP_ROOT/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [0.39.1] — 2026-08-30
+- fix: something
+
+## [0.39.0] — 2026-08-30
+- feat: something else
+EOF
+got=$(parse_version "$TMP_ROOT")
+if [ "$got" = "0.39.1" ]; then
+  pass "parses the real latest version (0.39.1), not Unreleased"
+else
+  fail "expected 0.39.1, got '$got' — issue #584 not fixed"
+fi
+
+echo "--- No Unreleased section (older CHANGELOG shape, must still work) ---"
+cat > "$TMP_ROOT/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [0.38.5] — 2026-08-18
+- fix: older release
+EOF
+got=$(parse_version "$TMP_ROOT")
+if [ "$got" = "0.38.5" ]; then
+  pass "still parses the version when there is no Unreleased section at all"
+else
+  fail "expected 0.38.5, got '$got' — fix broke the no-Unreleased case"
+fi
+
+echo "--- Nothing released yet (Unreleased only) — must not crash, empty is acceptable ---"
+cat > "$TMP_ROOT/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## [Unreleased]
+- feat: work in progress
+EOF
+got=$(parse_version "$TMP_ROOT")
+if [ -z "$got" ]; then
+  pass "no released version yet → empty FMT_VERSION, no crash (honest 'nothing shipped' state)"
+else
+  fail "expected empty FMT_VERSION with only Unreleased present, got '$got'"
+fi
+
+echo "issue-584 build-runtime.sh version fix: $pass_count checks passed"

--- a/setup/build-runtime.sh
+++ b/setup/build-runtime.sh
@@ -265,7 +265,7 @@ INPUT_HASH=$(
     } | (command -v shasum >/dev/null && shasum -a 256 || sha256sum) | cut -d' ' -f1
 )
 
-FMT_VERSION=$(grep -m1 '^## \[' "$TEMPLATE_DIR/CHANGELOG.md" | sed 's/.*\[\(.*\)\].*/\1/')
+FMT_VERSION=$(grep '^## \[' "$TEMPLATE_DIR/CHANGELOG.md" | grep -v '^## \[Unreleased\]' | head -1 | sed 's/.*\[\(.*\)\].*/\1/')
 
 # === Apply substitutions ===
 build_substituted_file() {

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1009,7 +1009,7 @@
     },
     {
       "path": "extensions/day-open.checks.md",
-      "sha256": "9b007e3e07ed952e743d6d5a4770829678ec13f5617cfb1a8a3fa8b6206869cf"
+      "sha256": "41fd9c38d4a29c02ee99b7ff5eb849841215dd026711eb50fb1b93bfde57c48d"
     },
     {
       "path": "extensions/local-llm/ADR-001-local-llm-stack.md",
@@ -2797,7 +2797,7 @@
     },
     {
       "path": "setup/build-runtime.sh",
-      "sha256": "818f7ed16d24e87fea34a028d093709bdd09e41ba6a6afec23f8460c4b6ebe20"
+      "sha256": "6609c5b6b41d4b6916dd6895bd5e5e7397717d34b81a290ba3a47f67ba9c18df"
     },
     {
       "path": "setup/install-iwe-paths.sh",
@@ -2873,6 +2873,8 @@
     "scripts/tests/test_issue_530_staged_self_scan.sh",
     "scripts/tests/test_issue_531_index_health_status_cell.py",
     "scripts/tests/test_issue_532_dayplan_strategy_gate.sh",
+    "scripts/tests/test_issue_583_dayopen_yaml.sh",
+    "scripts/tests/test_issue_584_build_version.sh",
     "scripts/tests/test_issue_python_resolver_contract.sh",
     "scripts/tests/test_manifest_coverage_local.py",
     "scripts/tests/test_pending_phases_sweep.sh",


### PR DESCRIPTION
## Summary
- Closes #583 — default `day-open.checks.md` blocks read the physical first line instead of the first `# `-heading, so any DayPlan with a YAML frontmatter (the real `day-open-scaffold.sh` output shape) blocked commit. The date-consistency block additionally died silently under `set -e` when the header search came up empty.
- Closes #584 — `build-runtime.sh`'s version parser always took the first `## [...]` CHANGELOG heading, which under Keep a Changelog is `[Unreleased]` whenever present — the runtime always stamped itself "Unreleased".
- Two new mutation-checked regression tests (`scripts/tests/test_issue_583_dayopen_yaml.sh`, `scripts/tests/test_issue_584_build_version.sh`), manifest regenerated to register them.

## Test plan
- [x] `scripts/tests/run-issue-tests.sh` — 22/22 passing
- [x] Mutation check on both fixes: reverted each fix, confirmed the new test reproduces the exact original failure text from the issue, restored, confirmed green
- [x] Independent cold-context code review (no Critical/High/Medium findings)
- [x] Independent smoke verification via `/verify` skill (both invariants confirmed by execution against the real entrypoint and real CHANGELOG.md)

Refs: peer-session 2026-08-30-26-fmt-issues-triage (WP-529), triaged with kimi + codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)