### PR TITLE
feat(wp522): /agent-fault пишет факт М15 в чек-лист участника после записи косяка

### DIFF
--- a/scripts/agent-fault/iwe_checklist_memory.py
+++ b/scripts/agent-fault/iwe_checklist_memory.py
@@ -858,6 +858,35 @@ def _validate_subject(kind: str, subject_id: str) -> tuple[str, str]:
     return kind, value
 
 
+def _post_m15_practiced_fact(paths: ProfilePaths, fault: str) -> None:
+    """WP-522 (раздел М, пир-сессия 2026-08-31-30): за завершённую запись
+    косяка агента (М15 «зафиксировал инцидент или паттерн ошибки в журнале»)
+    отчитаться в чек-лист участника экосистемы — best-effort, не влияет на
+    уже сохранённую в SQLite запись косяка (вызывается ПОСЛЕ commit).
+    Специфично для персонального проекта этого пилота (writer живёт в
+    governance-репо, не в этом платформенном шаблоне) — молча пропустить,
+    если writer не установлен, вместо ошибки для остальных пользователей IWE."""
+    writer = paths.governance / "scripts" / "post-culture-fact.py"
+    if not writer.is_file():
+        return
+    try:
+        # Короткий таймаут (не 10с, как у самого writer'а — код-ревью 31.08,
+        # High): запись косяка не должна заметно виснуть на медленной сети
+        # ради best-effort побочного отчёта.
+        subprocess.run(
+            [sys.executable, str(writer), "--element", "M15", "--mode", "record", "--evidence", fault],
+            timeout=3,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        # Code review 31.08 (Critical): `str(TimeoutExpired)` включает полный
+        # cmd, а значит и `fault` (может нести чувствительные детали
+        # инцидента) — логировать только тип и таймаут, не текст исключения.
+        print("culture_element_practiced (M15): writer call timed out", file=sys.stderr)
+    except (OSError, subprocess.SubprocessError) as e:
+        print(f"culture_element_practiced (M15): writer call failed: {type(e).__name__}", file=sys.stderr)
+
+
 def record_fault(paths: ProfilePaths, args: argparse.Namespace) -> None:
     fault = _join_words(args.fault, "fault", required=True)
     citation = _join_words(args.source_citation, "source-citation", required=False)
@@ -981,6 +1010,7 @@ def record_fault(paths: ProfilePaths, args: argparse.Namespace) -> None:
         raise
     finally:
         _close(connection, paths)
+    _post_m15_practiced_fact(paths, fault)
     print(f"OK: fault {action} ({subject_kind}:{subject_id}, n={count})")
 
 

--- a/scripts/agent-fault/test_iwe_checklist_memory_m15.py
+++ b/scripts/agent-fault/test_iwe_checklist_memory_m15.py
@@ -1,0 +1,80 @@
+"""WP-522 (М15, пир-сессия 2026-08-31-30): тесты хука
+_post_m15_practiced_fact в iwe_checklist_memory.py — вызывается после
+успешной записи косяка агента, best-effort (не должен мешать record_fault)."""
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+SCRIPT = Path(__file__).parent / "iwe_checklist_memory.py"
+SPEC = importlib.util.spec_from_file_location("iwe_checklist_memory_m15", SCRIPT)
+mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = mod
+SPEC.loader.exec_module(mod)
+
+
+def _paths(governance: Path) -> "mod.ProfilePaths":
+    workspace = governance.parent
+    return mod.ProfilePaths(
+        workspace=workspace,
+        governance=governance,
+        profile=workspace / "profile",
+        database=workspace / "db.sqlite3",
+        ignore=workspace / "ignore",
+        audit=workspace / "audit.log",
+        export=workspace / "export.md",
+    )
+
+
+def test_writer_missing_is_silent_noop(tmp_path):
+    governance = tmp_path / "governance-repo"
+    governance.mkdir()
+    with mock.patch("subprocess.run") as run:
+        mod._post_m15_practiced_fact(_paths(governance), "агент пропустил чеклист")
+    run.assert_not_called()
+
+
+def test_writer_present_is_called_with_correct_args(tmp_path):
+    governance = tmp_path / "governance-repo"
+    (governance / "scripts").mkdir(parents=True)
+    writer = governance / "scripts" / "post-culture-fact.py"
+    writer.write_text("# stub\n")
+    with mock.patch("subprocess.run") as run:
+        mod._post_m15_practiced_fact(_paths(governance), "агент пропустил чеклист")
+    run.assert_called_once()
+    call_args = run.call_args[0][0]
+    assert call_args[0] == sys.executable
+    assert call_args[1] == str(writer)
+    assert "--element" in call_args and call_args[call_args.index("--element") + 1] == "M15"
+    assert "--mode" in call_args and call_args[call_args.index("--mode") + 1] == "record"
+    assert "--evidence" in call_args and call_args[call_args.index("--evidence") + 1] == "агент пропустил чеклист"
+
+
+def test_subprocess_failure_is_caught_and_logged(tmp_path, capsys):
+    governance = tmp_path / "governance-repo"
+    (governance / "scripts").mkdir(parents=True)
+    (governance / "scripts" / "post-culture-fact.py").write_text("# stub\n")
+    with mock.patch("subprocess.run", side_effect=OSError("no such executable")):
+        mod._post_m15_practiced_fact(_paths(governance), "x")
+    assert "M15" in capsys.readouterr().err
+
+
+def test_subprocess_timeout_is_caught_and_logged_without_leaking_fault_text(tmp_path, capsys):
+    # Код-ревью 31.08 (Critical): str(TimeoutExpired) включает полный cmd —
+    # значит и сам текст --evidence (fault может нести чувствительные детали
+    # инцидента). Реалистичный argv с фактическим fault — тест обязан
+    # поймать утечку, если она вернётся, не только формально пройти.
+    governance = tmp_path / "governance-repo"
+    (governance / "scripts").mkdir(parents=True)
+    writer = governance / "scripts" / "post-culture-fact.py"
+    writer.write_text("# stub\n")
+    sensitive_fault = "утечка токена в логах SENSITIVE_DETAIL_XYZ"
+    real_argv = [sys.executable, str(writer), "--element", "M15", "--mode", "record", "--evidence", sensitive_fault]
+    with mock.patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=real_argv, timeout=3)):
+        mod._post_m15_practiced_fact(_paths(governance), sensitive_fault)
+    err = capsys.readouterr().err
+    assert "M15" in err
+    assert sensitive_fault not in err
+    assert "SENSITIVE_DETAIL_XYZ" not in err

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1929,7 +1929,11 @@
     },
     {
       "path": "scripts/agent-fault/iwe_checklist_memory.py",
-      "sha256": "0e498f9aa925f3a91c031fd2a10823a53f0d350d6fdb09b086d703ae4035ea79"
+      "sha256": "783bd2969693df8c2cbd58300624b88df4da95fb94114c974ddfd3649f800b3f"
+    },
+    {
+      "path": "scripts/agent-fault/test_iwe_checklist_memory_m15.py",
+      "sha256": "8d6c3c9d81c93b4da051cd2f6e15089c6b429650c908459d81becf08e4ee425e"
     },
     {
       "path": "scripts/agent-heartbeat.sh",


### PR DESCRIPTION
## Summary
- Скилл `/agent-fault` (единственный элемент раздела «М» чек-листа участника без LLM-шага) теперь после успешной записи косяка агента (после `connection.commit()`) шлёт факт М15 в чек-лист — best-effort, короткий таймаут (3с), молча no-op для пользователей без установленного writer'а (`scripts/post-culture-fact.py`, специфичен для одного проекта, не общеплатформенный).
- Правка защищённого шаблона — с явного разрешения пилота.
- Прошло холодное код-ревью (1 итерация): критическая находка — при таймауте подпроцесса текст записанного косяка мог попасть в лог ошибки, исправлено логированием только типа исключения; средняя — таймаут снижен с 10 до 3 секунд, чтобы не задерживать основную запись.

## Test plan
- [x] 4/4 новых юнит-теста (`scripts/agent-fault/test_iwe_checklist_memory_m15.py`)
- [x] Живой сквозной прогон `record_fault()` с временным writer'ом — подтверждён корректный вызов хука и успешная запись косяка
- [x] `update-manifest.json` обновлён (новый файл + новый хэш изменённого)

Refs: peer-session `2026-08-31-30-wp522-checklist-m-rollout-remaining`

🤖 Generated with [Claude Code](https://claude.com/claude-code)