### PR TITLE
fix(agent-fault): sqlite busy_timeout 5с → 30с для конкурентных писателей-хуков

### DIFF
--- a/scripts/agent-fault/iwe_checklist_memory.py
+++ b/scripts/agent-fault/iwe_checklist_memory.py
@@ -539,9 +539,14 @@ def _prepare_database(paths: ProfilePaths, *, create: bool) -> bool:
 def _connect(paths: ProfilePaths, *, create: bool) -> sqlite3.Connection | None:
     if not _prepare_database(paths, create=create):
         return None
-    connection = sqlite3.connect(paths.database, timeout=5)
+    # 30s (было 5s): десятки параллельных писателей (хуки нескольких агентов
+    # одновременно) на нагруженном хосте периодически превышали 5s очереди на
+    # блокировке — "database is locked" и в проде, и в CI (issue-tests 533,
+    # мерцал на каждом втором прогоне). busy_timeout остаётся ограничением
+    # ожидания, не бесконечным зависанием.
+    connection = sqlite3.connect(paths.database, timeout=30)
     connection.row_factory = sqlite3.Row
-    connection.execute("PRAGMA busy_timeout=5000")
+    connection.execute("PRAGMA busy_timeout=30000")
     try:
         _migrate(connection)
         _harden_database_files(paths)

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1925,7 +1925,7 @@
     },
     {
       "path": "scripts/agent-fault/iwe_checklist_memory.py",
-      "sha256": "2c9fe09b959ca6c8c1c1db66f148388e97e2f92b2e4b4abd310962526bed03a4"
+      "sha256": "0e498f9aa925f3a91c031fd2a10823a53f0d350d6fdb09b086d703ae4035ea79"
     },
     {
       "path": "scripts/agent-heartbeat.sh",


### PR DESCRIPTION
## Что чинит

Мерцающий `test_issue_533` (`database is locked` каждый второй прогон CI, в т.ч. на main): десятки конкурентных писателей-хуков (несколько агентов одновременно) превышали очередь ожидания блокировки SQLite в 5 секунд на нагруженном хосте.

## Фикс

`busy_timeout` и `timeout` соединения 5с → 30с (`scripts/agent-fault/iwe_checklist_memory.py`). Ожидание остаётся ограниченным, транзакции короткими. По ревью: WAL и логирование долгих ожиданий — кандидаты отдельным шагом, не здесь.

## Проверка

`pytest scripts/tests/test_issue_533_agent_fault_delivery.py` — 122 passed, 1 skipped.

Analyzed-by: Codex <noreply@openai.com>
