### PR TITLE
fix(ci): weekly-bump opens a PR instead of pushing to main directly

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -2,25 +2,32 @@ name: Weekly Release
 
 # Еженедельно (Вс 20:00 UTC = Пн 00:00 MSK+1) проверяет CHANGELOG.md:
 # если секция [Unreleased] непустая — бампает patch-версию в
-# update-manifest.json и коммитит.
+# update-manifest.json и открывает PR с этим бампом.
 #
-# WP-7 Ф62 (10.08.2026): раньше отсюда явно звали release.yml напрямую —
-# тег и релиз создавались БЕЗ единой проверки CI на этом коммите (сам бамп
-# нигде не тестировался). Теперь этот job явно зовёт validate-template.yml
-# (workflow_dispatch — коммит идёт от github-actions[bot] через стандартный
-# GITHUB_TOKEN, а такие коммиты по anti-recursion policy GitHub не
-# каскадируют в push-триггеры сами по себе) и на этом останавливается —
-# release.yml подписан на завершение Validate Template (workflow_run) и
-# сам создаст тег/релиз, если та проверка прошла зелёной. Раньше здесь же
-# был polling + gh run watch, чтобы дождаться результата и явно вызвать
-# release.yml — убрано (пир-ревью 2026-08-10-13-wp7-f62-release-gate-review):
-# опасная гонка (какой конкретно run соответствует какому push) была в
-# самом сопоставлении по SHA/времени, а не в том, что job не ждёт результата.
-# release.yml сам берёт SHA из события workflow_run — гонки нет по построению.
+# WP-529 (31.08.2026): main с 27.08 требует обязательное ревью от code
+# owner'а на каждый мердж (защита ветки, часть слоя принуждения red-team
+# гейта) — прямой `git push origin main` от бота больше физически не
+# проходит (`GH006: Protected branch update failed`). Раньше здесь же был
+# прямой push + явный dispatch validate-template.yml/release.yml (нужен
+# был из-за anti-recursion policy: коммит от github-actions[bot] через
+# стандартный GITHUB_TOKEN не каскадирует в push-триггеры сам по себе) —
+# убрано вместе с прямым push. Теперь job останавливается на открытии PR;
+# CODEOWNERS назначается автоматически, а как только пилот вручную
+# смерджит PR — обычный merge-коммит от GitHub (не от GITHUB_TOKEN
+# Actions-рана) штатно триггерит push-подписки validate-template.yml, а
+# та в свою очередь — release.yml (workflow_run) без какого-либо ручного
+# dispatch: та же цепочка, что и для любого другого мерджа в main.
 #
-# Причина: раньше версия бампалась только вручную — паузы между
-# выпусками доходили до 2-3 недель, хотя коммиты в [Unreleased]
-# шли почти ежедневно (см. docs/RELEASE-PROCESS.md).
+# WP-7 Ф62 (10.08.2026): исходная причина вообще звать validate перед
+# релизом — раньше бамп версии никак не тестировался перед тем, как
+# release.yml создавал тег. Это по-прежнему так: PR проходит все
+# обязательные проверки (включая release-receipt) прежде чем его можно
+# смерджить.
+#
+# Причина автоматизации в целом: раньше версия бампалась только вручную —
+# паузы между выпусками доходили до 2-3 недель, хотя коммиты в
+# [Unreleased] шли почти ежедневно (см. docs/RELEASE-PROCESS.md). Теперь
+# ручной шаг — только мердж уже готового PR, не сборка бампа с нуля.
 
 on:
   schedule:
@@ -29,7 +36,7 @@ on:
 
 permissions:
   contents: write
-  actions: write
+  pull-requests: write
 
 jobs:
   weekly-bump:
@@ -91,42 +98,30 @@ jobs:
           bash scripts/sync-version-badge.sh --fix
           bash generate-manifest.sh
 
-      - name: Commit and push
+      - name: Commit to a release branch
         if: steps.check.outputs.has_content == 'true'
+        id: commit
         run: |
+          BRANCH="release/v${{ steps.bump.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add update-manifest.json CHANGELOG.md README.md
           git commit -m "chore(release): weekly auto-bump to v${{ steps.bump.outputs.version }}"
-          git push origin main
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
-      - name: Validate the bump commit and close the release chain
-        # 2026-08-22, live half-release v0.38.7: a Validate run dispatched
-        # with GITHUB_TOKEN completes WITHOUT emitting workflow_run events
-        # (GitHub anti-recursion), so release.yml never fired for the bump
-        # commit — the version bumped, the tag never appeared, and the daily
-        # notify announced a release that did not exist. Fire-and-forget is
-        # not an option with the default token: wait for that exact Validate
-        # run and dispatch release.yml explicitly (API dispatches DO run).
+      - name: Open release PR
+        # main требует ревью code owner'а (branch protection, WP-529) —
+        # смердженный PR даёт обычный push-коммит, который штатно
+        # запускает validate-template.yml → release.yml, тот же путь, что
+        # и любой другой мердж. Явный dispatch здесь больше не нужен.
         if: steps.check.outputs.has_content == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          BUMP_SHA=$(git rev-parse HEAD)
-          gh workflow run validate-template.yml --ref main
-          sleep 20
-          RUN_ID=""
-          for i in $(seq 1 30); do
-            RUN_ID=$(gh run list --workflow validate-template.yml --branch main               --json databaseId,headSha,event               --jq ".[] | select(.headSha==\"$BUMP_SHA\" and .event==\"workflow_dispatch\") | .databaseId" | head -1)
-            [ -n "$RUN_ID" ] && break
-            sleep 10
-          done
-          [ -n "$RUN_ID" ] || { echo "Validate run for bump commit $BUMP_SHA never appeared"; exit 1; }
-          gh run watch "$RUN_ID" --exit-status
-          # 2026-08-22 (Codex peer-review of the v0.38.7 post-mortem): pass the
-          # validated SHA explicitly — a bare `--ref main` dispatch would tag
-          # whatever main's tip is when release.yml starts, so a commit landing
-          # between the green Validate and the dispatch would ride into the
-          # release unvalidated. release.yml pins checkout (and therefore the
-          # tag) to this SHA.
-          gh workflow run release.yml --ref main -f version="${{ steps.bump.outputs.version }}" -f sha="$BUMP_SHA"
+          gh pr create \
+            --title "chore(release): weekly auto-bump to v${{ steps.bump.outputs.version }}" \
+            --body "Еженедельный автобамп версии. Мердж запускает обычный релизный конвейер (validate → release) через штатный push-триггер." \
+            --base main \
+            --head "${{ steps.commit.outputs.branch }}"


### PR DESCRIPTION
## Что и почему

С 27.08 `main` требует ревью code owner'а на каждый мердж (защита ветки,
WP-529). Еженедельный бамп версии (`weekly-release.yml`) пытался пушить
коммит напрямую в `main` от `github-actions[bot]` — это больше физически
не проходит: `GH006: Protected branch update failed`. Живой пример упавшего
прогона — 2026-08-30 22:30 UTC.

## Что сделал

Не стал обходить требование ревью для бота (это реальный компромисс
безопасности — решение не для одного PR, а для пилота отдельно). Вместо
этого: job теперь коммитит бамп в ветку `release/vX.Y.Z` и открывает PR.
Явный `gh workflow run validate-template.yml` + polling + явный dispatch
`release.yml` (нужны были только чтобы обойти anti-recursion policy для
прямого push) больше не нужны и удалены — обычный мердж-коммит после
ручного мерджа PR штатно триггерит `validate-template.yml` по push, а та
через `workflow_run` — `release.yml`, тем же путём, что и любой другой
мердж в main.

## Проверка

- YAML валиден (`yaml.safe_load`).
- `.github/workflows/*` — файлы «только для мейнтейнера», манифест их не
  трекает, регенерация не требуется (подтвердил: `git status` после
  `generate-manifest.sh` не тронул `update-manifest.json`).
- Живой прогон через `workflow_dispatch` не делал — он бы попытался
  реально открыть PR с бампом версии на текущем `[Unreleased]`, что
  преждевременно вне контекста настоящего еженедельного цикла. Логика
  step-by-step идентична существующему шаблону (тот же паттерн, что уже
  использует `weekly-bump`), риск ограничен одним новым `gh pr create`.

Refs: WP-529 (конвейер доставки шаблона IWE 2.0)