### PR TITLE
fix(extractor): follow-up from Layer 5 adversarial audit of PR #642

### DIFF
--- a/docs/LEARNING-PATH.md
+++ b/docs/LEARNING-PATH.md
@@ -983,6 +983,8 @@ PACK-{область}/
 2. При Close → Claude активирует роль Экстрактора (R2) и показывает Extraction Report
 3. Ты одобряешь → сущности записываются в Pack
 
+**Inbox-Check работает без тебя** — headless-запуск по расписанию (каждые 3 часа) не может использовать твой интерактивный вход в Claude Code, ему нужен отдельный долгоживущий токен подписки. Подключается один раз: `cd ~/IWE/FMT-exocortex-template && bash roles/extractor/scripts/connect.sh` (после `roles/extractor/install.sh`, см. [roles/extractor/README.md](../roles/extractor/README.md)). Session-Close, On-Demand и Bulk-Extraction работают в твоей уже открытой сессии — подключения не требуют.
+
 **Где изучить:**
 - Протокол Close (§ 5.1) — когда активируется Экстрактор
 - [DP.ROLE.001](https://github.com/TserenTserenov/PACK-digital-platform/blob/main/pack/digital-platform/02-domain-entities/DP.ROLE.001-platform-roles.md) R2 — полное описание роли

--- a/docs/SETUP-GUIDE.md
+++ b/docs/SETUP-GUIDE.md
@@ -341,7 +341,7 @@ cd ~/IWE/FMT-exocortex-template
 # Экстрактор — извлечение знаний из сессий, проверка inbox (каждые 3 часа)
 bash roles/extractor/install.sh
 # Проверка inbox идёт без тебя (headless) — нужен отдельный вход в подписку один раз:
-bash "$IWE_TEMPLATE/roles/extractor/scripts/connect.sh"
+bash roles/extractor/scripts/connect.sh
 
 # Синхронизатор — центральный scheduler: расписание агентов, уведомления, code-scan
 bash roles/synchronizer/install.sh

--- a/roles/extractor/scripts/extractor.sh
+++ b/roles/extractor/scripts/extractor.sh
@@ -158,8 +158,8 @@ check_auth() {
     if status_out=$("$AI_CLI" auth status --json 2>&1); then
         return 0
     fi
-    log "ERROR: Claude Code не подключён — headless-запуск невозможен. Ответ 'claude auth status': $(printf '%s' "$status_out" | tr -s '[:space:]' ' ')"
-    log "Выполните: bash \$IWE_TEMPLATE/roles/extractor/scripts/connect.sh"
+    log "ERROR: проверка входа Claude Code не прошла — headless-запуск невозможен. Ответ 'claude auth status': $(printf '%s' "$status_out" | tr -s '[:space:]' ' ')"
+    log "Если это не сетевой/временный сбой, а подписка правда не подключена: bash \$IWE_TEMPLATE/roles/extractor/scripts/connect.sh"
     return 1
 }
 

--- a/setup/test-build-runtime-preserves-live-state.sh
+++ b/setup/test-build-runtime-preserves-live-state.sh
@@ -54,6 +54,10 @@ echo "--- Сею живое состояние, которое build-runtime.sh 
 mkdir -p "$TEST_WORKSPACE/.iwe-runtime/sessions" "$TEST_WORKSPACE/.iwe-runtime/isolate-push-attempts"
 echo "live-session-marker" > "$TEST_WORKSPACE/.iwe-runtime/sessions/claude-code-999.open"
 echo "live-isolate-attempt" > "$TEST_WORKSPACE/.iwe-runtime/isolate-push-attempts/attempt.json"
+# A top-level FILE, not just directories (open-sessions.log lives exactly like
+# this in the real .iwe-runtime/) — the fix's `[ -e ... ] || mv` check must not
+# assume every surviving entry is a directory.
+echo "live-log-line" > "$TEST_WORKSPACE/.iwe-runtime/open-sessions.log"
 
 echo "--- Вторая сборка: должна пересобрать roles/, но не тронуть живое состояние ---"
 if bash "$BUILD_SCRIPT" --workspace "$TEST_WORKSPACE" --env-file "$ENV_FILE" --quiet >"$TEST_WORKSPACE/build2.log" 2>&1; then
@@ -73,6 +77,13 @@ if [ -f "$TEST_WORKSPACE/.iwe-runtime/isolate-push-attempts/attempt.json" ]; the
     pass "isolate-push-attempts/ пережил пересборку"
 else
     fail "isolate-push-attempts/ ПОТЕРЯН при пересборке"
+fi
+
+if [ -f "$TEST_WORKSPACE/.iwe-runtime/open-sessions.log" ] \
+   && [ "$(cat "$TEST_WORKSPACE/.iwe-runtime/open-sessions.log")" = "live-log-line" ]; then
+    pass "живой файл верхнего уровня (не директория) пережил пересборку"
+else
+    fail "живой файл верхнего уровня ПОТЕРЯН при пересборке"
 fi
 
 [ -d "$TEST_WORKSPACE/.iwe-runtime/roles/extractor" ] && pass "roles/extractor всё ещё на месте после второй сборки" \

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -825,7 +825,7 @@
     },
     {
       "path": "docs/LEARNING-PATH.md",
-      "sha256": "4990040c4505bbba9b520177bb4aa2f105ea1e91546ba3cae1d31b2bf822434a"
+      "sha256": "45d551ccc33148a0cda1262b23613586afe3fcda9dc9b664e35ed90fb86f6f4b"
     },
     {
       "path": "docs/PACK-CREATION.md",
@@ -857,7 +857,7 @@
     },
     {
       "path": "docs/SETUP-GUIDE.md",
-      "sha256": "8038fd267bd9508502bcdf1ef0c86114e388fb0d0a2054855a8c2ffefd50e5a0"
+      "sha256": "0fdcee057931141ba27cd97c81fa013194230e8d0aa6998e52e62b15c0e0e671"
     },
     {
       "path": "docs/VERIFY-KNOWLEDGE-MCP.md",
@@ -1641,7 +1641,7 @@
     },
     {
       "path": "roles/extractor/scripts/extractor.sh",
-      "sha256": "216a2121cd67a329dc2e1ac95a4719d63ec125871d1cc11fa4a4af1146d8393f"
+      "sha256": "3474f35ccdfe93cf170ac0c2fcb91b5fbdf192855ecc54896478e3b10eaf1318"
     },
     {
       "path": "roles/extractor/scripts/launchd/com.extractor.inbox-check.plist",


### PR DESCRIPTION
## Summary
Три находки состязательного аудита (Layer 5 пятислойной пост-релизной верификации, PACK-verification VR.M.006), прогнанного изолированным субагентом против уже смерженного PR #642:

- `docs/SETUP-GUIDE.md` — команда `connect.sh` полагалась на `$IWE_TEMPLATE`, который не гарантированно задан в свежем терминале (setup.sh не просит перезапустить shell). Привёл к стилю соседних команд в том же блоке (`cd` + относительный путь).
- `docs/LEARNING-PATH.md` — обучающий абзац про `connect.sh`, заявленный в PR #642, реально не доехал (манифест подтверждает отсутствие). Доставлен сейчас.
- `extractor.sh` `check_auth()` — сообщение об ошибке безусловно утверждало «не подключён» для ЛЮБОГО ненулевого exit `claude auth status`, включая причины, которые `connect.sh` не лечит (сетевой сбой, битый конфиг). Смягчил формулировку.
- `setup/test-build-runtime-preserves-live-state.sh` — тест сеял только директории, не файл верхнего уровня (как реальный `open-sessions.log`). Добавил сценарий.

## Test plan
- [x] `bash -n` + `shellcheck -S warning` — чисто (кроме пред-существующего SC1090)
- [x] Обновлённый регресс-тест `build-runtime.sh` — 8/8 PASS, включая новый сценарий с файлом
- [x] `integration-contract-validator.sh` — 11/11 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)