### PR TITLE
docs(hindsight): clarify manual integration up front

### DIFF
--- a/docs/hindsight-setup.md
+++ b/docs/hindsight-setup.md
@@ -1,6 +1,8 @@
 # Hindsight Setup Guide
 
-Quick start for IWE pilots who want semantic fault memory (L2 layer).
+Sets up the Hindsight storage backend (L2 layer) for IWE pilots. This guide
+only starts the container — it does not wire Recall, Retain, or Reflect into
+your workflow. See "4. Manual integration" below for that step.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Moves the "storage only, wiring is manual" caveat from section 4 to the top of the guide, before the first command
- Fixes the gap reported in issue #430 (Denis): docs promised recall/retain/reflect, delivery doesn't trigger it

## Decision context
WP-5 F38, decided in a peer session with Codex (WP-502 pass 27, 2026-08-31): narrow the documentation promise rather than build the automatic wiring.

## Test plan
- [ ] Read through as a new pilot - does the top framing now match section 4?