### PR TITLE
fix: CLAUDE.md 3-way merge silent line loss + dangling /lesson reference

### DIFF
--- a/.claude/skills/lesson-close/SKILL.md
+++ b/.claude/skills/lesson-close/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: lesson-close
-description: Закрыть занятие, открытое скиллом /lesson. Финализирует lesson/YYYY-MM-DD.md (frontmatter status, метаданные времени, длительность), делает commit + push в репо DS-personal-guide. Триггерит замкнутый контур доставки — после push → GitHub webhook → bot oauth_server.py:/webhook/github/workbook → sync_one_user_to_dt → ЦД обновляется в Neon. Используй когда пилот говорит «закрываем», «всё», «закончили», «закрой урок» — или после явного завершения задания в /lesson.
+description: Закрыть текущее занятие. Финализирует lesson/YYYY-MM-DD.md (frontmatter status, метаданные времени, длительность), делает commit + push в репо DS-personal-guide. Триггерит замкнутый контур доставки — после push → GitHub webhook → bot oauth_server.py:/webhook/github/workbook → sync_one_user_to_dt → ЦД обновляется в Neon. Используй когда пилот говорит «закрываем», «всё», «закончили», «закрой урок» — или после явного завершения задания в текущем lesson-файле.
 argument-hint: "[необязательно: дата урока YYYY-MM-DD; по умолчанию сегодня; либо --skipped если урок был пропущен; --no-push для локального commit без push]"
 experimental: true
 sunset: "после WP-301 Ф6 (E2E smoke) и WP-149 Block D (ИИ-агент-носитель Портного)"
-related: [WP-149, WP-175, WP-245, WP-301, lesson, PD.METHOD.008]
+related: [WP-149, WP-175, WP-245, WP-301, PD.METHOD.008]
 version: 1.0.0
 layer: L1
 status: active
@@ -29,13 +29,13 @@ gates_rationale: "операционный скилл; WP Gate применим 
 
 ## When to use
 
-Закрыть занятие, открытое скиллом /lesson. Финализирует lesson/YYYY-MM-DD.md (frontmatter status, метаданные времени, длительность), делает commit + push в репо DS-personal-guide. Триггерит замкнутый контур доставки — после push → GitHub webhook → bot oauth_server.py:/webhook/github/workbook → sync_one_user_to_dt → ЦД обновляется в Neon. Используй когда пилот говорит «закрываем», «всё», «закончили», «закрой урок» — или после явного завершения задания в /lesson.
+Закрыть текущее занятие. Финализирует lesson/YYYY-MM-DD.md (frontmatter status, метаданные времени, длительность), делает commit + push в репо DS-personal-guide. Триггерит замкнутый контур доставки — после push → GitHub webhook → bot oauth_server.py:/webhook/github/workbook → sync_one_user_to_dt → ЦД обновляется в Neon. Используй когда пилот говорит «закрываем», «всё», «закончили», «закрой урок» — или после явного завершения задания в текущем lesson-файле.
 
 ## Контракт скилла
 
-- **Вход:** существующий `lesson/YYYY-MM-DD.md` в репо `DS-personal-guide` со статусом `status: in_progress` (создан скиллом `/lesson`). Активный git remote с правом push.
+- **Вход:** существующий `lesson/YYYY-MM-DD.md` в репо `DS-personal-guide` со статусом `status: in_progress`. Активный git remote с правом push.
 - **Выход:** lesson-файл с финализированным frontmatter (`status: done|partial|skipped`, `finished_at`, `duration_min`) + git commit + git push. На сервере: webhook triggered → `sync_one_user_to_dt(user_id)` → Neon `digital_twins.data['2_collected']` обновлён + событие в `public.domain_event`.
-- **Время:** ≤2 мин (быстрая финализация после `/lesson`).
+- **Время:** ≤2 мин (быстрая финализация занятия).
 - **Не делает:** не оценивает качество ответа (Оценщик R12 — отдельно, асинхронно); не генерирует assignment на завтра (Портной, ночной рендер).
 
 ## Algorithm
@@ -85,7 +85,7 @@ bash "$IWE_SCRIPTS/route-task.sh" --skill lesson-close --args "<YYYY-MM-DD> [--n
 
 ## Связь с другими механизмами
 
-- **`/lesson`** — парный скилл, открывает занятие, создаёт lesson-скелет.
+- **Открытие занятия** выполняется отдельным процессом; `/lesson-close` требует уже существующий lesson-файл со статусом `in_progress`.
 - **GitHub webhook** — handler в бот-репозитории (`oauth_server.py`, роут `POST /webhook/github/workbook`). HMAC-секрет = `GITHUB_WORKBOOK_WEBHOOK_SECRET` в env. Регистрируется один раз в `DS-personal-guide` репо: Settings → Webhooks.
 - **Активность в Neon:** webhook записывает событие в `public.domain_event` (source=`iwe`, event_type=`lesson_closed`) и триггерит `sync_one_user_to_dt(user_id)` → пишет в `digital_twins.data['2_collected']`.
 - **Профайлер (асинхронно):** отдельный сервис пересчитывает `3_derived` на основе обновлённого `2_collected`. Запускается отдельным cron.

--- a/scripts/tests/test_issue_555_claude_silent_loss.sh
+++ b/scripts/tests/test_issue_555_claude_silent_loss.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #555: a "clean" `git merge-file` exit (no
+# <<<<<<< markers) can still make a pilot's customized CLAUDE.md line vanish
+# from the result — reported live with a stale `.claude.md.base`. The exact
+# diff3 trigger was not reliably reproducible in isolation (every synthetic
+# base/current/new combination tried during triage produced real conflict
+# markers instead), so the fix does not try to prevent the specific
+# diff3 behavior — it verifies the OUTCOME via detect_claude_silent_loss():
+# every line the pilot added/changed relative to base must still be present
+# in the merge result, regardless of exit code or markers.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+TMP=$(mktemp -d)
+trap 'rm -rf -- "$TMP"' EXIT
+
+pass_count=0
+pass() { echo "  ✅ PASS: $*"; pass_count=$((pass_count + 1)); }
+fail() { echo "  ❌ FAIL: $*" >&2; exit 1; }
+
+# Load only the function under test — sourcing update.sh would execute the
+# updater (same isolation pattern as test_update_install_path_guard.sh).
+eval "$(awk '
+  /^detect_claude_silent_loss\(\)/ { capture=1 }
+  capture { print }
+  capture && /^}/ { exit }
+' "$ROOT/update.sh")"
+declare -F detect_claude_silent_loss >/dev/null
+
+echo "--- pilot line silently dropped by the merge (no conflict markers) ---"
+cat >"$TMP/base.md" <<'EOF'
+- **Obsidian:** старая формулировка про vault.
+EOF
+cat >"$TMP/before.md" <<'EOF'
+- **Без Obsidian (DS-strategy):** просмотр через VS Code.
+EOF
+# Simulates a "clean" merge result that dropped the pilot's line entirely —
+# constructed directly rather than via git merge-file, because every
+# realistic base/current/new triple tried during triage produced real
+# conflict markers instead of a silent drop (diff3 IS good at this in the
+# cases actually tested). The guard must catch the outcome either way.
+cat >"$TMP/merged-lossy.md" <<'EOF'
+- **Obsidian:** поддерживаемый vault — отдельный governance-репозиторий `DS-strategy`.
+EOF
+out=$(detect_claude_silent_loss "$TMP/base.md" "$TMP/before.md" "$TMP/merged-lossy.md" 2>"$TMP/warnings.txt")
+if [ "$out" = "1" ] && grep -qF "Без Obsidian" "$TMP/warnings.txt"; then
+  pass "lossy merge detected: count=1, warning names the exact pilot line"
+else
+  fail "expected count=1 with a named warning, got count='$out', warnings: $(cat "$TMP/warnings.txt")"
+fi
+
+echo "--- clean merge that genuinely preserved the pilot line ---"
+cat >"$TMP/merged-clean.md" <<'EOF'
+- **Локальный контекст:** описание платформы.
+- **Без Obsidian (DS-strategy):** просмотр через VS Code.
+- **Комментарии кода:** только EN.
+EOF
+out=$(detect_claude_silent_loss "$TMP/base.md" "$TMP/before.md" "$TMP/merged-clean.md" 2>"$TMP/warnings-clean.txt")
+if [ "$out" = "0" ] && [ ! -s "$TMP/warnings-clean.txt" ]; then
+  pass "genuinely clean merge reports zero loss and stays silent"
+else
+  fail "expected count=0 with no warnings, got count='$out', warnings: $(cat "$TMP/warnings-clean.txt")"
+fi
+
+echo "--- pilot never customized the file (before == base) — nothing to lose ---"
+cp "$TMP/base.md" "$TMP/before-unchanged.md"
+out=$(detect_claude_silent_loss "$TMP/base.md" "$TMP/before-unchanged.md" "$TMP/merged-lossy.md" 2>"$TMP/warnings-unchanged.txt")
+if [ "$out" = "0" ]; then
+  pass "no pilot customization → nothing flagged even though merged differs from base"
+else
+  fail "expected count=0 (nothing pilot-authored to lose), got count='$out'"
+fi
+
+echo "issue-555 CLAUDE.md silent-loss guard: $pass_count checks passed"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -497,7 +497,7 @@
     },
     {
       "path": ".claude/skills/lesson-close/SKILL.md",
-      "sha256": "cbcb057371f7dc02c7322316662045956a85a88354b5eb4c8095558eda820949"
+      "sha256": "cf87b710578bd9fb2b9df38c9da9d9f43507bd92b8c01fbeabf1f39e3a6ddd34"
     },
     {
       "path": ".claude/skills/local-llm/SKILL.md",
@@ -2833,7 +2833,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "994eaafb76e4a9a40a5d3871551a1f988180d085f63795bb7fc64662e6b029ff"
+      "sha256": "489ec46304d6d8d4eafe8cbeb5c97e62085f7ff18ddf7ca849c6512702f2c178"
     }
   ],
   "excluded_paths": [
@@ -2873,6 +2873,7 @@
     "scripts/tests/test_issue_530_staged_self_scan.sh",
     "scripts/tests/test_issue_531_index_health_status_cell.py",
     "scripts/tests/test_issue_532_dayplan_strategy_gate.sh",
+    "scripts/tests/test_issue_555_claude_silent_loss.sh",
     "scripts/tests/test_issue_583_dayopen_yaml.sh",
     "scripts/tests/test_issue_584_build_version.sh",
     "scripts/tests/test_issue_python_resolver_contract.sh",

--- a/update.sh
+++ b/update.sh
@@ -211,6 +211,28 @@ restore_claude_placeholders() {
     done
 }
 
+# detect_claude_silent_loss BASE PRE_MERGE_CURRENT MERGED — issue #555: a
+# "clean" `git merge-file` exit (no <<<<<<< markers) can still make a pilot's
+# customized line vanish from the result — reported live with a stale
+# `.claude.md.base` where diff3 resolved a genuine conflict in the platform's
+# favor without ever surfacing markers. This does not try to explain WHY
+# (diff3's line-alignment heuristic is opaque and was not reliably
+# reproducible in isolation) — it verifies the OUTCOME instead: every line
+# the pilot added or changed relative to BASE must still be present
+# somewhere in MERGED. Prints one warning line per lost line to stderr,
+# echoes the lost-line count to stdout for the caller to branch on.
+detect_claude_silent_loss() {
+    local base="$1" before="$2" merged="$3" lost=0 line
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        grep -qF -- "$line" "$merged" || {
+            echo "    ⚠ пользовательская строка пропала при слиянии без маркеров конфликта: $line" >&2
+            lost=$((lost + 1))
+        }
+    done < <(LC_ALL=C comm -13 <(LC_ALL=C sort -u "$base") <(LC_ALL=C sort -u "$before"))
+    echo "$lost"
+}
+
 # Protected user files (issue #154): once seeded, these hold user-authored content
 # (permissions, memory, peer-session journal) — update.sh must never touch them again,
 # neither overwrite (download loop) nor delete (deprecated-file cleanup). Single source
@@ -2256,9 +2278,16 @@ sync_workspace_claude_md() {
             WS_MERGE_TMP="$TMPDIR_UPDATE/ws-claude-merge.md"
             cp "$WS_CURRENT" "$WS_MERGE_TMP"
             if git merge-file -p "$WS_MERGE_TMP" "$WS_BASE" "$WS_NEW" > "$TMPDIR_UPDATE/ws-claude-merged.md" 2>/dev/null; then
-                cp "$TMPDIR_UPDATE/ws-claude-merged.md" "$WS_CURRENT"
-                cp "$WS_NEW" "$WS_BASE"
-                echo "  ✓ $WS_CURRENT обновлён (3-way merge)"
+                WS_SILENT_LOSS=$(detect_claude_silent_loss "$WS_BASE" "$WS_CURRENT" "$TMPDIR_UPDATE/ws-claude-merged.md")
+                if [ "$WS_SILENT_LOSS" -gt 0 ]; then
+                    CLAUDE_SILENT_LOSS_FILES+=("$WS_CURRENT")
+                    echo "  ⚠ $WS_CURRENT НЕ тронут — слияние потеряло бы $WS_SILENT_LOSS строк(и) без маркеров конфликта."
+                    echo "    Сверьте вручную: diff \"$WS_CURRENT\" \"$WS_NEW\""
+                else
+                    cp "$TMPDIR_UPDATE/ws-claude-merged.md" "$WS_CURRENT"
+                    cp "$WS_NEW" "$WS_BASE"
+                    echo "  ✓ $WS_CURRENT обновлён (3-way merge)"
+                fi
             else
                 WS_CONFLICTS=$(grep -c '^<<<<<<<' "$TMPDIR_UPDATE/ws-claude-merged.md" 2>/dev/null || true); WS_CONFLICTS=${WS_CONFLICTS:-0}
                 cp "$TMPDIR_UPDATE/ws-claude-merged.md" "$WS_CURRENT"
@@ -2318,7 +2347,7 @@ sync_workspace_claude_md() {
 # below, plus the pre-existing final gate at the end of the script) — third
 # repetition, extract instead of copy-pasting a fourth time.
 claude_conflict_gate() {
-    if $CLAUDE_CONFLICT_DETECTED || [ "${#CLAUDE_BASE_MISSING_FILES[@]}" -gt 0 ]; then
+    if $CLAUDE_CONFLICT_DETECTED || [ "${#CLAUDE_BASE_MISSING_FILES[@]}" -gt 0 ] || [ "${#CLAUDE_SILENT_LOSS_FILES[@]}" -gt 0 ]; then
         echo "  ⚠ Workspace-копия CLAUDE.md требует ручной сверки (см. предупреждения выше)."
         exit "$EXIT_CONFLICT"
     fi
@@ -2344,6 +2373,12 @@ CLAUDE_CONFLICT_FILES=()
 # file was simply left untouched. Tracked separately so the final summary
 # doesn't tell the pilot to look for markers that were never written.
 CLAUDE_BASE_MISSING_FILES=()
+# issue #555: a THIRD failure class, distinct from both of the above — a real
+# base existed, `git merge-file` reported success, no markers, but a pilot's
+# customized line still vanished from the result. Also left untouched and
+# reported separately (detect_claude_silent_loss above), so the summary
+# points at the right cause instead of "no base file" or "look for markers".
+CLAUDE_SILENT_LOSS_FILES=()
 
 # WP-546 (peer-session 2026-08-20-11, WP-546 Ф2 consensus with Codex): the
 # manifest loop used to run one `curl` per file, sequentially — 632 files at
@@ -3132,10 +3167,18 @@ for f in "${UPDATED_FILES[@]}"; do
             cp "$RAW_CURRENT_FILE" "$MERGE_TMP"
 
             if git merge-file -p "$MERGE_TMP" "$RAW_BASE_FILE" "$NEW_FILE" > "$TMPDIR_UPDATE/claude-merged.md" 2>/dev/null; then
-                # Clean merge — no conflicts
-                cp "$TMPDIR_UPDATE/claude-merged.md" "$CURRENT_FILE"
-                cp "$NEW_FILE" "$BASE_FILE"
-                echo "  ~ $f (3-way merge, чисто)"
+                # Clean merge — no conflict markers. Still verify no pilot line
+                # silently vanished (issue #555) before trusting "clean".
+                SILENT_LOSS=$(detect_claude_silent_loss "$RAW_BASE_FILE" "$RAW_CURRENT_FILE" "$TMPDIR_UPDATE/claude-merged.md")
+                if [ "$SILENT_LOSS" -gt 0 ]; then
+                    CLAUDE_SILENT_LOSS_FILES+=("$CURRENT_FILE")
+                    echo "  ⚠ $f НЕ тронут — слияние потеряло бы $SILENT_LOSS строк(и) без маркеров конфликта."
+                    echo "    Сверьте вручную: diff \"$CURRENT_FILE\" \"$NEW_FILE\""
+                else
+                    cp "$TMPDIR_UPDATE/claude-merged.md" "$CURRENT_FILE"
+                    cp "$NEW_FILE" "$BASE_FILE"
+                    echo "  ~ $f (3-way merge, чисто)"
+                fi
             else
                 CONFLICT_COUNT=$(grep -c '^<<<<<<<' "$TMPDIR_UPDATE/claude-merged.md" 2>/dev/null || true); CONFLICT_COUNT=${CONFLICT_COUNT:-0}
                 if [ "$CONFLICT_COUNT" -gt 0 ]; then
@@ -4062,7 +4105,16 @@ if [ "${#CLAUDE_BASE_MISSING_FILES[@]}" -gt 0 ]; then
     echo "  Сверьте свои правки §8/§9 вручную (см. diff-команду в выводе выше) и закоммитьте отдельно."
 fi
 
-if $CLAUDE_CONFLICT_DETECTED || [ "${#CLAUDE_BASE_MISSING_FILES[@]}" -gt 0 ]; then
+# issue #555: separate from both blocks above — base existed, merge reported
+# clean, but a pilot line still vanished (see detect_claude_silent_loss).
+if [ "${#CLAUDE_SILENT_LOSS_FILES[@]}" -gt 0 ]; then
+    echo ""
+    echo "⚠ CLAUDE.md не тронут (слияние потеряло бы вашу правку без предупреждения) в:"
+    for cf in "${CLAUDE_SILENT_LOSS_FILES[@]}"; do echo "  - $cf"; done
+    echo "  Пропавшие строки — в предупреждениях выше. Сверьте вручную и закоммитьте отдельно."
+fi
+
+if $CLAUDE_CONFLICT_DETECTED || [ "${#CLAUDE_BASE_MISSING_FILES[@]}" -gt 0 ] || [ "${#CLAUDE_SILENT_LOSS_FILES[@]}" -gt 0 ]; then
     exit "$EXIT_CONFLICT"
 fi
 


### PR DESCRIPTION
## Summary
- Closes #555 — `update.sh`'s 3-way merge for CLAUDE.md could report a clean `git merge-file` exit while still silently dropping a pilot's customized line, with no conflict markers and no warning. Added `detect_claude_silent_loss()`, a post-merge outcome check (not a diff3-behavior fix — the exact trigger wasn't reliably reproducible in isolation during triage) that verifies every pilot-authored line survives the merge; on failure the file is left untouched and reported, matching the existing #336 precedent for a missing base file.
- Closes #579 — `lesson-close/SKILL.md` referenced a `/lesson` skill that doesn't exist anywhere in the repo (not a delivery gap, never built). Reworded 5 spots to describe the actual precondition instead.

## Test plan
- [x] `scripts/tests/run-issue-tests.sh` — 23/23 passing (new `test_issue_555_claude_silent_loss.sh` included)
- [x] Mutation check on `detect_claude_silent_loss()`: broke the guard, confirmed the test catches it; restored, confirmed green
- [x] `setup/test-update-edge-cases.sh` — 159/159 (includes pre-existing T3/T10 CLAUDE.md merge scenarios, no regression)
- [x] `setup/test-update-issue-226.sh` — 37/37
- [x] Independent cold-context code review (Medium: `LC_ALL=C` added for `sort`/`comm` determinism per reviewer suggestion; no Critical/High)
- [x] Manual `git merge-file` reproduction attempts against the reported scenario — all produced real conflict markers rather than a silent drop, confirming the fix is a general safety net on the merge *outcome*, not a patch for one pinned-down diff3 defect

Refs: peer-session 2026-08-30-27-fmt-issues-finish (WP-529), triaged and implemented with codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)