### PR TITLE
fix(ci): allowlist known test-fixture false positives in nightly secret scan

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+title = "gitleaks config for FMT-exocortex-template"
+
+[extend]
+useDefault = true
+
+# Both files below are unit tests for the platform's own secret-quarantine
+# detector (guide-kit/structurer/quarantine.py). They intentionally embed
+# fake AWS/API-key-shaped strings as test input so the detector has
+# something to catch — the strings never touch a real credential. Verified
+# live 2026-08-31 (WP-529 red-team prep) against the SARIF from the failing
+# Nightly Audit run: every finding pointed at these two files.
+[allowlist]
+paths = [
+  '''guide-kit/structurer/test_quarantine\.py''',
+  '''setup/test-update-release-channel\.sh''',
+]

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -732,6 +732,10 @@
       "sha256": "af6d4f4f3b7b4b07faef627856bd77c28ac0a957b42fcb9c8b68ff7f460094d4"
     },
     {
+      "path": ".gitleaks.toml",
+      "sha256": "1d86da22e3faa02a9c9789a8cfe5b000ce7daae9d04e3a99530fec2ca899d57c"
+    },
+    {
       "path": ".mcp.json",
       "sha256": "ecd2f0ef900004f49208fed8f71500ca23876807a0cd3ae3525de306f25df6d8"
     },


### PR DESCRIPTION
## Что и почему

Ночная проверка шаблона (`Поиск секретов`, gitleaks) красная каждую ночь на
двух тестовых файлах: `guide-kit/structurer/test_quarantine.py` и
`setup/test-update-release-channel.sh`. Проверил SARIF реального упавшего
прогона (30.08 22:16 UTC) — все 8 находок указывают ровно на эти два файла.
Оба намеренно содержат синтетические AWS/API-key-подобные строки как тестовый
ввод: `test_quarantine.py` тестирует собственный детектор
секретов-в-заметках платформы (`guide-kit/structurer/quarantine.py`),
`test-update-release-channel.sh` тестирует, что секрет не утекает в trace
под `set -x`. Реальных значений там нет.

## Что сделал

Добавил `.gitleaks.toml` с `useDefault = true` (правила по умолчанию не
теряются) + allowlist по путям только для этих двух файлов.

## Проверка

- `gitleaks detect --config .gitleaks.toml --no-git` на локальной копии —
  чисто, конфиг синтаксически валиден.
- Полной локальной репродукции исходных находок не получил (расхождение
  версий gitleaks CLI vs `gitleaks-action@v2` в CI) — финальная проверка
  через реальный прогон `Ночная проверка шаблона IWE` на этой ветке.

Refs: WP-529 (конвейер доставки шаблона IWE 2.0)