### PR TITLE
fix(hooks): настоящий pre-commit валидирует staged-артефакты при любой форме коммита (issue #544)

### DIFF
--- a/scripts/tests/test_issue_544_staged_precommit.sh
+++ b/scripts/tests/test_issue_544_staged_precommit.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# test_issue_544_staged_precommit.sh — regression for issue #544.
+#
+# The PreToolUse artifact validator reads the index BEFORE the command runs,
+# so a combined `git add && git commit` silently bypassed all three artifact
+# validators. Fix: a real git pre-commit hook (seed/strategy/.githooks/)
+# running scripts/validate-staged-artifacts.sh, which reads staged blobs
+# (`git show :path`), not the worktree. This test drives real git commits:
+#   1. слитная форма с невалидным WeekPlan обязана блокироваться;
+#   2. staged-семантика «за»: валидный staged + сломанное рабочее дерево →
+#      коммит проходит (проверяется то, что попадёт в коммит);
+#   3. staged-семантика «против»: невалидный staged + починенное рабочее
+#      дерево без повторного add → блок;
+#   4. валидная слитная форма проходит.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+ok()   { echo "PASS: $1"; }
+bad()  { echo "FAIL: $1"; fail=$((fail + 1)); }
+
+# --- Каркас: workspace/FMT-exocortex-template/scripts + governance-репо ---
+WS="$TMP/ws"
+mkdir -p "$WS/FMT-exocortex-template/scripts"
+cp "$ROOT/scripts/validate-staged-artifacts.sh" "$WS/FMT-exocortex-template/scripts/"
+GOV="$WS/${GOVERNANCE_REPO:-DS-strategy}"
+mkdir -p "$GOV/.githooks" "$GOV/current"
+cp "$ROOT/seed/strategy/.githooks/pre-commit" "$GOV/.githooks/pre-commit"
+chmod +x "$GOV/.githooks/pre-commit"
+git -C "$GOV" init -q
+git -C "$GOV" config user.email test@test && git -C "$GOV" config user.name test
+git -C "$GOV" config core.hooksPath .githooks
+# Герметичность: хук сначала смотрит $IWE_SCRIPTS — без явного значения тест
+# исполнял бы валидатор боевой машины, а не копию фикстуры. То же для
+# IWE_WORKSPACE/IWE_ROOT: от них валидатор ищет memory/day-rhythm-config.yaml.
+export IWE_SCRIPTS="$WS/FMT-exocortex-template/scripts"
+export IWE_WORKSPACE="$WS"
+export IWE_ROOT="$WS"
+echo "init" > "$GOV/README.md"
+git -C "$GOV" add README.md && git -C "$GOV" commit -qm init
+
+valid_weekplan() { # <path>
+    { echo "# WeekPlan W36"; echo '## План'; echo '<summary>x</summary>'; echo '## Лог';
+      for i in $(seq 80); do echo "строка $i"; done; } > "$1"
+}
+invalid_weekplan() { # <path> — >80 строк без заголовков
+    { echo "# WeekPlan W36"; for i in $(seq 85); do echo "строка $i"; done; } > "$1"
+}
+valid_dayplan() { # <path>
+    cat > "$1" <<'EOF'
+# DayPlan 2026-08-30
+## План на сегодня
+| Время | РП |
+|-------|----|
+| 10:00 | WP-544 |
+## Календарь
+| Время | Событие |
+|-------|---------|
+| 11:00 | Встреча |
+## IWE за ночь
+всё зелёное
+## Разбор заметок
+нет
+## Итоги вчера
+сделано
+Мультипликатор: ~1.0x
+Бюджет: ~5ч РП / ~2ч физ
+Carry-over: нет
+EOF
+}
+
+# --- 1. Слитная форма с невалидным WeekPlan (точное воспроизведение issue) ---
+invalid_weekplan "$GOV/current/WeekPlan W36.md"
+if (cd "$GOV" && git add "current/WeekPlan W36.md" && git commit -qm "combined") >"$TMP/c1.err" 2>&1; then
+    bad "слитная форма с невалидным WeekPlan заблокирована"
+else
+    ok "слитная форма с невалидным WeekPlan заблокирована"
+fi
+grep -q 'PROTOCOL ARTIFACT VALIDATION FAILED' "$TMP/c1.err" \
+    && ok "блок с человекочитаемым разбором" \
+    || bad "блок с человекочитаемым разбором"
+git -C "$GOV" reset -q
+rm -f "$GOV/current/WeekPlan W36.md"
+
+# --- 2. Staged-семантика «за»: валидный staged, сломанное рабочее дерево ---
+valid_dayplan "$GOV/current/DayPlan 2026-08-30.md"
+git -C "$GOV" add "current/DayPlan 2026-08-30.md"
+echo "мусор без структуры" > "$GOV/current/DayPlan 2026-08-30.md"  # worktree сломан ПОСЛЕ add
+if (cd "$GOV" && git commit -qm "staged-valid") >"$TMP/c2.err" 2>&1; then
+    ok "валидный staged + сломанное рабочее дерево → коммит проходит"
+else
+    bad "валидный staged + сломанное рабочее дерево → коммит проходит"
+    cat "$TMP/c2.err"
+fi
+
+# --- 3. Staged-семантика «против»: невалидный staged, починенное дерево ---
+git -C "$GOV" reset -q
+rm -f "$GOV/current/DayPlan 2026-08-30.md"
+invalid_weekplan "$GOV/current/WeekPlan W36.md"
+git -C "$GOV" add "current/WeekPlan W36.md"          # staged = невалидный
+valid_weekplan "$GOV/current/WeekPlan W36.md"        # worktree починен, add НЕ повторялся
+echo x >> "$GOV/README.md"
+if (cd "$GOV" && git add README.md && git commit -qm "combined-other") >"$TMP/c3.err" 2>&1; then
+    bad "невалидный staged + починенное дерево без re-add → блок"
+else
+    ok "невалидный staged + починенное дерево без re-add → блок"
+fi
+git -C "$GOV" reset -q
+rm -f "$GOV/current/WeekPlan W36.md"
+git -C "$GOV" checkout -q README.md 2>/dev/null || true
+
+# --- 4. Валидная слитная форма проходит ---
+valid_weekplan "$GOV/current/WeekPlan W36.md"
+if (cd "$GOV" && git add "current/WeekPlan W36.md" && git commit -qm "combined-valid") >"$TMP/c4.err" 2>&1; then
+    ok "валидная слитная форма проходит"
+else
+    bad "валидная слитная форма проходит"
+    cat "$TMP/c4.err"
+fi
+
+# --- 5. Контракт поставки: валидатор подключён в seed-хуке и не требует
+# PreToolUse-контекста ---
+grep -q 'validate-staged-artifacts.sh' "$ROOT/seed/strategy/.githooks/pre-commit" \
+    && ok "seed pre-commit вызывает валидатор" \
+    || bad "seed pre-commit вызывает валидатор"
+if grep -qF 'git show ":$p"' "$ROOT/scripts/validate-staged-artifacts.sh"; then
+    ok "валидатор читает staged blob (git show :path), не рабочее дерево"
+else
+    bad "валидатор читает staged blob (git show :path), не рабочее дерево"
+fi
+
+# --- 6. Два WeekPlan одним коммитом: невалидный не прячется за валидным
+# (ревью: sort|tail -1 проверял бы только лексикографически последний) ---
+valid_weekplan "$GOV/current/WeekPlan W36.md"
+echo "допустимая правка W36, чтобы файл реально попал в индекс" >> "$GOV/current/WeekPlan W36.md"
+invalid_weekplan "$GOV/current/WeekPlan W99.md"
+# Санити: оба файла обязаны быть staged, иначе тест ничего не доказывает.
+STAGED_NOW=$(git -C "$GOV" add "current/WeekPlan W36.md" "current/WeekPlan W99.md" && git -C "$GOV" diff --cached --name-only)
+if [ "$(echo "$STAGED_NOW" | grep -c 'WeekPlan')" != "2" ]; then
+    bad "кейс 6 негерметичен: staged не оба WeekPlan"
+fi
+if (cd "$GOV" && git commit -qm "two-weekplans") >"$TMP/c6.err" 2>&1; then
+    bad "два WeekPlan одним коммитом: невалидный заблокирован"
+else
+    ok "два WeekPlan одним коммитом: невалидный заблокирован"
+fi
+grep -qF 'WeekPlan W99' "$TMP/c6.err" \
+    && ok "разбор называет именно невалидный файл" \
+    || bad "разбор называет именно невалидный файл"
+git -C "$GOV" reset -q
+rm -f "$GOV/current/WeekPlan W99.md"
+
+# --- 7. Mandatory fail-closed: конфиг существует, но не читается ---
+mkdir -p "$WS/scripts/lib" "$WS/memory"
+cp "$ROOT/scripts/lib/find-python3.sh" "$WS/scripts/lib/"
+printf 'mandatory_daily_wps: [сломано\n  без закрывающей скобки\n' > "$WS/memory/day-rhythm-config.yaml"
+valid_dayplan "$GOV/current/DayPlan 2026-08-31.md"
+if (cd "$GOV" && git add "current/DayPlan 2026-08-31.md" && git commit -qm "broken-config") >"$TMP/c7.err" 2>&1; then
+    bad "битый day-rhythm-config.yaml блокирует коммит DayPlan (fail-closed)"
+else
+    ok "битый day-rhythm-config.yaml блокирует коммит DayPlan (fail-closed)"
+fi
+grep -qF 'day-rhythm-config.yaml существует, но не читается' "$TMP/c7.err" \
+    && ok "fail-closed называет причину (конфиг не читается)" \
+    || bad "fail-closed называет причину (конфиг не читается)"
+git -C "$GOV" reset -q
+rm -f "$GOV/current/DayPlan 2026-08-31.md" "$WS/memory/day-rhythm-config.yaml"
+
+# --- 8. Резолюция пути: template-fallback без IWE_SCRIPTS (основной путь
+# обычного git commit вне сессии агента) ---
+unset IWE_SCRIPTS
+invalid_weekplan "$GOV/current/WeekPlan W37.md"
+if (cd "$GOV" && git add "current/WeekPlan W37.md" && git commit -qm "fallback-path") >"$TMP/c8.err" 2>&1; then
+    bad "без IWE_SCRIPTS невалидный WeekPlan блокируется (template-fallback)"
+else
+    ok "без IWE_SCRIPTS невалидный WeekPlan блокируется (template-fallback)"
+fi
+git -C "$GOV" reset -q
+rm -f "$GOV/current/WeekPlan W37.md"
+
+# --- 9. Резолюция пути: деградированный repo-local режим с WARN ---
+mv "$WS/FMT-exocortex-template/scripts/validate-staged-artifacts.sh" "$WS/FMT-exocortex-template/scripts/validate-staged-artifacts.sh.away"
+mkdir -p "$GOV/scripts"
+cp "$WS/FMT-exocortex-template/scripts/validate-staged-artifacts.sh.away" "$GOV/scripts/validate-staged-artifacts.sh"
+invalid_weekplan "$GOV/current/WeekPlan W38.md"
+if (cd "$GOV" && git add "current/WeekPlan W38.md" && git commit -qm "degraded") >"$TMP/c9.err" 2>&1; then
+    bad "repo-local fallback: невалидный WeekPlan блокируется"
+else
+    ok "repo-local fallback: невалидный WeekPlan блокируется"
+fi
+grep -qF 'деградированный режим' "$TMP/c9.err" \
+    && ok "repo-local fallback помечен WARNом о деградации" \
+    || bad "repo-local fallback помечен WARNом о деградации"
+mv "$WS/FMT-exocortex-template/scripts/validate-staged-artifacts.sh.away" "$WS/FMT-exocortex-template/scripts/validate-staged-artifacts.sh"
+rm -rf "$GOV/scripts"
+git -C "$GOV" reset -q
+rm -f "$GOV/current/WeekPlan W38.md"
+
+# --- 10. Пустой YAML-конфиг — fail-closed (корень не map) ---
+: > "$WS/memory/day-rhythm-config.yaml"
+valid_dayplan "$GOV/current/DayPlan 2026-09-01.md"
+if (cd "$GOV" && git add "current/DayPlan 2026-09-01.md" && git commit -qm "empty-config") >"$TMP/c10.err" 2>&1; then
+    bad "пустой day-rhythm-config.yaml блокирует коммит DayPlan (fail-closed)"
+else
+    ok "пустой day-rhythm-config.yaml блокирует коммит DayPlan (fail-closed)"
+fi
+git -C "$GOV" reset -q
+rm -f "$GOV/current/DayPlan 2026-09-01.md" "$WS/memory/day-rhythm-config.yaml"
+
+# --- 11. Интерпретатор падает нестандартным кодом (126) — fail-closed ---
+mkdir -p "$WS/memory"
+printf 'mandatory_daily_wps: []
+' > "$WS/memory/day-rhythm-config.yaml"
+FAKEPY="$WS/fake-python3"
+printf '#!/bin/sh\nexit 126\n' > "$FAKEPY"; chmod +x "$FAKEPY"
+# Подменяем резолвер: он должен вернуть путь к падающему интерпретатору.
+mv "$WS/scripts/lib/find-python3.sh" "$WS/scripts/lib/find-python3.sh.away"
+printf '#!/bin/sh\necho "%s"\n' "$FAKEPY" > "$WS/scripts/lib/find-python3.sh"; chmod +x "$WS/scripts/lib/find-python3.sh"
+valid_dayplan "$GOV/current/DayPlan 2026-09-02.md"
+if (cd "$GOV" && git add "current/DayPlan 2026-09-02.md" && git commit -qm "weird-rc") >"$TMP/c11.err" 2>&1; then
+    bad "нестандартный rc интерпретатора (126) блокирует коммит (fail-closed)"
+else
+    ok "нестандартный rc интерпретатора (126) блокирует коммит (fail-closed)"
+fi
+mv "$WS/scripts/lib/find-python3.sh.away" "$WS/scripts/lib/find-python3.sh"
+git -C "$GOV" reset -q
+rm -f "$GOV/current/DayPlan 2026-09-02.md" "$WS/memory/day-rhythm-config.yaml" "$FAKEPY"
+
+if [ "$fail" -gt 0 ]; then
+    echo "FAIL: $fail проверок упало"
+    exit 1
+fi
+echo "PASS: real pre-commit validates staged artifacts regardless of add/commit form (issue #544)"

--- a/scripts/validate-staged-artifacts.sh
+++ b/scripts/validate-staged-artifacts.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# routing: guard  deterministic=true
+# validate-staged-artifacts.sh — корректностная граница pre-commit для
+# протокольных артефактов governance-репо (issue #544).
+#
+# PreToolUse-хук protocol-artifact-validate.sh — ранний слой быстрой обратной
+# связи, но он читает индекс ДО выполнения команды, поэтому на слитной форме
+# `git add … && git commit` молчит. Этот скрипт вызывается НАСТОЯЩИМ git-хуком
+# pre-commit — он видит индекс после любой формы add (маски, -A/-u, слитные
+# команды) и читает staged blob (`git show :path`), а не рабочее дерево:
+# при частичном стейджинге проверяется именно то содержимое, что попадёт в
+# коммит. Проверяются ВСЕ staged-артефакты каждого типа, не один
+# лексикографически последний.
+#
+# Запуск: из .githooks/pre-commit governance-репо (cwd = корень репо).
+# Весь вывод — в stderr: stdout git-хука не гарантированно виден пользователю.
+# Exit 0 — коммит разрешён; exit 1 — блок с человекочитаемым разбором.
+set -uo pipefail
+
+TMPDIR_OWN=$(mktemp -d "${TMPDIR:-/tmp}/staged-artifacts.XXXXXX")
+trap 'rm -rf "$TMPDIR_OWN"' EXIT HUP INT TERM
+
+WORKSPACE="${IWE_WORKSPACE:-${IWE_ROOT:-$(cd "$(git rev-parse --show-toplevel)/.." 2>/dev/null && pwd || true)}}"
+GOV_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+ERRORS=()
+
+err() { ERRORS+=("$1"); }
+
+# staged_to_tmp <path> — staged blob во временный файл; печатает путь.
+staged_to_tmp() {
+    local p="$1" tmp
+    tmp=$(mktemp "$TMPDIR_OWN/blob.XXXXXX")
+    if git show ":$p" > "$tmp" 2>/dev/null; then
+        printf '%s\n' "$tmp"
+    else
+        rm -f "$tmp"
+        return 1
+    fi
+}
+
+validate_dayplan() { # <staged-path> <tmpfile>
+    local rel="$1" f="$2"
+    local section
+    local SECTIONS=(
+      "План на сегодня|Plan for Today|Today.s Plan"
+      "Календарь|Calendar"
+      "IWE за ночь|IWE Overnight"
+      "Разбор заметок|Notes Review"
+      "Итоги вчера|Yesterday"
+    )
+    for section in "${SECTIONS[@]}"; do
+        grep -qE "$section" "$f" || err "DayPlan $rel: пропущена секция «$section»"
+    done
+
+    local headings
+    headings=$(grep -cE '^## |^[[:space:]]*<summary>' "$f" 2>/dev/null || true)
+    if [ "${headings:-0}" -lt 3 ]; then
+        err "DayPlan $rel: секций (## или <summary>) меньше 3 (найдено: ${headings:-0})"
+    fi
+
+    local calendar_lines
+    calendar_lines=$(awk 'f && /^## /{exit} /Календарь|Calendar/{f=1} f' "$f" 2>/dev/null | wc -l | tr -d ' ')
+    if [ "${calendar_lines:-0}" -lt 3 ]; then
+        err "DayPlan $rel: секция «Календарь» пустая или слишком короткая (${calendar_lines:-0} строк)"
+    fi
+
+    if grep -q "Наработки Scout" "$f" 2>/dev/null; then
+        if ! awk 'f && /^## /{exit} /Наработки Scout/{f=1} f' "$f" 2>/dev/null | grep -iqE 'наход|capture|статус|нет|find|disabled|not configured'; then
+            err "DayPlan $rel: секция «Наработки Scout» пустая (допустимы маркеры 'нет находок', 'disabled', 'not configured')"
+        fi
+    fi
+
+    if ! grep -qE "~[0-9]+\.?[0-9]*x" "$f" && ! grep -qiE "мультипликатор.*(не считаю|не наст)" "$f"; then
+        err "DayPlan $rel: мультипликатор не найден — нужен '~N.Nx' в строке бюджета или явная оговорка «мультипликатор не считаю»"
+    fi
+
+    # Mandatory check — только если сконфигурирован. Конфиг существует, но
+    # не читается (битый YAML) — fail-closed: обязательная граница не вправе
+    # молча пропустить проверку из-за инфраструктурной ошибки. Python без
+    # резолвера/интерпретатора — пропуск с WARN (оценить конфиг нечем).
+    local config="$WORKSPACE/memory/day-rhythm-config.yaml"
+    local py=""
+    if [ -f "$WORKSPACE/scripts/lib/find-python3.sh" ]; then
+        py=$("$WORKSPACE/scripts/lib/find-python3.sh" 2>/dev/null) || py=""
+    fi
+    if [ -f "$config" ]; then
+        if [ -z "$py" ]; then
+            echo "WARN: day-rhythm-config.yaml есть, но python3 не найден — mandatory-проверка DayPlan пропущена" >&2
+        else
+            # Коды: 0 = mandatory сконфигурирован; 1 = валидный конфиг (map)
+            # без mandatory; 2 = любая ошибка (нет PyYAML, битый YAML, корень
+            # не map, включая пустой файл/null) — fail-closed (ревью #544).
+            local py_rc=0
+            "$py" -c "
+import sys
+try:
+    import yaml
+    d = yaml.safe_load(open(sys.argv[1]))
+except Exception:
+    sys.exit(2)
+if not isinstance(d, dict):
+    sys.exit(2)
+sys.exit(0 if d.get('mandatory_daily_wps') else 1)
+" "$config" 2>/dev/null || py_rc=$?
+            case "$py_rc" in
+                0)
+                    grep -qi "mandatory" "$f" || err "DayPlan $rel: mandatory check не найден (mandatory_daily_wps сконфигурирован)"
+                    ;;
+                1)
+                    : # валидный конфиг без mandatory — проверка не требуется
+                    ;;
+                *)
+                    # 2 — ошибки чтения/схемы; прочие коды (126/127/сигнал) —
+                    # тоже fail-closed: неизвестный исход проверки ≠ «не
+                    # сконфигурирован».
+                    err "DayPlan $rel: day-rhythm-config.yaml существует, но не читается (нет PyYAML / битый или пустой YAML / корень не map / интерпретатор упал rc=$py_rc) — mandatory-проверка невозможна, fail-closed"
+                    ;;
+            esac
+        fi
+    fi
+
+    if ! grep -qE "~[0-9]+\.?[0-9]* ?[hч] РП" "$f"; then
+        err "DayPlan $rel: бюджет дня не в формате '~Xч РП / ~Yч физ'"
+    fi
+
+    # Carry-over: предыдущий DayPlan ищется на диске (другие файлы — не часть
+    # индекса, это нормально), сам артефакт проверен из staged blob выше.
+    local prev
+    prev=$(ls "$GOV_ROOT"/current/DayPlan\ *.md 2>/dev/null | sort | tail -2 | head -1)
+    if [ -n "$prev" ] && [ "$prev" != "$GOV_ROOT/$rel" ]; then
+        grep -qiE 'carry.over|carry_over' "$f" || \
+            err "DayPlan $rel: carry-over из предыдущего Day Close отсутствует (предыдущий: $(basename "$prev"))"
+    fi
+}
+
+validate_weekplan() { # <staged-path> <tmpfile>
+    local rel="$1" f="$2"
+    local lines headings
+    lines=$(wc -l < "$f" | tr -d ' ')
+    headings=$(grep -cE '^## |^[[:space:]]*<summary>' "$f" 2>/dev/null || true)
+    if [ "${lines:-0}" -gt 80 ] && [ "${headings:-0}" -lt 3 ]; then
+        err "WeekPlan $rel: больше 80 строк ($lines), но секций (## или <summary>) меньше 3 (${headings:-0}) — структурируй через ## или <details><summary>"
+    fi
+}
+
+validate_weekreport() { # <staged-path> <tmpfile>
+    local rel="$1" f="$2"
+    grep -q "Итоги" "$f" || err "WeekReport $rel: нет секции «Итоги»"
+}
+
+# Обход ВСЕХ staged-артефактов каждого типа (а не одного sort|tail -1):
+# коммит с двумя WeekPlan не должен прятать невалидный за валидным.
+# -z + --diff-filter=ACMRT: имена с пробелами/юникодом не ломают разбор;
+# удалённые файлы не проверяются (проверять нечего), type-change (файл стал
+# симлинком) — проверяется. Перечисление индекса — fail-closed: не смогли
+# прочитать индекс → блок, а не молчаливый пропуск (ревью #544, раунд 2).
+STAGED_FILE="$TMPDIR_OWN/staged.list"
+if ! git diff --cached --name-only -z --diff-filter=ACMRT > "$STAGED_FILE" 2>"$TMPDIR_OWN/staged.err"; then
+    echo "⛔ Не удалось перечислить индекс (git diff --cached) — коммит заблокирован (fail-closed):" >&2
+    sed 's/^/  /' "$TMPDIR_OWN/staged.err" >&2
+    exit 1
+fi
+while IFS= read -r -d '' rel; do
+    case "$rel" in
+        current/DayPlan*.md)    kind=dayplan ;;
+        current/WeekPlan*.md)   kind=weekplan ;;
+        current/WeekReport*.md) kind=weekreport ;;
+        *) continue ;;
+    esac
+    tmp=$(staged_to_tmp "$rel") || {
+        echo "⛔ Не удалось прочитать staged blob $rel — коммит заблокирован (fail-closed)." >&2
+        exit 1
+    }
+    case "$kind" in
+        dayplan)    validate_dayplan "$rel" "$tmp" ;;
+        weekplan)   validate_weekplan "$rel" "$tmp" ;;
+        weekreport) validate_weekreport "$rel" "$tmp" ;;
+    esac
+    rm -f "$tmp"
+done < "$STAGED_FILE"
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo "⛔ PROTOCOL ARTIFACT VALIDATION FAILED (pre-commit, staged blob):" >&2
+    printf '  - %s\n' "${ERRORS[@]}" >&2
+    echo "Проверяется содержимое ИНДЕКСА (git show :path), не рабочего дерева —" >&2
+    echo "после правки файла повтори git add." >&2
+    exit 1
+fi
+exit 0

--- a/seed/strategy/.githooks/pre-commit
+++ b/seed/strategy/.githooks/pre-commit
@@ -9,4 +9,36 @@ if git diff --cached --name-only 2>/dev/null | grep -q '\.exocortex\.env'; then
     exit 1
 fi
 
+# === Protocol artifacts (issue #544): staged-semantics validation ===
+# Настоящий pre-commit видит реальный индекс после любой формы git add
+# (слитные `git add && git commit`, маски, -A/-u) — PreToolUse-перехватчик
+# protocol-artifact-validate.sh остаётся ранним слоем быстрой обратной связи,
+# эта граница — корректностная. Читает staged blob, не рабочее дерево.
+HOOK_REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+VALIDATOR=""
+VALIDATOR_MODE=""
+if [ -n "${IWE_SCRIPTS:-}" ] && [ -f "${IWE_SCRIPTS}/validate-staged-artifacts.sh" ]; then
+    VALIDATOR="${IWE_SCRIPTS}/validate-staged-artifacts.sh"
+    VALIDATOR_MODE="template"
+elif [ -f "$HOOK_REPO_ROOT/../FMT-exocortex-template/scripts/validate-staged-artifacts.sh" ]; then
+    VALIDATOR="$HOOK_REPO_ROOT/../FMT-exocortex-template/scripts/validate-staged-artifacts.sh"
+    VALIDATOR_MODE="template"
+elif [ -f "$HOOK_REPO_ROOT/scripts/validate-staged-artifacts.sh" ]; then
+    # Деградированный режим: исполняется версия из рабочего дерева, а не из
+    # индекса/шаблона — локальная правка валидатора влияет на саму проверку.
+    VALIDATOR="$HOOK_REPO_ROOT/scripts/validate-staged-artifacts.sh"
+    VALIDATOR_MODE="degraded-repo-local"
+fi
+if [ -z "$VALIDATOR" ]; then
+    # Не блокируем: на свежей установке до первого /iwe-update валидатора может
+    # ещё не быть. Отсутствие границы обязано быть видимым, не тихим.
+    echo "WARN: validate-staged-artifacts.sh не найден — протокольные артефакты коммитятся без staged-проверки (обновите шаблон: /iwe-update)" >&2
+else
+    [ "$VALIDATOR_MODE" = "degraded-repo-local" ] && \
+        echo "WARN: validate-staged-artifacts.sh исполняется из рабочего дерева репо (деградированный режим), а не из шаблона" >&2
+    if ! bash "$VALIDATOR"; then
+        exit 1
+    fi
+fi
+
 exit 0

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2720,6 +2720,10 @@
       "sha256": "35c13fa3df643cade27d01f6a15e62ae0002c6adb6e9885545d47e5d8becd815"
     },
     {
+      "path": "scripts/validate-staged-artifacts.sh",
+      "sha256": "be628b27788432af3497f918c5e7a2157d0f98914ae02a2e2a6d82c7f78204da"
+    },
+    {
       "path": "scripts/verify-context-budget.sh",
       "sha256": "f5d55e0427acabe899428cdaa3b64cbc2a64c8f2c4a402041a66ba48365ea4d2"
     },
@@ -2749,7 +2753,7 @@
     },
     {
       "path": "seed/strategy/.githooks/pre-commit",
-      "sha256": "8588fd4668cee6d9808e852bb57f575b87b80103bd5ea654cc64c5de64e01a0b"
+      "sha256": "b52c3095b14d589223b1651cb5d573242cea22aa9fb7a2df0f2b010a950be8f4"
     },
     {
       "path": "seed/strategy/.githooks/pre-push",
@@ -2877,6 +2881,7 @@
     "scripts/tests/test_issue_530_staged_self_scan.sh",
     "scripts/tests/test_issue_531_index_health_status_cell.py",
     "scripts/tests/test_issue_532_dayplan_strategy_gate.sh",
+    "scripts/tests/test_issue_544_staged_precommit.sh",
     "scripts/tests/test_issue_545_sessions_root.sh",
     "scripts/tests/test_issue_555_claude_silent_loss.sh",
     "scripts/tests/test_issue_581_calendar_single_source.sh",


### PR DESCRIPTION
## Что чинит

Closes #544.

PreToolUse-хук `protocol-artifact-validate.sh` читает индекс ДО выполнения команды, поэтому слитная форма `git add && git commit` молча обходила все три валидатора (DayPlan/WeekPlan/WeekReport) — «нет сигнала» читалось как «проверено».

## Фикс

- Настоящий git-хук pre-commit — обязательная корректностная граница: новый `scripts/validate-staged-artifacts.sh` перечисляет индекс fail-closed, читает staged blob (`git show :path`), проверяет **каждый** staged-артефакт (не один `tail -1`), mandatory-проверка fail-closed при любой ошибке чтения конфига/интерпретатора. PreToolUse-хук не тронут — остаётся ранним слоем быстрой обратной связи.
- `seed/strategy/.githooks/pre-commit`: вызов валидатора с резолюцией пути (шаблон → соседний шаблон → repo-local как деградированный режим с WARN); отсутствие валидатора — видимый WARN без блока (свежая установка до первого update).

## Проверка

`scripts/tests/test_issue_544_staged_precommit.sh` — настоящий git-репозиторий, настоящие коммиты (17 проверок): слитная форма блокируется; staged-семантика доказана в обе стороны (валидный staged + сломанное дерево → проходит; невалидный staged + починенное дерево без re-add → блок); два артефакта одним коммитом; битый/пустой конфиг и нестандартный код интерпретатора → fail-closed; обе ветки резолюции пути. Полный набор issue-тестов зелёный.

## Пир-ревью

4 раунда (Codex + Claude), консенсус. Закрыты: проверка одного файла вместо всех, stdout/stderr, герметичность тестов, fail-open на PyYAML/импорте и перечислении индекса, маркировка деградированного режима.

Analyzed-by: Codex <noreply@openai.com>
Analyzed-by: Claude Sonnet 4.6 <noreply@anthropic.com>