### PR TITLE
fix(wp484): restore 6 regressions in update-derived-snapshot.py, fix day-open-llm-fill.py is_today_plan

### DIFF
--- a/scripts/day-open-llm-fill.py
+++ b/scripts/day-open-llm-fill.py
@@ -617,8 +617,26 @@ def fill_chunk(chunk: dict, weekplan: str, active_wps: str, calendar: str,
     header = chunk["header"]
     content = "".join(chunk["lines"][1:])  # без заголовка
 
-    # Consolidated prompt with JSON facts for today_plan
-    is_today_plan = "План на сегодня" in header or "today_plan" in header.lower()
+    # Consolidated prompt with JSON facts for today_plan.
+    # `header` is usually the bare "<details>"/"<details open>" tag (chunking
+    # stores the <summary> title in `content`, not `header`) — checking
+    # `header` alone means this branch never fires for that shape, and the
+    # plan table falls through to the generic per-section prompt, which
+    # leaves the scaffold's example placeholders (N/NNN/X) unreplaced instead
+    # of computing a real seq/hours value per WP. Checking `content` alone
+    # would instead miss a plain "## План на сегодня" heading (chunk header
+    # can carry the title directly there) if the body never repeats the
+    # phrase — Codex review, WP-484 backfill-regression-fix session, 31.08.
+    # Checking both covers each chunking shape without betting on which one
+    # is live. Regressed and re-fixed three times in a consumer's installed
+    # copy (2026-07-09, then 26.08, then 31.08) — each time only that copy
+    # was patched, so this canonical source kept re-seeding the bug on the
+    # next backfill; fixed here too (WP-484, peer-session with Codex, same
+    # day) to close that loop.
+    is_today_plan = (
+        "План на сегодня" in content or "today_plan" in content.lower()
+        or "План на сегодня" in header or "today_plan" in header.lower()
+    )
     if is_today_plan and wp_facts:
         prompt = build_today_plan_prompt(header, content, weekplan, wp_facts,
                                          calendar, cp_profile, fault_profile)

--- a/scripts/update-derived-snapshot.py
+++ b/scripts/update-derived-snapshot.py
@@ -73,6 +73,12 @@ _STAGE_INT_TO_LABEL = {
 # RCS slots tracked in rcs_indices (M3/IT/A are rarely bottlenecks but included for completeness).
 _RCS_SLOTS = ["W", "M1", "M2", "M3", "M4", "IT", "A"]
 
+# Claude Code registers MCP tools as mcp__<server>__<tool>; the short tool name
+# alone never matches --allowedTools, so a headless call is silently denied at
+# the permission gate (no TTY to prompt) and every retry fails the same way.
+# See bug-2026-07-12-digital-twin-fetch-fails-headless.md.
+_ALLOWED_TOOL_DT_READ = "mcp__claude_ai_IWE__dt_read_digital_twin"
+
 
 def _is_stale(stale_days: int) -> bool:
     """Return True if snapshot is missing or older than stale_days."""
@@ -100,7 +106,7 @@ def _fetch_derived_via_headless_claude() -> dict:
     )
     try:
         result = subprocess.run(
-            ["claude", "-p", prompt, "--allowedTools", "dt_read_digital_twin",
+            ["claude", "-p", prompt, "--allowedTools", _ALLOWED_TOOL_DT_READ,
              "--output-format", "text"],
             capture_output=True, text=True, timeout=120,
         )
@@ -143,8 +149,13 @@ def _parse_qualification(response: dict) -> dict:
         if isinstance(data, dict) and key in data and isinstance(data[key], dict):
             data = data[key]
 
-    # Locate 3_4_qualification — may be nested or top-level.
-    qual = data.get("3_4_qualification") or data.get("3_derived", {}).get("3_4_qualification") or data
+    # Locate 3_4_qualification — may be nested or top-level, under either the
+    # current key or the pre-WP-462 name (render-pilot-guides.py:_rcs_from_digital_twin
+    # hit the same profiler rename and checks both; mirrored here).
+    def _find_qual(d: dict):
+        return d.get("3_4_qualification_estimate") or d.get("3_4_qualification")
+
+    qual = _find_qual(data) or _find_qual(data.get("3_derived", {})) or data
     if not isinstance(qual, dict):
         raise RuntimeError(f"Cannot locate 3_4_qualification in response: {str(response)[:300]}")
 
@@ -157,18 +168,36 @@ def _parse_qualification(response: dict) -> dict:
         raise RuntimeError(f"Unknown stage_id '{stage_id}' and no fallback stage in response")
 
     rcs = qual.get("rcs_indices", {})
-    slot_vals = {s: rcs.get(s, 0) for s in _RCS_SLOTS if rcs.get(s) is not None}
+    if isinstance(rcs, str):
+        rcs = json.loads(rcs)
+    if not isinstance(rcs, dict):
+        raise RuntimeError(f"rcs_indices has unexpected type {type(rcs).__name__}")
+    # Each slot is {"idx": N, ...metadata} (calibrated/streak/events), not a bare
+    # number — same shape render-pilot-guides.py:_rcs_from_digital_twin already
+    # unwraps. Surfaced only once the fetch itself started working (bug-2026-07-12):
+    # the old `rcs.get(s, 0)` returned the dict itself, TypeError on min() below.
+    slot_vals = {
+        s: rcs[s]["idx"] for s in _RCS_SLOTS
+        if isinstance(rcs.get(s), dict) and "idx" in rcs[s]
+    }
     if not slot_vals:
         raise RuntimeError("rcs_indices missing or empty in qualification data")
 
     # Bottleneck = slot with minimum value; M1 preferred on ties.
     bottleneck = min(slot_vals, key=lambda k: (slot_vals[k], k != "M1"))
 
+    # bottleneck can land on a rare slot (M3/IT/A, kept in _RCS_SLOTS "for
+    # completeness") not among the 4 always shown — keep it in rcs too, so
+    # bottleneck_slot never names a key absent from the snapshot's own rcs.
+    rcs_keys = ["W", "M1", "M2", "M4"]
+    if bottleneck not in rcs_keys:
+        rcs_keys.append(bottleneck)
+
     return {
         "stage_raw": stage,
         "stage_label": _STAGE_INT_TO_LABEL.get(stage, f"Ступень {stage}"),
         "bottleneck_slot": bottleneck,
-        "rcs": {s: slot_vals[s] for s in ["W", "M1", "M2", "M4"] if s in slot_vals},
+        "rcs": {s: slot_vals[s] for s in rcs_keys if s in slot_vals},
     }
 
 
@@ -213,14 +242,17 @@ def main() -> int:
     logging.info("Fetching 3_derived via headless claude...")
     try:
         response = _fetch_derived_via_headless_claude()
-    except RuntimeError as exc:
+    except Exception as exc:
+        # Broad on purpose: this is a cron/launchd entry point — any unexpected
+        # failure (incl. shapes we didn't anticipate) must log one clean line,
+        # not a raw traceback, so the cron log stays scannable.
         logging.error("Fetch failed: %s", exc)
         return 1
 
     logging.info("Parsing 3_4_qualification...")
     try:
         parsed = _parse_qualification(response)
-    except RuntimeError as exc:
+    except Exception as exc:
         logging.error("Parse failed: %s", exc)
         return 1
 

--- a/seed/strategy/scripts/day-open-llm-fill.py
+++ b/seed/strategy/scripts/day-open-llm-fill.py
@@ -1,5 +1,5 @@
-# SNAPSHOT — synced manually via script-promote.sh from FMT-exocortex-template/scripts/. Do not edit here directly.
 from __future__ import annotations
+# SNAPSHOT — synced manually via script-promote.sh from FMT-exocortex-template/scripts/. Do not edit here directly.
 #!/usr/bin/env python3
 """
 day-open-llm-fill.py — WP-356: per-section LLM-заполнение PENDING-маркеров DayPlan.
@@ -618,8 +618,26 @@ def fill_chunk(chunk: dict, weekplan: str, active_wps: str, calendar: str,
     header = chunk["header"]
     content = "".join(chunk["lines"][1:])  # без заголовка
 
-    # Consolidated prompt with JSON facts for today_plan
-    is_today_plan = "План на сегодня" in header or "today_plan" in header.lower()
+    # Consolidated prompt with JSON facts for today_plan.
+    # `header` is usually the bare "<details>"/"<details open>" tag (chunking
+    # stores the <summary> title in `content`, not `header`) — checking
+    # `header` alone means this branch never fires for that shape, and the
+    # plan table falls through to the generic per-section prompt, which
+    # leaves the scaffold's example placeholders (N/NNN/X) unreplaced instead
+    # of computing a real seq/hours value per WP. Checking `content` alone
+    # would instead miss a plain "## План на сегодня" heading (chunk header
+    # can carry the title directly there) if the body never repeats the
+    # phrase — Codex review, WP-484 backfill-regression-fix session, 31.08.
+    # Checking both covers each chunking shape without betting on which one
+    # is live. Regressed and re-fixed three times in a consumer's installed
+    # copy (2026-07-09, then 26.08, then 31.08) — each time only that copy
+    # was patched, so this canonical source kept re-seeding the bug on the
+    # next backfill; fixed here too (WP-484, peer-session with Codex, same
+    # day) to close that loop.
+    is_today_plan = (
+        "План на сегодня" in content or "today_plan" in content.lower()
+        or "План на сегодня" in header or "today_plan" in header.lower()
+    )
     if is_today_plan and wp_facts:
         prompt = build_today_plan_prompt(header, content, weekplan, wp_facts,
                                          calendar, cp_profile, fault_profile)

--- a/seed/strategy/scripts/update-derived-snapshot.py
+++ b/seed/strategy/scripts/update-derived-snapshot.py
@@ -74,6 +74,12 @@ _STAGE_INT_TO_LABEL = {
 # RCS slots tracked in rcs_indices (M3/IT/A are rarely bottlenecks but included for completeness).
 _RCS_SLOTS = ["W", "M1", "M2", "M3", "M4", "IT", "A"]
 
+# Claude Code registers MCP tools as mcp__<server>__<tool>; the short tool name
+# alone never matches --allowedTools, so a headless call is silently denied at
+# the permission gate (no TTY to prompt) and every retry fails the same way.
+# See bug-2026-07-12-digital-twin-fetch-fails-headless.md.
+_ALLOWED_TOOL_DT_READ = "mcp__claude_ai_IWE__dt_read_digital_twin"
+
 
 def _is_stale(stale_days: int) -> bool:
     """Return True if snapshot is missing or older than stale_days."""
@@ -101,7 +107,7 @@ def _fetch_derived_via_headless_claude() -> dict:
     )
     try:
         result = subprocess.run(
-            ["claude", "-p", prompt, "--allowedTools", "dt_read_digital_twin",
+            ["claude", "-p", prompt, "--allowedTools", _ALLOWED_TOOL_DT_READ,
              "--output-format", "text"],
             capture_output=True, text=True, timeout=120,
         )
@@ -144,8 +150,13 @@ def _parse_qualification(response: dict) -> dict:
         if isinstance(data, dict) and key in data and isinstance(data[key], dict):
             data = data[key]
 
-    # Locate 3_4_qualification — may be nested or top-level.
-    qual = data.get("3_4_qualification") or data.get("3_derived", {}).get("3_4_qualification") or data
+    # Locate 3_4_qualification — may be nested or top-level, under either the
+    # current key or the pre-WP-462 name (render-pilot-guides.py:_rcs_from_digital_twin
+    # hit the same profiler rename and checks both; mirrored here).
+    def _find_qual(d: dict):
+        return d.get("3_4_qualification_estimate") or d.get("3_4_qualification")
+
+    qual = _find_qual(data) or _find_qual(data.get("3_derived", {})) or data
     if not isinstance(qual, dict):
         raise RuntimeError(f"Cannot locate 3_4_qualification in response: {str(response)[:300]}")
 
@@ -158,18 +169,36 @@ def _parse_qualification(response: dict) -> dict:
         raise RuntimeError(f"Unknown stage_id '{stage_id}' and no fallback stage in response")
 
     rcs = qual.get("rcs_indices", {})
-    slot_vals = {s: rcs.get(s, 0) for s in _RCS_SLOTS if rcs.get(s) is not None}
+    if isinstance(rcs, str):
+        rcs = json.loads(rcs)
+    if not isinstance(rcs, dict):
+        raise RuntimeError(f"rcs_indices has unexpected type {type(rcs).__name__}")
+    # Each slot is {"idx": N, ...metadata} (calibrated/streak/events), not a bare
+    # number — same shape render-pilot-guides.py:_rcs_from_digital_twin already
+    # unwraps. Surfaced only once the fetch itself started working (bug-2026-07-12):
+    # the old `rcs.get(s, 0)` returned the dict itself, TypeError on min() below.
+    slot_vals = {
+        s: rcs[s]["idx"] for s in _RCS_SLOTS
+        if isinstance(rcs.get(s), dict) and "idx" in rcs[s]
+    }
     if not slot_vals:
         raise RuntimeError("rcs_indices missing or empty in qualification data")
 
     # Bottleneck = slot with minimum value; M1 preferred on ties.
     bottleneck = min(slot_vals, key=lambda k: (slot_vals[k], k != "M1"))
 
+    # bottleneck can land on a rare slot (M3/IT/A, kept in _RCS_SLOTS "for
+    # completeness") not among the 4 always shown — keep it in rcs too, so
+    # bottleneck_slot never names a key absent from the snapshot's own rcs.
+    rcs_keys = ["W", "M1", "M2", "M4"]
+    if bottleneck not in rcs_keys:
+        rcs_keys.append(bottleneck)
+
     return {
         "stage_raw": stage,
         "stage_label": _STAGE_INT_TO_LABEL.get(stage, f"Ступень {stage}"),
         "bottleneck_slot": bottleneck,
-        "rcs": {s: slot_vals[s] for s in ["W", "M1", "M2", "M4"] if s in slot_vals},
+        "rcs": {s: slot_vals[s] for s in rcs_keys if s in slot_vals},
     }
 
 
@@ -214,14 +243,17 @@ def main() -> int:
     logging.info("Fetching 3_derived via headless claude...")
     try:
         response = _fetch_derived_via_headless_claude()
-    except RuntimeError as exc:
+    except Exception as exc:
+        # Broad on purpose: this is a cron/launchd entry point — any unexpected
+        # failure (incl. shapes we didn't anticipate) must log one clean line,
+        # not a raw traceback, so the cron log stays scannable.
         logging.error("Fetch failed: %s", exc)
         return 1
 
     logging.info("Parsing 3_4_qualification...")
     try:
         parsed = _parse_qualification(response)
-    except RuntimeError as exc:
+    except Exception as exc:
         logging.error("Parse failed: %s", exc)
         return 1
 

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2125,7 +2125,7 @@
     },
     {
       "path": "scripts/day-open-llm-fill.py",
-      "sha256": "0f12094cd1b447669c4dd0d1331f22806f27c2afc7fb96fdf3d1a14acda9bf32"
+      "sha256": "0cd2567d6f6066d3dc0af23e30d1acc3b7a896bfc59a425895a1a2ae3fb63e1a"
     },
     {
       "path": "scripts/day-open-pipeline.sh",
@@ -2717,7 +2717,7 @@
     },
     {
       "path": "scripts/update-derived-snapshot.py",
-      "sha256": "de307912328167d0cb9cb9022e57bed873cb8cc2e2b14fd4d10b181bb51cb39c"
+      "sha256": "0d5e7404bc60b4830de2f096e0b15d08712d6fd4405a3176b3d563f5a25f9252"
     },
     {
       "path": "scripts/validate-fmt-scripts.sh",
@@ -2785,7 +2785,7 @@
     },
     {
       "path": "seed/strategy/scripts/day-open-llm-fill.py",
-      "sha256": "a6179a0d089486a9685b94964a56ed66cbe8791b9ee50c25a6a9ecd4bc0d32d1"
+      "sha256": "c9e59fc04fa83950662cb3c266313387a9642fafa031294b3cee0adad8b0f4c2"
     },
     {
       "path": "seed/strategy/scripts/generate-executor-catalog.py",
@@ -2805,7 +2805,7 @@
     },
     {
       "path": "seed/strategy/scripts/update-derived-snapshot.py",
-      "sha256": "d8d273c6ab6f7429f194fb184baaea15405364eeb051234ea5b0e708c927e4c8"
+      "sha256": "b1c7ca80792acfa1e4b0ae528148ca2cf3ebbff6589ab699ec63b36611a438d8"
     },
     {
       "path": "sessions/00-index.md",


### PR DESCRIPTION
## Summary
- `update-derived-snapshot.py`: restores 6 protections silently reverted by a prior platform hook/script backfill in a consumer repo — the backfill turned out to have pulled the regression FROM this canonical file, confirmed byte-identical (bar a sync comment) via sha256/diff before this fix.
  - qualified MCP tool name (`mcp__claude_ai_IWE__dt_read_digital_twin`) for `--allowedTools`
  - dual qualification-key lookup (`3_4_qualification_estimate`/`3_4_qualification`, nested under `3_derived`)
  - JSON-string and object-form (`{"idx": N}`) `rcs_indices` parsing
  - rare-bottleneck (M3/IT/A) inclusion in the returned `rcs`
  - broad `except Exception` in the cron entrypoint (`main()`)
  - defensive `RuntimeError` for a non-dict `rcs_indices` shape (added during cold-context review)
- `day-open-llm-fill.py`: `is_today_plan` now checks both `header` and `content` — this canonical copy had regressed 3 times in a consumer repo because only that copy was ever patched, never this source.

## Test plan
- [x] `python3 -m py_compile` on both files — syntax OK
- [x] New regression test `scripts/tests/update-derived-snapshot-regression-smoke.sh` (in the consumer repo) — 10/10 checks, confirmed as a real barrier (fails on the pre-fix regressed content, passes on the fix)
- [x] Existing `day-open-llm-fill-today-plan-detect-smoke.sh` — 5/5, no regression
- [x] Live `--dry-run` of `update-derived-snapshot.py` against the real MCP endpoint — correct output
- [x] Cold-context code review (0 Critical, 1 High + 2 Medium found and fixed)

🤖 Generated with peer-session 2026-08-31-27-wp484-backlog-continue (writer: Claude Code, peer: Codex)