### PR TITLE
fix(scripts): generate-skills-catalog.sh — блок-скаляр description + список slash

### DIFF
--- a/scripts/generate-skills-catalog.sh
+++ b/scripts/generate-skills-catalog.sh
@@ -30,27 +30,56 @@ done
 
 log() { echo "$*" >&2; }
 
-# Извлечь значение поля из YAML frontmatter (первое вхождение)
+# Извлечь значение поля из YAML frontmatter (первое вхождение).
+# Поддерживает block scalar (`field: |` / `field: >`) — читает следующие
+# более-отступленные строки до дедента и схлопывает их в одну строку
+# (найдено 01.09, WP-527: `description: |` в repo-new/skill-creator
+# ломался в буквальное значение "|", а не читался как блок).
 get_field() {
     local file="$1" field="$2"
-    sed -n "/^---$/,/^---$/p" "$file" 2>/dev/null \
-      | grep "^${field}:" \
-      | head -1 \
-      | sed "s/^${field}: *//" \
-      | sed 's/^"\(.*\)"$/\1/' \
-      | sed "s/^'\(.*\)'$/\1/"
+    local block value
+    block=$(sed -n "/^---$/,/^---$/p" "$file" 2>/dev/null)
+    value=$(echo "$block" | grep "^${field}:" | head -1 | sed "s/^${field}: *//")
+    case "$value" in
+        '|'|'>'|'|-'|'>-'|'|+'|'>+')
+            echo "$block" | awk -v field="^${field}:" '
+                BEGIN{found=0}
+                $0 ~ field {found=1; next}
+                found==1 {
+                    if ($0 !~ /^[ \t]/ || $0 == "") { exit }
+                    gsub(/^[ \t]+/, "");
+                    printf "%s ", $0
+                }
+            ' | sed 's/ *$//'
+            ;;
+        *)
+            echo "$value" | sed 's/^"\(.*\)"$/\1/' | sed "s/^'\(.*\)'$/\1/"
+            ;;
+    esac
 }
 
-# Извлечь список (slash или phrases) из triggers блока
+# Извлечь список (slash) из triggers блока. Поддерживает и inline-стиль
+# (`slash: [/a, /b]`), и YAML-список (`slash:` + `- item` строками ниже —
+# формат, который выдаёт scaffold-init.sh; найден 01.09 WP-527, раньше давал
+# мусор вида "- slash:" вместо реальных триггеров).
 get_triggers_slash() {
     local file="$1"
-    # Ищем triggers.slash как inline список [/skill]
-    sed -n '/^triggers:/,/^[a-z]/p' "$file" 2>/dev/null \
-      | grep "slash:" \
-      | sed 's/.*slash: *\[//;s/\].*//' \
-      | tr ',' '\n' \
-      | sed 's/^ *//;s/ *$//;s/^\/\?/\//' \
-      | grep -v '^$' || true
+    local block inline
+    block=$(sed -n '/^triggers:/,/^[a-z]/p' "$file" 2>/dev/null)
+    inline=$(echo "$block" | grep "slash: *\[" | sed 's/.*slash: *\[//;s/\].*//' \
+        | tr ',' '\n' | sed 's/^ *//;s/ *$//' | grep -v '^$')
+    if [[ -n "$inline" ]]; then
+        echo "$inline" | sed 's/^\/\?/\//'
+        return
+    fi
+    echo "$block" | awk '
+        /slash:[ \t]*$/ {insl=1; next}
+        insl==1 {
+            if ($0 ~ /^[ \t]*-[ \t]*/) {
+                sub(/^[ \t]*-[ \t]*/, ""); print; next
+            } else { insl=0 }
+        }
+    ' | sed 's/^ *//;s/ *$//;s/^\/\?/\//' | grep -v '^$' || true
 }
 
 # Собрать все файлы где упоминается скилл (для invoked_by)

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2209,7 +2209,7 @@
     },
     {
       "path": "scripts/generate-skills-catalog.sh",
-      "sha256": "9317c613a92abfae4c3166cb2b9d786d6f83a14d03bf02c927a0316f4f47d8a7"
+      "sha256": "8809f5a65e200f683eb80ef35b1054fc859e8dcad0492c195aa1c3d561fd44a0"
     },
     {
       "path": "scripts/git-dirty-guard.sh",


### PR DESCRIPTION
## Что чинится

Найдено попутно при доставке `repo-new` (WP-527): генератор каталога скиллов не умел разбирать два реальных формата YAML, которые уже используются в этом же репозитории:

1. `description: |` (многострочный блок) — читался буквально как строка `"|"` вместо содержимого. Затрагивало минимум `repo-new` и `skill-creator`.
2. `slash:` в виде YAML-списка (`- item` на следующих строках, формат самого `scaffold-init.sh`) — раньше давал мусор `- slash:` вместо реального триггера.

Оба формата теперь разбираются корректно, старый inline-формат (`slash: [/a, /b]`) не тронут.

## Проверка

Прогнал полную регенерацию по всем 55 скиллам авторской рабочей копии, проверил через Python/PyYAML round-trip — 0 пустых описаний, 0 сломанных slash-триггеров. Diff `update-manifest.json` — ровно одна строка (новый хеш самого скрипта).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>