### PR TITLE
docs(audit-log): v0.39.1 completed — independent delta re-audit GO

### DIFF
--- a/docs/release-audit-log.md
+++ b/docs/release-audit-log.md
@@ -30,6 +30,7 @@ release tag vX.Y.Z → auto-issue (legacy) | новая практика → з�
 
 | Version | Status | Date | Findings | Result | Notes |
 |---------|--------|------|----------|--------|-------|
+| v0.39.1 | **completed** | 2026-08-30 | 0 P0/P1, 3 low-severity (pre-existing, not caused by this delta) | GO | issue #576 (self-run by implementing agent, pilot-waived); independent context-isolated re-audit of the delta (PR #585 f896701 + PR #586 10c9732, personal-guide rename) — separate GO, findings: stale `docs/skills-catalog.md` (pre-existing), `org-dev/SKILL.md` references unrelated `PACK-personal/personal-guide/` path (needs owner confirmation it's intentionally distinct), `seed/strategy/scripts/day-open-scaffold.sh` not covered by manifest B2 (pre-existing gap) |
 | v0.34.1 | skipped-unverified | — | — | — | migrated from #133 |
 | v0.34.0 | skipped-unverified | — | — | — | migrated from #130 |
 | v0.33.x | skipped-unverified | — | — | — | migrated from #129, #127 |

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -925,7 +925,7 @@
     },
     {
       "path": "docs/release-audit-log.md",
-      "sha256": "0cacb64d15259054e58261ff67e8f78f8b26ca899c0b9d6ff3827f0ca903498b"
+      "sha256": "b0a41a43e1a0c127008de723f5e3b00372be1d7b5d54f8cf8c1cdabc5bc7e029"
     },
     {
       "path": "docs/roles-catalog.md",


### PR DESCRIPTION
Records issue #576 verdict + a separate independent context-isolated re-audit of the personal-guide rename delta. Both GO. Refs: WP-559