### PR TITLE
feat(wp526): declarative bootstrap-repo loop in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1014,9 +1014,17 @@ else
         fi
     }
 
-    clone_base_repo "ZP" "TserenTserenov/ZP"
-    clone_base_repo "FPF" "ailev/FPF"
-    clone_base_repo "SPF" "TserenTserenov/SPF"
+    # Declarative list instead of 3 hardcoded calls (WP-526 Ф6). PD-*/MC-*
+    # repo families are NOT added here — they are created on-demand by
+    # WP-527, not at install time (see hint printed at the end of setup).
+    BOOTSTRAP_REPOS=(
+        "ZP:TserenTserenov/ZP"
+        "FPF:ailev/FPF"
+        "SPF:TserenTserenov/SPF"
+    )
+    for entry in "${BOOTSTRAP_REPOS[@]}"; do
+        clone_base_repo "${entry%%:*}" "${entry#*:}"
+    done
 fi
 
 # === Done ===
@@ -1063,6 +1071,10 @@ else
     echo ""
     echo "Update from upstream:"
     echo "  cd $TEMPLATE_DIR && bash update.sh"
+    echo ""
+
+    echo "Личные (PD-*) и служебные (MC-*) репозитории (WP-526/WP-527):"
+    echo "  создаются по запросу, не при установке — см. README.md § «5 семей репозиториев»"
     echo ""
 
     # === Post-install validation (WP-265 Ф8) ===

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2813,7 +2813,7 @@
     },
     {
       "path": "setup.sh",
-      "sha256": "a32cc0a57ff6dd081cb2db2e1581855331b5f9c1b17db855afd4dccbb896ac64"
+      "sha256": "78b5d12b52c4aa10db3b2ca6a1e3f25cb7ed219cc32ed33c470936aca20677ed"
     },
     {
       "path": "setup/build-runtime.sh",


### PR DESCRIPTION
## Summary
- WP-526 Ф6: `setup.sh` clone_base_repo(ZP/FPF/SPF) hardcode -> declarative array + loop (pure refactor, verified byte-identical dry-run output/order in isolation).
- Post-install hint added: PD-*/MC-* repo families are created on demand (WP-527), not by setup.sh — points to README § "5 семей репозиториев".
- Scope split with WP-527 recorded in inbox/WP-526/WP-526.md and inbox/WP-527/WP-527.md (governance repo, not part of this PR).

## Test plan
- [x] `bash -n setup.sh` clean
- [x] `shellcheck -S warning setup.sh` — no new warnings (2 pre-existing, unrelated lines)
- [x] Isolated loop reproduction: identical dry-run output/order vs old 3 hardcoded calls
- [x] Cold-context code review (subagent): set -e/idempotency/quoting/entry-leak all traced — 0 critical/high/medium

Refs: peer-session `2026-08-31-25-wp526-uncommitted-triage` (Claude + Codex), consensus turn 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)