### PR TITLE
fix(wp527): personal-guide-start — Ф7 живая обкатка, текстовые правки

### DIFF
--- a/.claude/skills-catalog.yaml
+++ b/.claude/skills-catalog.yaml
@@ -445,7 +445,7 @@ skills:
   - id: personal-guide-start
     name: "personal-guide-start"
     description: "Bootstrap-обёртка — создаёт пустой репо `DS-personal-guide` под аккаунтом пилота (плоское имя, без логина в названии; если ещё нет), затем вызывает /personal-guide-render для наполнения 6 файлами. Используй когда пилот в первый раз просит «создай мне персональное руководство», «хочу начать программу личного развития», «собери мне стартовый план»."
-    version: 1.3.1
+    version: 1.3.2
     layer: L1
     status: active
     triggers:

--- a/.claude/skills/personal-guide-start/SKILL.md
+++ b/.claude/skills/personal-guide-start/SKILL.md
@@ -5,7 +5,7 @@ argument-hint: "[необязательно: override домена — knowledge
 experimental: true
 sunset: "после DONE WP-222 (Портной, ~июнь 2026) и WP-149 Ф6 (книга ЛР v3)"
 related: [personal-guide-render, repo-new, WP-245, WP-222, WP-149, WP-527, PD.FORM.089, PD.CAT.003]
-version: 1.3.1
+version: 1.3.2
 layer: L1
 status: active
 triggers:
@@ -54,7 +54,7 @@ Bootstrap-обёртка — создаёт пустой репо `DS-personal-g
 - name: `DS-personal-guide` (константа для всех подписчиков — не подставлять GitHub-логин; один личный аккаунт = один репо)
 - `template_type`: `notes`
 - privacy: `private`
-- назначение: личное пространство участника программы ЛР
+- назначение: личное пространство участника программы МИМ; `description` для `create_repository` дословно: «Персональное руководство пилота программы МИМ» (WP-527 Ф7, поправлено 01.09 — раньше было «программы ЛР (IWE)»)
 - data domains: личные материалы участника (детализация — Step 3 `/repo-new`)
 - writer/owner/readers: writer = подписчик (правки) + `/personal-guide-render` (пересборка); owner = подписчик; readers = подписчик, его агенты сессии
 - registry mode: без регистрации в `REPOSITORY-REGISTRY.md` (Step 7 `/repo-new`, исключение по `repo_class: personal-subscriber`)
@@ -112,7 +112,7 @@ personal_write(
 
 > **Класс:** личное пространство данных пилота. **Назначение:** персональное руководство — план, методы, история занятий пилота. **Писатель:** пилот (правки) + render-скилл `/personal-guide-render` (пересборка). **Владелец:** пилот. **Читатели:** пилот, его агенты сессии.
 
-Создан через `/personal-guide-start` (быстрый bootstrap для этого конкретного случая — не общий гейт создания репозитория).
+Создан через `/personal-guide-start` — UX-обёртка над общим гейтом создания репозитория `/repo-new` с предзаполненными параметрами (WP-527 Ф4/Ф5).
 
 ## Работа с этим репозиторием
 

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -289,7 +289,7 @@
     },
     {
       "path": ".claude/skills-catalog.yaml",
-      "sha256": "2e600c8dd5318bf90c9d393f5ccb5016be56197a77cf67827aff7d719d29b443"
+      "sha256": "5d8752ff4dda433e822e52fad57bdf0121b4f339587ae4a5e9ebb0ce2fc89200"
     },
     {
       "path": ".claude/skills/SKILL-INDEX.yaml",
@@ -541,7 +541,7 @@
     },
     {
       "path": ".claude/skills/personal-guide-start/SKILL.md",
-      "sha256": "4892f3bab82aa865473efe7a0c990ca38d3ad8e9eb92f7865eb11f28b3ab907a"
+      "sha256": "a3bdd67d6776d922f7662e3ca3168f095054c55e5064c4f1058b00caca95f368"
     },
     {
       "path": ".claude/skills/platform-bottleneck/SKILL.md",


### PR DESCRIPTION
## Summary
- WP-527 Ф7: живая обкатка Step 1 `/personal-guide-start` на реальном тестовом GitHub-аккаунте пилота — гейт `/repo-new` (Plan → Decision Gate → Execute) отработал целиком, репозиторий создан приватным, первая живая запись в `usage_log` bounded-policy.
- По ходу теста пилот поправил название программы в описании репозитория: «программы ЛР (IWE)» → «программы МИМ».
- Заодно найдена и исправлена ещё одна устаревшая фраза в деплоимом CLAUDE.md-шаблоне ("не общий гейт создания репозитория" — было верно до Ф4, сейчас нет).

## Test plan
- [x] `verify-skill.sh personal-guide-start` — PASS
- [x] Живой прогон на реальном тестовом аккаунте — репозиторий создан, приватный, верное имя/описание