### PR TITLE
fix(hooks): install-hooks.sh never overwrites an existing differing hook

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -18,13 +18,20 @@
 # create-wp.sh already use) and by refusing to claim success if a hook is
 # still missing afterwards.
 #
+# WP-484 (31.08.2026): a hook that exists but differs from canonical is never
+# overwritten anymore — only a MISSING hook gets copied. The previous
+# behavior force-synced content on every drift, which discarded a governance
+# repo's own repo-specific composite pre-commit hook during an unrelated
+# core.hooksPath repair. Divergent local content is assumed intentional; the
+# backup-then-overwrite dance existed only to make that destructive overwrite
+# less bad, so it's gone along with it.
+#
 # see WP-436 (force-push guard) + seed/strategy/.githooks/
 
 set -euo pipefail
 
 REPO="${1:-${PWD}}"
 HOOK_DIR="$REPO/.githooks"
-BACKUP_DIR="$REPO/.git/hook-backups"
 
 if [ -L "$REPO" ] || [ -L "$REPO/.git" ] || [ ! -d "$REPO/.git" ]; then
   echo "❌ Not a git repo: $REPO"
@@ -57,8 +64,8 @@ if [ -n "$MISSING_SOURCE" ]; then
   exit 1
 fi
 
-if [ -L "$HOOK_DIR" ] || [ -L "$BACKUP_DIR" ]; then
-  echo "❌ Refusing symlink hook or backup directory in $REPO" >&2
+if [ -L "$HOOK_DIR" ]; then
+  echo "❌ Refusing symlink hook directory in $REPO" >&2
   echo "   core.hooksPath не изменён." >&2
   exit 1
 fi
@@ -69,7 +76,7 @@ for hook in pre-commit pre-push; do
     exit 1
   fi
 done
-mkdir -p "$HOOK_DIR" "$BACKUP_DIR"
+mkdir -p "$HOOK_DIR"
 
 copy_hook_atomically() {
   local source_hook="$1" target="$2" temporary
@@ -87,19 +94,10 @@ for hook in pre-commit pre-push; do
   target="$HOOK_DIR/$hook"
   source_hook="$CANONICAL_HOOKS_DIR/$hook"
 
-  if [ -f "$target" ] && ! cmp -s "$source_hook" "$target"; then
-    backup="$BACKUP_DIR/$hook.backup.$(date +%s)"
-    backup_index=0
-    while [ -e "$backup" ]; do
-      backup_index=$((backup_index + 1))
-      backup="$BACKUP_DIR/$hook.backup.$(date +%s).$backup_index"
-    done
-    cp "$target" "$backup"
-    echo "📝 Existing $hook backed up to: $backup"
-  fi
-
-  if [ ! -f "$target" ] || ! cmp -s "$source_hook" "$target"; then
+  if [ ! -f "$target" ]; then
     copy_hook_atomically "$source_hook" "$target"
+  elif ! cmp -s "$source_hook" "$target"; then
+    echo "⚠️  $hook отличается от канонического шаблона — оставляю локальную версию (не самолечу контент, см. WP-484 в комментарии выше)."
   fi
 
   [ -f "$target" ] && chmod +x "$target"

--- a/scripts/tests/test_install_hooks.py
+++ b/scripts/tests/test_install_hooks.py
@@ -107,22 +107,27 @@ def test_fresh_repo_gets_both_hooks(tmp_path):
     assert (repo / ".githooks" / "pre-push").is_file()
 
 
-def test_repeated_install_is_idempotent_without_backup_churn(tmp_path):
+def test_repeated_install_never_overwrites_differing_local_hook(tmp_path):
+    """WP-484 (31.08.2026): a hook that exists but differs from canonical is a
+    local customization (e.g. a repo-specific composite pre-commit), not
+    drift to repair — self-heal must warn and leave it alone, not back it up
+    and replace it."""
     repo = tmp_path / "repo"
     _init_repo(repo)
     hooks_dir = repo / ".githooks"
     hooks_dir.mkdir()
-    (hooks_dir / "pre-commit").write_text("#!/bin/bash\necho custom\n", encoding="utf-8")
+    custom_pre_commit = "#!/bin/bash\necho custom\n"
+    (hooks_dir / "pre-commit").write_text(custom_pre_commit, encoding="utf-8")
 
     first = _run_install_hooks(repo, IWE_TEMPLATE=str(ROOT))
     assert first.returncode == 0, first.stdout + first.stderr
-    backups_after_first = sorted((repo / ".git" / "hook-backups").iterdir())
-    assert backups_after_first, "changed user hook must be backed up before replacement"
+    assert (hooks_dir / "pre-commit").read_text(encoding="utf-8") == custom_pre_commit
+    assert "отличается от канонического" in first.stdout + first.stderr
+    assert not (repo / ".git" / "hook-backups").exists()
 
     second = _run_install_hooks(repo, IWE_TEMPLATE=str(ROOT))
     assert second.returncode == 0, second.stdout + second.stderr
-    backups_after_second = sorted((repo / ".git" / "hook-backups").iterdir())
-    assert backups_after_second == backups_after_first
+    assert (hooks_dir / "pre-commit").read_text(encoding="utf-8") == custom_pre_commit
 
 
 def test_missing_canonical_source_fails_loud_not_silent_success(tmp_path):
@@ -256,6 +261,10 @@ def test_update_backfill_delivers_installer_and_hooks_idempotently(tmp_path):
         check=True,
     ).stdout.strip() == ".githooks"
 
+    # backup_dir here is update.sh's own -- it backs up the replaced
+    # install-hooks.sh installer script (platform code, always kept in sync),
+    # unrelated to install-hooks.sh's own hook-content handling below. A
+    # stable installer means no new backup on the second, idempotent run.
     backups_after_first = sorted((governance / ".git" / "hook-backups").iterdir())
     second = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
     assert second.returncode == 0, second.stdout + second.stderr
@@ -338,36 +347,6 @@ def test_update_backfill_refuses_symlink_scripts_parent(tmp_path):
     assert "symlink" in (result.stdout + result.stderr).lower()
     assert sentinel.read_text(encoding="utf-8") == "outside scripts sentinel\n"
     assert not (outside / "install-hooks.sh").exists()
-    assert subprocess.run(
-        ["git", "config", "--get", "core.hooksPath"], cwd=governance
-    ).returncode != 0
-
-
-def test_update_backfill_refuses_symlink_backup_directory(tmp_path):
-    workspace = tmp_path / "IWE-symlink-backup"
-    governance = workspace / "custom-governance"
-    _init_repo(governance)
-    scripts_dir = governance / "scripts"
-    scripts_dir.mkdir()
-    (scripts_dir / "install-hooks.sh").write_text("old installer\n", encoding="utf-8")
-    outside = tmp_path / "outside-backups"
-    outside.mkdir()
-    sentinel = outside / "sentinel"
-    sentinel.write_text("outside backup sentinel\n", encoding="utf-8")
-    (governance / ".git" / "hook-backups").symlink_to(
-        outside, target_is_directory=True
-    )
-
-    result = subprocess.run(
-        ["bash", "-c", _update_backfill_script(workspace)],
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode != 0
-    assert "symlink" in (result.stdout + result.stderr).lower()
-    assert sentinel.read_text(encoding="utf-8") == "outside backup sentinel\n"
-    assert list(outside.iterdir()) == [sentinel]
     assert subprocess.run(
         ["git", "config", "--get", "core.hooksPath"], cwd=governance
     ).returncode != 0

--- a/seed/strategy/scripts/install-hooks.sh
+++ b/seed/strategy/scripts/install-hooks.sh
@@ -18,13 +18,20 @@
 # create-wp.sh already use) and by refusing to claim success if a hook is
 # still missing afterwards.
 #
+# WP-484 (31.08.2026): a hook that exists but differs from canonical is never
+# overwritten anymore — only a MISSING hook gets copied. The previous
+# behavior force-synced content on every drift, which discarded a governance
+# repo's own repo-specific composite pre-commit hook during an unrelated
+# core.hooksPath repair. Divergent local content is assumed intentional; the
+# backup-then-overwrite dance existed only to make that destructive overwrite
+# less bad, so it's gone along with it.
+#
 # see WP-436 (force-push guard) + seed/strategy/.githooks/
 
 set -euo pipefail
 
 REPO="${1:-${PWD}}"
 HOOK_DIR="$REPO/.githooks"
-BACKUP_DIR="$REPO/.git/hook-backups"
 
 if [ -L "$REPO" ] || [ -L "$REPO/.git" ] || [ ! -d "$REPO/.git" ]; then
   echo "❌ Not a git repo: $REPO"
@@ -57,8 +64,8 @@ if [ -n "$MISSING_SOURCE" ]; then
   exit 1
 fi
 
-if [ -L "$HOOK_DIR" ] || [ -L "$BACKUP_DIR" ]; then
-  echo "❌ Refusing symlink hook or backup directory in $REPO" >&2
+if [ -L "$HOOK_DIR" ]; then
+  echo "❌ Refusing symlink hook directory in $REPO" >&2
   echo "   core.hooksPath не изменён." >&2
   exit 1
 fi
@@ -69,7 +76,7 @@ for hook in pre-commit pre-push; do
     exit 1
   fi
 done
-mkdir -p "$HOOK_DIR" "$BACKUP_DIR"
+mkdir -p "$HOOK_DIR"
 
 copy_hook_atomically() {
   local source_hook="$1" target="$2" temporary
@@ -87,19 +94,10 @@ for hook in pre-commit pre-push; do
   target="$HOOK_DIR/$hook"
   source_hook="$CANONICAL_HOOKS_DIR/$hook"
 
-  if [ -f "$target" ] && ! cmp -s "$source_hook" "$target"; then
-    backup="$BACKUP_DIR/$hook.backup.$(date +%s)"
-    backup_index=0
-    while [ -e "$backup" ]; do
-      backup_index=$((backup_index + 1))
-      backup="$BACKUP_DIR/$hook.backup.$(date +%s).$backup_index"
-    done
-    cp "$target" "$backup"
-    echo "📝 Existing $hook backed up to: $backup"
-  fi
-
-  if [ ! -f "$target" ] || ! cmp -s "$source_hook" "$target"; then
+  if [ ! -f "$target" ]; then
     copy_hook_atomically "$source_hook" "$target"
+  elif ! cmp -s "$source_hook" "$target"; then
+    echo "⚠️  $hook отличается от канонического шаблона — оставляю локальную версию (не самолечу контент, см. WP-484 в комментарии выше)."
   fi
 
   [ -f "$target" ] && chmod +x "$target"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2229,7 +2229,7 @@
     },
     {
       "path": "scripts/install-hooks.sh",
-      "sha256": "516c29f4fe4c41723b714d244c508bdcc8143032331a56eb4666461b2851a9d4"
+      "sha256": "80f856ba356a49b4d2d0635235b9edb8bd725178a687c0fce23af2e8b44184e8"
     },
     {
       "path": "scripts/iwe-agent-dispatcher.py",
@@ -2609,7 +2609,7 @@
     },
     {
       "path": "scripts/tests/test_install_hooks.py",
-      "sha256": "9c91a95bdc2b6314671b0e609680841e9fadd5f4e9bcd66186dd76a9272d5ed3"
+      "sha256": "afe084887934053e9208edd7702b9e25e14cf855dc17fc513012aeb0cd83aacd"
     },
     {
       "path": "scripts/tests/test_issue_434_pipeline_scaffold_only.sh",
@@ -2797,7 +2797,7 @@
     },
     {
       "path": "seed/strategy/scripts/install-hooks.sh",
-      "sha256": "516c29f4fe4c41723b714d244c508bdcc8143032331a56eb4666461b2851a9d4"
+      "sha256": "80f856ba356a49b4d2d0635235b9edb8bd725178a687c0fce23af2e8b44184e8"
     },
     {
       "path": "seed/strategy/scripts/iwe_checklist_memory.py",


### PR DESCRIPTION
## Summary
- Self-heal (`install-hooks.sh`, invoked by `day-open-pipeline.sh` when `core.hooksPath` drifts) used to force-sync hook content on every drift, not just missing files — found live discarding a governance repo's own repo-specific composite pre-commit hook during a routine config repair.
- The script's own header comment (issue #342) already documented "copying missing hooks" as the intent; only the implementation went further and overwrote existing-but-different hooks too.
- Now it only copies a missing hook and warns (does not touch) when an existing one differs. `BACKUP_DIR` and its symlink guard removed as dead code — nothing left to back up.

## Test plan
- [x] `pytest scripts/tests/test_install_hooks.py` — 17/17 passing (changed-hook test rewritten to assert survival across reruns instead of a backup; symlinked-backup-dir test removed as testing a now-nonexistent code path)
- [x] `bash setup/validate-template.sh` — all 8 checks pass
- [x] Manual smoke: empty repo (both hooks copied), existing differing hook (preserved untouched), repeated run (idempotent, no warnings)

Refs: WP-484 AE, MC-sessions/2026-08/31/2026-08-31-31-wp484-backfill-regressions-ae

🤖 Generated with [Claude Code](https://claude.com/claude-code)