### PR TITLE
feat(ci): notify pilot via bot when a real red-team audit issue is created

### DIFF
--- a/.github/workflows/post-release-audit.yml
+++ b/.github/workflows/post-release-audit.yml
@@ -62,6 +62,7 @@ jobs:
           fi
       - name: Create or update audit reminder issue
         if: github.event_name == 'workflow_dispatch' || steps.gate.outputs.skip != 'true'
+        id: issue
         uses: actions/github-script@v8
         with:
           script: |
@@ -76,15 +77,14 @@ jobs:
             >
             > **После audit — обновить \`docs/release-audit-log.md\`** (status + findings + result), затем закрыть этот issue.
 
-            ## Шаги
+            ## Шаги (минимум ручной работы)
 
-            1. Открыть Claude Code сессию в FMT-exocortex-template
-            2. Скопировать промпт ниже и адаптировать <TARGET-VERSION>
-            3. Прогнать через \`Agent\` или sub-agent
-            4. Найденные классы → +detector в \`integration-contract-validator.sh\`
-            5. Закрыть issue с комментарием: STABLE / X classes found
+            1. Открой НОВЫЙ чат с агентом (не тот, где делались правки релиза) — независимость проверяющего от автора важна.
+            2. Скажи одной фразой: «прогони red team проверку из задачи #<номер этой задачи> в FMT-exocortex-template». Агент сам откроет эту задачу, прочитает промпт ниже и выполнит его — копировать текст руками не нужно.
+            3. Найденные классы регрессий → +detector в \`integration-contract-validator.sh\`.
+            4. Закрыть issue с комментарием: STABLE / X classes found.
 
-            ## Промпт
+            ## Промпт (агент прочитает сам — не для ручного копирования)
 
             <details>
             <summary>Развернуть промпт</summary>
@@ -108,6 +108,9 @@ jobs:
             const existing = issues.find(i => i.title === title);
             if (existing) {
               console.log(`Issue already exists: #${existing.number}`);
+              core.setOutput('created', 'false');
+              core.setOutput('number', existing.number);
+              core.setOutput('url', existing.html_url);
             } else {
               const { data } = await github.rest.issues.create({
                 owner: context.repo.owner,
@@ -117,4 +120,52 @@ jobs:
                 labels: ['release-audit']
               });
               console.log(`Created issue #${data.number}: ${data.html_url}`);
+              core.setOutput('created', 'true');
+              core.setOutput('number', data.number);
+              core.setOutput('url', data.html_url);
             }
+
+      - name: Notify pilot via bot (new issue only)
+        if: steps.issue.outputs.created == 'true'
+        env:
+          BOT_WEBHOOK_URL: ${{ secrets.BOT_WEBHOOK_URL }}
+          TEMPLATE_WEBHOOK_SECRET: ${{ secrets.TEMPLATE_WEBHOOK_SECRET }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          ISSUE_URL: ${{ steps.issue.outputs.url }}
+        run: |
+          # Same channel-detection rule as notify-security.yml (issue #547/#454):
+          # gate on whether the channel is CONFIGURED, not on repo name — a
+          # fork with no author secrets must skip silently, a half-configured
+          # channel (exactly one secret set) must fail loudly, not skip.
+          if [ -z "${BOT_WEBHOOK_URL}" ] && [ -z "${TEMPLATE_WEBHOOK_SECRET}" ]; then
+            echo "Skip: канал уведомлений не настроен (форк без секретов автора)."
+            exit 0
+          fi
+          if [ -z "${BOT_WEBHOOK_URL}" ] || [ -z "${TEMPLATE_WEBHOOK_SECRET}" ]; then
+            echo "ERROR: настроен только один из двух секретов канала — это полунастроенное состояние, не skip." >&2
+            exit 1
+          fi
+          MESSAGE="🔴 Нужна независимая проверка (red team) для выпуска v${VERSION}.
+          Задача: ${ISSUE_URL}
+
+          Открой новый чат и скажи: «прогони red team проверку из задачи #${ISSUE_NUMBER} в FMT-exocortex-template»."
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${BOT_WEBHOOK_URL}/api/template-update" \
+            -H "Content-Type: application/json" \
+            -H "X-Webhook-Secret: ${TEMPLATE_WEBHOOK_SECRET}" \
+            -d "$(jq -n \
+              --arg version "$VERSION" \
+              --arg changelog "$MESSAGE" \
+              --arg commit_count "1" \
+              '{version: $version, changelog: $changelog, commit_count: ($commit_count | tonumber)}')")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "Audit reminder notification sent: $BODY"
+          else
+            echo "Audit reminder notification failed (HTTP $HTTP_CODE): $BODY"
+            exit 1
+          fi

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -725,7 +725,7 @@
     },
     {
       "path": ".github/workflows/post-release-audit.yml",
-      "sha256": "0605b87f81e8f2770955bcccb972f689468d26f307a568013cb4544f520b1e9d"
+      "sha256": "c01d2e59b832da6d692780cca4c97b42cf3050af7529f4e100c9f55f67438cb8"
     },
     {
       "path": ".gitignore",


### PR DESCRIPTION
## Summary
- `post-release-audit.yml` now sends a Telegram notification (same webhook as `notify-security.yml`) when it creates a NEW red-team audit issue (minor/major version bumps only).
- Issue body simplified: the pilot says a short trigger phrase in a new chat, the agent reads the issue itself instead of the pilot copy-pasting the prompt.
- Signing (`attestation-sign.yml`) stays manual on purpose — that's the control against self-attestation, not incidental friction.

## Test plan
- [x] YAML valid, actionlint clean for the new step (pre-existing shellcheck info-level notes in an untouched step)
- [x] Manifest regenerated in an isolated worktree (single-line diff, no interference with a concurrent session's staged work)

Refs: WP-559