### PR TITLE
feat(setup): adopt existing governance repo instead of creating a second one (WP-560 Ф5)

### DIFF
--- a/scripts/tests/test_adopt_governance.sh
+++ b/scripts/tests/test_adopt_governance.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# test_adopt_governance.sh — WP-560 Ф5-Phase-1.
+#
+# The browser path (create_personal_data_space → github-integration-service,
+# family-catalog.ts) creates the governance repository under the same canonical
+# name as setup.sh step 6. Before this phase, a user who started in the browser
+# and then ran setup.sh got a second, unrelated local repo plus a swallowed
+# `gh repo create` failure. Invariants under test (dry-run, fake gh on PATH):
+#   1. remote exists + owner matches → setup.sh announces ADOPTION (clone), not
+#      creation, and never calls `gh repo create`;
+#   2. remote absent → the pre-existing creation path is unchanged
+#      (discriminating control: the test can tell the two apart);
+#   3. foreign owner → refused before any clone;
+#   4. the structure markers checked after a real clone are the seed's own
+#      files, so a clone of a foreign/non-governance repo cannot pass.
+#
+# Bash 3.2 compatible. Usage: bash scripts/tests/test_adopt_governance.sh
+
+set -uo pipefail
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEMPLATE_ROOT="$(cd "$SELF_DIR/../.." && pwd)"
+
+FAIL_COUNT=0; PASS_COUNT=0
+fail() { echo "  ❌ FAIL: $*" >&2; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+pass() { echo "  ✅ PASS: $*"; PASS_COUNT=$((PASS_COUNT + 1)); }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT INT TERM
+TEMPLATE_COPY="$TMP/FMT-exocortex-template"; WORKSPACE="$TMP/workspace"; FAKE_BIN="$TMP/fake-bin"; GH_LOG="$TMP/gh.log"
+mkdir -p "$TEMPLATE_COPY" "$WORKSPACE" "$FAKE_BIN" "$TMP/home"
+tar -C "$TEMPLATE_ROOT" --exclude='./.git' -cf - . | tar -C "$TEMPLATE_COPY" -xf -
+
+# Fake gh: FAKE_GH_REMOTE_EXISTS=1 → `repo view` succeeds and reports FAKE_GH_OWNER;
+# every invocation is logged so the test can prove `repo create`/`repo clone` never ran.
+cat > "$FAKE_BIN/gh" <<'SH'
+#!/bin/sh
+printf '%s\n' "gh $*" >>"$FAKE_GH_LOG"
+case "$1 $2" in
+  "auth status") exit 0 ;;
+  "repo view")
+    [ "${FAKE_GH_REMOTE_EXISTS:-0}" = "1" ] || exit 1
+    case "$*" in
+      *"--jq .owner.login"*) printf '%s\n' "${FAKE_GH_OWNER:-nobody}" ;;
+      *) printf '{"name":"DS-strategy"}\n' ;;
+    esac
+    exit 0 ;;
+  *) exit 97 ;;
+esac
+SH
+chmod +x "$FAKE_BIN/gh"
+for c in curl wget; do printf '#!/bin/sh\nexit 97\n' > "$FAKE_BIN/$c"; chmod +x "$FAKE_BIN/$c"; done
+
+cat > "$WORKSPACE/.exocortex.env" <<ENVEOF
+GITHUB_USER="contract-test"
+WORKSPACE_DIR="$WORKSPACE"
+CLAUDE_PATH="claude"
+CLAUDE_PROJECT_SLUG="contract-test"
+TIMEZONE_HOUR="4"
+TIMEZONE_DESC="4:00 UTC"
+HOME_DIR="$TMP/home"
+USER_NAME="contract-test"
+GOVERNANCE_REPO="DS-strategy"
+IWE_TEMPLATE="$TEMPLATE_COPY"
+IWE_RUNTIME="$WORKSPACE/.iwe-runtime"
+ENVEOF
+
+run_setup() { # $1 = remote exists (0/1), $2 = owner reported by gh
+  : >"$GH_LOG"
+  # GOVERNANCE_REPO / IWE_GOVERNANCE_REPO are pinned: setup.sh honours an explicit
+  # env value first, and a developer shell usually exports its own governance name.
+  env HOME="$TMP/home" PATH="$FAKE_BIN:$PATH" FAKE_GH_LOG="$GH_LOG" FAKE_GH_REMOTE_EXISTS="$1" FAKE_GH_OWNER="$2" \
+      SETUP_CI=1 GITHUB_USER=contract-test WORKSPACE_DIR="$WORKSPACE" \
+      GOVERNANCE_REPO=DS-strategy IWE_GOVERNANCE_REPO=DS-strategy \
+      bash "$TEMPLATE_COPY/setup.sh" --dry-run >"$TMP/out.log" 2>&1
+  echo $?
+}
+
+echo "=== 1. Remote governance repo exists and is ours → adopt (clone), never create ==="
+rc=$(run_setup 1 contract-test)
+[ "$rc" = "0" ] && pass "setup.sh --dry-run exits 0" || fail "exit $rc; $(tail -5 "$TMP/out.log")"
+grep -qF "Remote contract-test/DS-strategy exists → would clone it into" "$TMP/out.log" \
+  && pass "announces adoption of the existing remote" || fail "no adoption line; output: $(grep -F '[6/6]' -A3 "$TMP/out.log")"
+grep -qF "Would verify governance markers: REPO-TYPE.md docs/WP-REGISTRY.md" "$TMP/out.log" \
+  && pass "structure markers are the seed's own files" || fail "marker list changed or missing"
+grep -qF "Would create DS-strategy from seed/strategy" "$TMP/out.log" \
+  && fail "creation path still announced alongside adoption" || pass "creation path not taken"
+grep -qE "^gh repo (create|clone)" "$GH_LOG" && fail "gh repo create/clone invoked in dry-run" || pass "no gh repo create/clone in dry-run"
+
+echo "=== 2. Discriminating control: remote absent → unchanged creation path ==="
+rc=$(run_setup 0 contract-test)
+[ "$rc" = "0" ] && pass "setup.sh --dry-run exits 0" || fail "exit $rc"
+grep -qF "Would create DS-strategy from seed/strategy" "$TMP/out.log" \
+  && pass "creation path announced when no remote" || fail "creation path missing; output: $(grep -F '[6/6]' -A3 "$TMP/out.log")"
+grep -qF "would clone it into" "$TMP/out.log" && fail "adoption announced without a remote" || pass "no adoption without a remote"
+
+echo "=== 3. Foreign owner → refused before any clone, even in dry-run ==="
+rc=$(run_setup 1 someone-else)
+[ "$rc" != "0" ] && pass "setup.sh refuses (exit $rc)" || fail "accepted a repo owned by someone-else"
+grep -qF "Refusing to adopt a repository that is not yours" "$TMP/out.log" \
+  && pass "refusal names the owner mismatch" || fail "no owner-mismatch message"
+grep -qE "^gh repo clone" "$GH_LOG" && fail "cloned a foreign repo" || pass "nothing cloned"
+
+echo "=== 4. Seed really ships the markers the adoption check relies on ==="
+for m in REPO-TYPE.md docs/WP-REGISTRY.md; do
+  [ -e "$TEMPLATE_ROOT/seed/strategy/$m" ] && pass "seed/strategy/$m present" || fail "seed/strategy/$m missing — adoption would reject a freshly seeded repo"
+done
+
+echo ""
+echo "Result: $PASS_COUNT PASS, $FAIL_COUNT FAIL"
+[ "$FAIL_COUNT" -eq 0 ]

--- a/setup.sh
+++ b/setup.sh
@@ -918,9 +918,84 @@ echo "[6/6] Setting up $GOVERNANCE_REPO..."
 MY_STRATEGY_DIR="$WORKSPACE_DIR/$GOVERNANCE_REPO"
 STRATEGY_TEMPLATE="$TEMPLATE_DIR/seed/strategy"
 
+# WP-560 Ф5-Phase-1: the browser path (create_personal_data_space via
+# github-integration-service, family-catalog.ts) creates the same governance
+# repository under the same canonical name, independently of this script. A user
+# who started in the browser and then installs VS Code used to hit
+# `gh repo create` failing on "already exists" while a second, unrelated local
+# repo got initialised. Adopt the existing remote instead — but only after
+# proving it is ours (owner = GITHUB_USER) and shaped like a governance repo
+# (seed markers). Anything else aborts loudly; nothing is ever pushed over it.
+GOVERNANCE_MARKERS=("REPO-TYPE.md" "docs/WP-REGISTRY.md")
+
+remote_governance_repo_exists() {
+    ! $CORE_ONLY && command -v gh >/dev/null 2>&1 \
+        && gh repo view "$GITHUB_USER/$GOVERNANCE_REPO" --json name >/dev/null 2>&1
+}
+
+governance_markers_missing() {
+    local root="$1" m
+    for m in "${GOVERNANCE_MARKERS[@]}"; do
+        [ -e "$root/$m" ] || echo "$m"
+    done
+}
+
+adopt_existing_governance_repo() {
+    local owner_login
+    owner_login=$(gh repo view "$GITHUB_USER/$GOVERNANCE_REPO" --json owner --jq '.owner.login' 2>/dev/null)
+    if [ "$owner_login" != "$GITHUB_USER" ]; then
+        echo "  ERROR: GitHub repo $GITHUB_USER/$GOVERNANCE_REPO resolves to owner '$owner_login', expected '$GITHUB_USER'."
+        echo "  Refusing to adopt a repository that is not yours. Set GOVERNANCE_REPO to another name and re-run."
+        exit 1
+    fi
+    if [ -d "$MY_STRATEGY_DIR" ] && [ -n "$(ls -A "$MY_STRATEGY_DIR" 2>/dev/null)" ]; then
+        echo "  ERROR: $MY_STRATEGY_DIR exists, is not a git repo, and is not empty — cannot clone into it."
+        echo "  Fix: inspect and clean it up (or rename it aside), then re-run setup.sh."
+        exit 1
+    fi
+    if $DRY_RUN; then
+        echo "  [DRY RUN] Remote $GITHUB_USER/$GOVERNANCE_REPO exists → would clone it into $MY_STRATEGY_DIR"
+        echo "  [DRY RUN] Would verify governance markers: ${GOVERNANCE_MARKERS[*]}"
+        generate_executor_catalog_for_governance
+        return
+    fi
+    echo "  Remote $GITHUB_USER/$GOVERNANCE_REPO already exists (created elsewhere, e.g. from the browser) — adopting it."
+    if ! gh repo clone "$GITHUB_USER/$GOVERNANCE_REPO" "$MY_STRATEGY_DIR" -- --quiet 2>/dev/null; then
+        echo "  ERROR: could not clone $GITHUB_USER/$GOVERNANCE_REPO. Check network/access and re-run."
+        exit 1
+    fi
+    local missing
+    missing=$(governance_markers_missing "$MY_STRATEGY_DIR")
+    if ! find "$MY_STRATEGY_DIR" -mindepth 1 -maxdepth 1 ! -name .git -print -quit | grep -q .; then
+        # Empty remote (browser created the repository but nothing landed yet): seed it.
+        echo "  Remote is empty — seeding governance structure into it."
+        cp -r "$STRATEGY_TEMPLATE"/. "$MY_STRATEGY_DIR"/
+        generate_executor_catalog_for_governance
+        (cd "$MY_STRATEGY_DIR" && git add -A && git commit -q -m "Initial exocortex: $GOVERNANCE_REPO governance hub" && git push -q -u origin HEAD) || {
+            echo "  ERROR: seeded $MY_STRATEGY_DIR but could not commit/push. Fix manually: cd $MY_STRATEGY_DIR && git push -u origin HEAD"
+            exit 1
+        }
+    elif [ -n "$missing" ]; then
+        echo "  ERROR: $GITHUB_USER/$GOVERNANCE_REPO exists but does not look like an IWE governance repo — missing:"
+        printf '    - %s\n' $missing
+        echo "  It was left untouched in $MY_STRATEGY_DIR (cloned, nothing pushed)."
+        echo "  Fix: either point GOVERNANCE_REPO at a different name, or bring this repo to the seed structure and re-run."
+        exit 1
+    else
+        echo "  ✓ $GOVERNANCE_REPO adopted: owner and structure verified."
+        generate_executor_catalog_for_governance
+    fi
+    if [ -d "$MY_STRATEGY_DIR/.githooks" ]; then
+        (cd "$MY_STRATEGY_DIR" && git config core.hooksPath .githooks 2>/dev/null) && \
+            echo "  Pre-commit hook enabled (.githooks/)" || true
+    fi
+}
+
 if [ -d "$MY_STRATEGY_DIR/.git" ]; then
     echo "  $GOVERNANCE_REPO already exists as git repo."
     generate_executor_catalog_for_governance
+elif [ -d "$STRATEGY_TEMPLATE" ] && remote_governance_repo_exists; then
+    adopt_existing_governance_repo
 elif $DRY_RUN; then
     if [ -d "$STRATEGY_TEMPLATE" ]; then
         echo "  [DRY RUN] Would create $GOVERNANCE_REPO from seed/strategy → $MY_STRATEGY_DIR"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2833,7 +2833,7 @@
     },
     {
       "path": "setup.sh",
-      "sha256": "78b5d12b52c4aa10db3b2ca6a1e3f25cb7ed219cc32ed33c470936aca20677ed"
+      "sha256": "3c8051f85afa8cdfc459ca74f38fc269a709174850aa02df2014728d9406a119"
     },
     {
       "path": "setup/build-runtime.sh",
@@ -2901,6 +2901,7 @@
     "scripts/tests/conftest.py",
     "scripts/tests/lib/extract-update-download-batch.sh",
     "scripts/tests/session-guard-audit-validate-orz-batch-smoke.sh",
+    "scripts/tests/test_adopt_governance.sh",
     "scripts/tests/test_agent_dashboard.py",
     "scripts/tests/test_copy_to_aisystant.py",
     "scripts/tests/test_day_close_prepare.py",


### PR DESCRIPTION
## Что
`setup.sh` шаг 6: если репозиторий-хаб (`$GOVERNANCE_REPO`) уже существует на GitHub у этого же владельца — клонируем и принимаем его, вместо `git init` + `gh repo create` (который молча падал на «already exists»). Пустой удалённый репо засеваем из `seed/strategy`; непустой обязан содержать маркеры governance-структуры (`REPO-TYPE.md`, `docs/WP-REGISTRY.md`), иначе — остановка с инструкцией, ничего не пушится. Чужой владелец — отказ до клонирования.

## Зачем
Браузерный путь (`create_personal_data_space` → `family-catalog.ts`) создаёт тот же репозиторий под тем же каноническим именем независимо от локальной установки. Пересечение двух путей — только governance-репо (WP-560 Ф5, уточнено 02.09). Phase-1 делает столкновение неразрушительным; единый машинно-читаемый источник имени — Phase-2, отдельно.

## Проверка
- `scripts/tests/test_adopt_governance.sh` — 13/13 (подменённый `gh`, dry-run: принятие, контроль без remote, отказ чужому владельцу, наличие маркеров в seed)
- `test_fresh_seed_reproduction.sh`, `test_setup_runtime_isolation.sh` — зелёные
- shellcheck: новых предупреждений нет; манифест пересобран (`verify-manifest.sh` ok)

Refs: peer-session `2026-09-02-12-wp560-f3-f5-implementation` (Claude + Kimi + Codex), WP-560 Ф5-Phase-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)