### PR TITLE
port(session-guard): audit -- eliminate per-file subprocess spawns

### DIFF
--- a/scripts/session-guard.sh
+++ b/scripts/session-guard.sh
@@ -572,9 +572,20 @@ EOF
 fi
 
 # --- helpers for ORZ validation ---
-validate_orz() {
+# Ported from ~/IWE/scripts/session-guard.sh (root commit 2779845553, WP-484
+# line AC, 31.08): batches the git-tracked lookup for `audit` (one
+# `git ls-files` instead of one per file) and reads each file once with
+# bash builtin pattern matching instead of ~13 grep/sed/head subprocesses.
+# Root's function already carried the WP-520 case-8 remote-refs fallback
+# below (published-but-unstaged ORZ files) before this batching commit --
+# ported together since it is the same function body, not a separate
+# addition to this session's scope.
+validate_orz() { # <orz-path> <agent> [orz-base-dir, default $ORZ_DIR] [tracked-set-file, optional]
   local orz="$1"
   local agent="$2"
+  local orz_base_dir="${3:-$ORZ_DIR}"
+  orz_base_dir="${orz_base_dir%/}"
+  local tracked_set_file="${4:-}"
   local errors=0
 
   # 1. file exists
@@ -583,19 +594,38 @@ validate_orz() {
     return 1
   fi
 
+  # Checks 2-4 read the file once into a bash variable and use builtin
+  # pattern matching instead of one grep/sed/head subprocess per check.
+  # `$'\n'` is prepended so "key at the very start of the file" and "key
+  # after a newline" are the same substring match, matching what the old
+  # `grep -qE "^key:"` anchor covered without needing multiline `^`.
+  local nl=$'\n'
+  local content
+  content="$(<"$orz")" 2>/dev/null || content=""
+  local content_nl="${nl}${content}"
+
   # 2. frontmatter keys
   local keys=("date:" "type:" "wp:" "duration_h:" "artifacts:" "agent:")
   for key in "${keys[@]}"; do
-    if ! grep -qE "^${key}" "$orz"; then
-      echo "  ❌ в frontmatter отсутствует ключ '$key'" >&2
-      errors=$((errors + 1))
-    fi
+    case "$content_nl" in
+      *"${nl}${key}"*) : ;;
+      *)
+        echo "  ❌ в frontmatter отсутствует ключ '$key'" >&2
+        errors=$((errors + 1))
+        ;;
+    esac
   done
 
   # 3. agent value
-  local orz_agent
-  orz_agent=$(grep -E "^agent:" "$orz" | sed 's/^agent: *//' | head -1 || true)
-  if [ -n "$orz_agent" ]; then
+  # `[ -n "$agent" ]` guard: a caller that doesn't care about agent identity
+  # (the archival `audit` scan) passes "" and skips this comparison outright,
+  # instead of re-deriving the file's own value and comparing it to itself
+  # (a self-match that could never fail -- the bug this port also fixes).
+  local orz_agent="" agent_re="${nl}agent:[[:space:]]*([^${nl}]*)"
+  if [[ "$content_nl" =~ $agent_re ]]; then
+    orz_agent="${BASH_REMATCH[1]}"
+  fi
+  if [ -n "$agent" ] && [ -n "$orz_agent" ]; then
     if [ "$orz_agent" != "$agent" ] && \
        ! { [ "$agent" = "kimi" ] && [ "$orz_agent" = "kimi-headless" ]; }; then
       echo "  ❌ agent в ORZ ('$orz_agent') не совпадает с агентом сессии ('$agent')" >&2
@@ -606,18 +636,55 @@ validate_orz() {
   # 4. required sections
   local sections=("## Главный инсайт" "## Контекст" "## Достигнуто" "## Ключевые решения")
   for sec in "${sections[@]}"; do
-    if ! grep -qF "$sec" "$orz"; then
-      echo "  ❌ отсутствует секция '$sec'" >&2
-      errors=$((errors + 1))
-    fi
+    case "$content" in
+      *"$sec"*) : ;;
+      *)
+        echo "  ❌ отсутствует секция '$sec'" >&2
+        errors=$((errors + 1))
+        ;;
+    esac
   done
 
   # 5. git tracked
   local rel
-  rel="$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[2], sys.argv[3]))" -- "$orz" "$ORZ_DIR")"
-  if ! git -C "$ORZ_DIR" ls-files --error-unmatch "$rel" >/dev/null 2>&1; then
-    echo "  ❌ ORZ-файл не добавлен в git index (git add $rel)" >&2
-    errors=$((errors + 1))
+  local is_tracked=1
+  if [ -n "$tracked_set_file" ] && [ -s "$tracked_set_file" ]; then
+    # Batch path (audit call site): one `git ls-files` snapshot up front
+    # instead of one `git ls-files --error-unmatch` + python3 relpath per
+    # file. Safe to inline the relpath here because this call site's `orz`
+    # always comes from `find "$ORZ_DIR" ...`, so it is always a literal
+    # `$orz_base_dir/...` path; the fallback below (other callers) keeps
+    # os.path.relpath for the non-prefixed cases it covers.
+    rel="${orz#"$orz_base_dir"/}"
+    grep -qxF "$rel" "$tracked_set_file" && is_tracked=0
+  else
+    rel="$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[2], sys.argv[3]))" -- "$orz" "$orz_base_dir")"
+    git -C "$orz_base_dir" ls-files --error-unmatch "$rel" >/dev/null 2>&1 && is_tracked=0
+  fi
+  if [ "$is_tracked" -ne 0 ]; then
+    # A file whose commit went to main through an isolated worktree cannot
+    # be staged in the live checkout (busy on a foreign branch). A file
+    # present in ANY published remote-tracking ref is a strictly stronger
+    # proof than a staged-only file: accept it as the index-equivalent.
+    local published_ref=""
+    local remote_ref
+    while IFS= read -r remote_ref; do
+      [ -z "$remote_ref" ] && continue
+      # Content must match too -- path-only acceptance would let a locally
+      # edited copy pass on legacy semaphores with no registered `file:`
+      # line for the scope gate's cmp to catch.
+      if git -C "$orz_base_dir" cat-file -e "$remote_ref:./$rel" 2>/dev/null &&
+         git -C "$orz_base_dir" cat-file blob "$remote_ref:./$rel" 2>/dev/null | cmp -s - "$orz"; then
+        published_ref="$remote_ref"
+        break
+      fi
+    done <<< "$(git -C "$orz_base_dir" for-each-ref --format='%(refname)' refs/remotes 2>/dev/null)"
+    if [ -n "$published_ref" ]; then
+      echo "  ✓ ORZ-файл не в git index, но побайтно совпадает с опубликованным blob в '$published_ref' — принят как эквивалент" >&2
+    else
+      echo "  ❌ ORZ-файл не добавлен в git index (git add $rel) и не совпадает ни с одним blob в refs/remotes/*" >&2
+      errors=$((errors + 1))
+    fi
   fi
 
   return $errors
@@ -1027,15 +1094,24 @@ if [ "$CMD" = "audit" ]; then
 
   # 3. ORZ-файлы с невалидным frontmatter/секциями
   echo "ORZ-файлы с дефектами (после $SINCE):"
+  # Ported alongside validate_orz() (root commit 2779845553): one `git
+  # ls-files` snapshot for the whole tree instead of one per file inside
+  # validate_orz. No agent extraction here either -- validate_orz's own
+  # "agent value" check always re-derived the value from this same file
+  # and compared it against whatever was passed, so a self-fed value could
+  # never fail; passing "" skips that no-op comparison instead of redoing
+  # the extraction to feed it.
+  AUDIT_TRACKED_SET=$(mktemp)
+  git -C "$ORZ_DIR" ls-files > "$AUDIT_TRACKED_SET" 2>/dev/null
   find "$ORZ_DIR" -maxdepth 2 -mindepth 2 -name '*.md' -type f ! -name '00-index.md' -newermt "$SINCE" 2>/dev/null | while read -r orz; do
     tmp_errors=$(mktemp)
-    orz_agent=$(grep -E "^agent:" "$orz" | sed 's/^agent: *//' | head -1 || true)
-    if ! validate_orz "$orz" "${orz_agent:-unknown}" >"$tmp_errors" 2>&1 && [ -s "$tmp_errors" ]; then
+    if ! validate_orz "$orz" "" "$ORZ_DIR" "$AUDIT_TRACKED_SET" >"$tmp_errors" 2>&1 && [ -s "$tmp_errors" ]; then
       echo "  $(basename "$orz"):"
       sed 's/^/    /' "$tmp_errors"
     fi
     rm -f "$tmp_errors"
   done
+  rm -f "$AUDIT_TRACKED_SET"
   echo
 
   # 4. Untracked ORZ-файлы

--- a/scripts/tests/session-guard-audit-validate-orz-batch-smoke.sh
+++ b/scripts/tests/session-guard-audit-validate-orz-batch-smoke.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# session-guard-audit-validate-orz-batch-smoke.sh -- ported from
+# ~/IWE/scripts/tests/ (root commit 2779845553, WP-484 line AC, 31.08).
+# validate_orz()'s "git tracked" and "frontmatter/sections" checks were
+# rewritten to avoid one grep/sed/git/python3 subprocess per ORZ file --
+# see the comments at those checks in session-guard.sh for the measured
+# cost this replaces. This test extracts validate_orz() in isolation and
+# checks both the batch path (tracked-set-file given, used by `audit`) and
+# the fallback path (used by `close`) against the same fixtures.
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+GUARD="$ROOT_DIR/scripts/session-guard.sh"
+TEST_ROOT=$(mktemp -d /private/tmp/session-guard-validate-orz-batch.XXXXXX)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+extract_fn() {
+    sed -n "/^${1}() {/,/^}/p" "$GUARD"
+}
+
+REPO="$TEST_ROOT/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name test
+
+run_validate() {
+    # args: orz-relpath agent [tracked-set-file]
+    local orz="$REPO/$1" agent="$2" tracked_set="${3:-}"
+    bash -c '
+        '"$(extract_fn validate_orz)"$'\n
+        validate_orz "$1" "$2" "$3" "$4"
+    ' _ "$orz" "$agent" "$REPO" "$tracked_set"
+}
+
+fail=0
+check() {
+    local desc="$1" expected_errors="$2"; shift 2
+    local out rc=0
+    out=$(run_validate "$@" 2>&1) || rc=$?
+    if [ "$rc" -ne "$expected_errors" ]; then
+        echo "FAIL ($desc): expected $expected_errors errors, got rc=$rc: $out" >&2
+        fail=1
+    else
+        echo "OK: $desc"
+    fi
+}
+
+# --- Fixture A: complete, valid, tracked ORZ file ---
+cat > "$REPO/good.md" <<'EOF'
+---
+date: 2026-08-31
+type: peer-session
+wp: WP-484
+agent: claude-code
+duration_h: 1.0
+artifacts: [report.md]
+---
+
+## Главный инсайт
+
+x
+
+## Контекст
+
+x
+
+## Достигнуто
+
+x
+
+## Ключевые решения
+
+x
+EOF
+git -C "$REPO" add good.md
+git -C "$REPO" commit -q -m good
+
+git -C "$REPO" ls-files > "$TEST_ROOT/tracked.txt"
+
+check "complete tracked file, no tracked-set (fallback/close path), matching agent" 0 good.md claude-code
+check "complete tracked file, batch path (audit), matching agent" 0 good.md claude-code "$TEST_ROOT/tracked.txt"
+check "complete tracked file, batch path (audit), empty agent (no-op comparison, WP-484 AC fix)" 0 good.md "" "$TEST_ROOT/tracked.txt"
+check "complete tracked file, batch path, mismatched real agent DOES flag (regression guard for the WP-484 AC bug: passing 'unknown' broke this)" 1 good.md some-other-agent "$TEST_ROOT/tracked.txt"
+
+cat > "$REPO/kimi-headless.md" <<'EOF'
+---
+date: 2026-08-31
+type: peer-session
+wp: WP-484
+agent: kimi-headless
+duration_h: 1.0
+artifacts: [report.md]
+---
+
+## Главный инсайт
+
+x
+
+## Контекст
+
+x
+
+## Достигнуто
+
+x
+
+## Ключевые решения
+
+x
+EOF
+git -C "$REPO" add kimi-headless.md
+git -C "$REPO" commit -q -m kimi-headless
+git -C "$REPO" ls-files > "$TEST_ROOT/tracked1b.txt"
+check "kimi/kimi-headless alias accepted, batch path" 0 kimi-headless.md kimi "$TEST_ROOT/tracked1b.txt"
+
+# --- Fixture B: missing keys and sections ---
+cat > "$REPO/bad.md" <<'EOF'
+---
+date: 2026-08-31
+agent: claude-code
+---
+
+## Контекст
+
+x
+EOF
+git -C "$REPO" add bad.md
+git -C "$REPO" commit -q -m bad
+git -C "$REPO" ls-files > "$TEST_ROOT/tracked2.txt"
+# 3 missing keys (type, wp, duration_h, artifacts = 4) + 3 missing sections
+# (Главный инсайт, Достигнуто, Ключевые решения) = 7
+check "missing keys/sections, fallback path" 7 bad.md claude-code
+check "missing keys/sections, batch path" 7 bad.md claude-code "$TEST_ROOT/tracked2.txt"
+
+# --- Fixture C: Kimi's edge case (round 3) -- key with no preceding blank
+# line before it (right after the opening '---', which is the only real
+# shape ORZ files ever have, but test the boundary explicitly). ---
+cat > "$REPO/edge.md" <<'EOF'
+---
+date: 2026-08-31
+type: t
+wp: WP-1
+duration_h: 1
+artifacts: []
+agent: claude-code
+---
+
+## Главный инсайт
+x
+## Контекст
+x
+## Достигнуто
+x
+## Ключевые решения
+x
+EOF
+git -C "$REPO" add edge.md
+git -C "$REPO" commit -q -m edge
+git -C "$REPO" ls-files > "$TEST_ROOT/tracked3.txt"
+check "all keys present starting right after '---', batch path" 0 edge.md claude-code "$TEST_ROOT/tracked3.txt"
+
+# --- Fixture D: untracked file, present in remote-refs (fallback promotion
+# path -- must still work identically through the batch path). ---
+mkdir -p "$REPO/.git/refs/remotes/origin"
+git -C "$REPO" rev-parse HEAD > "$REPO/.git/refs/remotes/origin/main"
+git -C "$REPO" rm -q --cached good.md
+git -C "$REPO" ls-files > "$TEST_ROOT/tracked4.txt"
+check "untracked-but-published file, batch path takes remote-refs fallback, still 0 errors" 0 good.md claude-code "$TEST_ROOT/tracked4.txt"
+
+if [ "$fail" -ne 0 ]; then
+    echo "FAIL: session-guard-audit-validate-orz-batch-smoke" >&2
+    exit 1
+fi
+echo "PASS: session-guard audit validate_orz batch/fallback equivalence"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2473,7 +2473,7 @@
     },
     {
       "path": "scripts/session-guard.sh",
-      "sha256": "af34b3bb132ffeb0d8093df829e5aae092832daa764f8fe0ab60265893baecfc"
+      "sha256": "f219b0ec7746e12d98f677d4984a2ad02eb573e0c2c5e5b41ca22724f465b3f3"
     },
     {
       "path": "scripts/settings-promote.sh",
@@ -2900,6 +2900,7 @@
     "scripts/session-dispatcher-tsekh.py",
     "scripts/tests/conftest.py",
     "scripts/tests/lib/extract-update-download-batch.sh",
+    "scripts/tests/session-guard-audit-validate-orz-batch-smoke.sh",
     "scripts/tests/test_agent_dashboard.py",
     "scripts/tests/test_copy_to_aisystant.py",
     "scripts/tests/test_day_close_prepare.py",


### PR DESCRIPTION
## Summary
- Ports the batched `validate_orz()` from `~/IWE/scripts/session-guard.sh` (root commit `2779845553`, WP-484 line AC): one `git ls-files` snapshot per audit run instead of one per file, and a real bugfix (agent self-match in the audit call site could never flag a mismatch).
- New regression test ported unchanged from root (9/9 checks), registered in `update-manifest.json`.
- Scoped port per WP-485/WP-546: file stays on the reduced/freeze-canonical variant; six other accumulated root commits were evaluated and deliberately NOT ported (superseded, depend on template-missing subsystems, or author-specific problem that doesn't apply to a standard template install).

## Test plan
- [x] `bash -n scripts/session-guard.sh` — syntax OK
- [x] `shellcheck` — clean (only pre-existing unrelated info-level note)
- [x] New test `scripts/tests/session-guard-audit-validate-orz-batch-smoke.sh` — 9/9 checks pass
- [x] Cold-context review by Codex (peer session) — no defects found

Refs: peer-session `MC-sessions:2026-09/01/2026-09-01-20-wp485-template-delta-port`

🤖 Generated with peer-session (Claude + Codex)