### PR TITLE
fix(wp527): personal-guide-start — Ф5 хвосты 3/4

### DIFF
--- a/.claude/skills-catalog.yaml
+++ b/.claude/skills-catalog.yaml
@@ -445,7 +445,7 @@ skills:
   - id: personal-guide-start
     name: "personal-guide-start"
     description: "Bootstrap-обёртка — создаёт пустой репо `DS-personal-guide` под аккаунтом пилота (плоское имя, без логина в названии; если ещё нет), затем вызывает /personal-guide-render для наполнения 6 файлами. Используй когда пилот в первый раз просит «создай мне персональное руководство», «хочу начать программу личного развития», «собери мне стартовый план»."
-    version: 1.3.0
+    version: 1.3.1
     layer: L1
     status: active
     triggers:

--- a/.claude/skills/personal-guide-start/SKILL.md
+++ b/.claude/skills/personal-guide-start/SKILL.md
@@ -5,7 +5,7 @@ argument-hint: "[необязательно: override домена — knowledge
 experimental: true
 sunset: "после DONE WP-222 (Портной, ~июнь 2026) и WP-149 Ф6 (книга ЛР v3)"
 related: [personal-guide-render, repo-new, WP-245, WP-222, WP-149, WP-527, PD.FORM.089, PD.CAT.003]
-version: 1.3.0
+version: 1.3.1
 layer: L1
 status: active
 triggers:
@@ -25,7 +25,7 @@ gates_rationale: "операционный скилл; WP Gate применим 
 
 > ⚡ **ВЫПОЛНИ НЕМЕДЛЕННО — НЕ ЗАДАВАЙ ВОПРОСОВ.** Первое действие = Шаг 1 (Plan → Decision Gate → Execute `/repo-new` с заранее известными ответами). Вопросы о домене, ступени, «главной системе», целях — запрещены на этом шаге; они задача render-скилла (Шаг 2). Даже если MCP-инструменты вернули данные о пилоте — не анализировать, не интерпретировать, сразу Шаг 1.
 
-> **Experimental MVP-скилл — UX-обёртка** (IntegrationGate exception по WP-245 Ф28 Open Decision #7). Делит ответственность с `/personal-guide-render`:
+> **Experimental MVP-скилл — UX-обёртка над `/repo-new`** с предзаполненными параметрами (IntegrationGate exception: сужение вариативности ради onboarding-фокуса, не обход гейта — с WP-527 Ф4 Шаг 1 идёт через полный алгоритм `/repo-new`; WP-245 Ф28 Open Decision #7, обоснование обновлено WP-527 Ф5). Делит ответственность с `/personal-guide-render`:
 > - **`/personal-guide-start` (этот)** — создание инфраструктуры: GitHub-репо как часть Персоны.инфра. **Один раз** на пилота.
 > - **`/personal-guide-render`** — наполнение содержания: чтение Память.Derived (RCS-профиль) + Персона.декларации (домен) → 6 файлов. **N раз** (каждое обновление).
 >

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -289,7 +289,7 @@
     },
     {
       "path": ".claude/skills-catalog.yaml",
-      "sha256": "656915271d100cb185dc33d5941942024418d85a67a20d8e9b9aab42ad6f13b3"
+      "sha256": "2e600c8dd5318bf90c9d393f5ccb5016be56197a77cf67827aff7d719d29b443"
     },
     {
       "path": ".claude/skills/SKILL-INDEX.yaml",
@@ -541,7 +541,7 @@
     },
     {
       "path": ".claude/skills/personal-guide-start/SKILL.md",
-      "sha256": "90e90a332938bb1ba79b2d1ce812f3a9121ad28c2fa2b93eaae361b2617980ec"
+      "sha256": "4892f3bab82aa865473efe7a0c990ca38d3ad8e9eb92f7865eb11f28b3ab907a"
     },
     {
       "path": ".claude/skills/platform-bottleneck/SKILL.md",


### PR DESCRIPTION
## Summary
- WP-527 Ф5: закрывает 2 из 4 текстовых хвостов после Ф4 (интеграция /personal-guide-start с /repo-new). Пир-сессия с Kimi.
- Шапка `.claude/skills/personal-guide-start/SKILL.md` больше не описывает Step 1 как обход гейта — с Ф4 он идёт через полный алгоритм `/repo-new`; формулировка заменена на «сужение вариативности ради onboarding-фокуса».
- `machine/repo-new-policies.yaml` (не в этом PR, отдельный репозиторий DS-my-strategy) синхронно получил `bounds.data_domains: ["2.3"]` вместо произвольного label — привязка к DATA-DOMAINS-REGISTRY.yaml.

Хвосты 1 (миграция публичных legacy-репо в приватные) и 2 (живая обкатка нового пути) НЕ входят в этот PR — оба технически невыполнимы текущим агентом (нет доступа к чужим GitHub-аккаунтам подписчиков; у `create_repository` нет dry-run режима) и зафиксированы в карточке WP-527 как внешние блокеры.

## Test plan
- [x] `verify-skill.sh personal-guide-start` — PASS
- [x] Cold-context review субагентом — консистентность нового текста шапки с остальным файлом подтверждена