### PR TITLE
feat(day-open): inject_panel_tile переключён на PD-dashboard (WP-417 Ф-cutover-switch)

### DIFF
--- a/scripts/day-open-llm-fill.py
+++ b/scripts/day-open-llm-fill.py
@@ -235,15 +235,19 @@ def rebuild_compact_dashboard(text: str) -> str:
     return "\n".join(out)
 
 
-def _panel_yesterday_iso() -> str:
-    """Вчера по московскому календарю — та же конвенция, что у ночного воркера (Ф3.3)."""
-    from datetime import datetime, timedelta, timezone
+def _dashboard_today_iso() -> str:
+    """Сегодня по московскому календарю -- дата, под которой dashboard_worker.py
+    пишет ночной снимок (запуск 07:30 MSK, WP-417 Ф-cutover-switch 2026-09-02).
+    Заменяет _panel_yesterday_iso() -- старая панель считала за ВЧЕРА (target_date
+    в panel_worker.py), PD-dashboard пишет файл под датой самого запуска."""
+    from datetime import datetime, timezone
     try:
         from zoneinfo import ZoneInfo
         now = datetime.now(ZoneInfo("Europe/Moscow"))
     except Exception:  # noqa: BLE001 — zoneinfo нет → Москва = UTC+3 (без DST с 2014)
+        from datetime import timedelta
         now = datetime.now(timezone.utc) + timedelta(hours=3)
-    return (now.date() - timedelta(days=1)).isoformat()
+    return now.date().isoformat()
 
 
 def _strip_panel_block(text: str, begin: str, end: str) -> str:
@@ -311,33 +315,38 @@ def inject_gate_metrics(text: str) -> str:
 
 
 def inject_panel_tile(text: str) -> str:
-    """Врезать тайл табло (WP-417 Ф3.4) в Compact Dashboard перед END-маркером.
+    """Врезать тайл табло (WP-417 Ф-cutover-switch, 2026-09-02) в Compact Dashboard
+    перед END-маркером.
 
-    Локальный режим: читает самую свежую панель из panel.db (вариант A data-ready
-    gate) и рендерит блок. Идемпотентно — старый блок <!-- panel-tile --> вырезается
-    и заменяется свежим (повторный Day Open не дублирует). Деградирует мягко: нет БД
-    или ошибка чтения → тайл пропускается, открытие дня не падает (P4: причина в лог).
-    Общий scaffold не трогаем — врезка только в локальном пайплайне ${IWE_GOVERNANCE_REPO:-DS-strategy}.
+    Источник -- PD-dashboard (git, ночной писатель dashboard_worker.py), не
+    panel.db/Neon (старый WP-417 Ф3.4 источник superseded архитектурным пивотом
+    18.08-01.09, см. inbox/WP-417/WP-417.md "Актуализация и решение пилота о
+    составе табло"). Идемпотентно -- старый блок <!-- panel-tile --> вырезается
+    и заменяется свежим (повторный Day Open не дублирует). Деградирует мягко:
+    нет PD-dashboard/файла на сегодня -> тайл пропускается, открытие дня не
+    падает (P4: причина в лог). Общий scaffold не трогаем -- врезка только в
+    локальном пайплайне ${IWE_GOVERNANCE_REPO:-DS-strategy}.
     """
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
     try:
-        from panel_render import PANEL_BEGIN, PANEL_END, read_panel, render_panel_block
-    except Exception:  # noqa: BLE001 — panel-модулей нет → тайл просто не показываем
-        print("[inject_panel_tile] panel-модули недоступны — тайл пропущен", file=sys.stderr)
+        from dashboard_render import (
+            PANEL_BEGIN, PANEL_END, read_dashboard_snapshot, render_dashboard_panel_block,
+        )
+    except Exception:  # noqa: BLE001 — dashboard-модули недоступны → тайл просто не показываем
+        print("[inject_panel_tile] dashboard-модули недоступны — тайл пропущен", file=sys.stderr)
         return text
 
     marker = "---END-COMPACT-DASHBOARD---"
     if marker not in text:
         return text  # нет дашборда (необычный scaffold) — некуда врезать
 
-    account_id = os.environ.get("PANEL_ACCOUNT_ID", "local")
     try:
-        panel = read_panel(account_id)
-    except Exception:  # noqa: BLE001 — БД недоступна → тайл пропускаем, день не валим
-        print("[inject_panel_tile] чтение panel.db не удалось — тайл пропущен", file=sys.stderr)
+        snapshot = read_dashboard_snapshot(_fault_profile_workspace())
+    except Exception:  # noqa: BLE001 — PD-dashboard недоступен → тайл пропускаем, день не валим
+        print("[inject_panel_tile] чтение PD-dashboard не удалось — тайл пропущен", file=sys.stderr)
         return text
 
-    block = render_panel_block(panel, _panel_yesterday_iso())
+    block = render_dashboard_panel_block(snapshot, _dashboard_today_iso())
     text = _strip_panel_block(text, PANEL_BEGIN, PANEL_END)
     idx = text.find(marker)
     return text[:idx] + block + "\n" + text[idx:]

--- a/seed/strategy/scripts/day-open-llm-fill.py
+++ b/seed/strategy/scripts/day-open-llm-fill.py
@@ -236,15 +236,19 @@ def rebuild_compact_dashboard(text: str) -> str:
     return "\n".join(out)
 
 
-def _panel_yesterday_iso() -> str:
-    """Вчера по московскому календарю — та же конвенция, что у ночного воркера (Ф3.3)."""
-    from datetime import datetime, timedelta, timezone
+def _dashboard_today_iso() -> str:
+    """Сегодня по московскому календарю -- дата, под которой dashboard_worker.py
+    пишет ночной снимок (запуск 07:30 MSK, WP-417 Ф-cutover-switch 2026-09-02).
+    Заменяет _panel_yesterday_iso() -- старая панель считала за ВЧЕРА (target_date
+    в panel_worker.py), PD-dashboard пишет файл под датой самого запуска."""
+    from datetime import datetime, timezone
     try:
         from zoneinfo import ZoneInfo
         now = datetime.now(ZoneInfo("Europe/Moscow"))
     except Exception:  # noqa: BLE001 — zoneinfo нет → Москва = UTC+3 (без DST с 2014)
+        from datetime import timedelta
         now = datetime.now(timezone.utc) + timedelta(hours=3)
-    return (now.date() - timedelta(days=1)).isoformat()
+    return now.date().isoformat()
 
 
 def _strip_panel_block(text: str, begin: str, end: str) -> str:
@@ -312,33 +316,38 @@ def inject_gate_metrics(text: str) -> str:
 
 
 def inject_panel_tile(text: str) -> str:
-    """Врезать тайл табло (WP-417 Ф3.4) в Compact Dashboard перед END-маркером.
+    """Врезать тайл табло (WP-417 Ф-cutover-switch, 2026-09-02) в Compact Dashboard
+    перед END-маркером.
 
-    Локальный режим: читает самую свежую панель из panel.db (вариант A data-ready
-    gate) и рендерит блок. Идемпотентно — старый блок <!-- panel-tile --> вырезается
-    и заменяется свежим (повторный Day Open не дублирует). Деградирует мягко: нет БД
-    или ошибка чтения → тайл пропускается, открытие дня не падает (P4: причина в лог).
-    Общий scaffold не трогаем — врезка только в локальном пайплайне ${IWE_GOVERNANCE_REPO:-DS-strategy}.
+    Источник -- PD-dashboard (git, ночной писатель dashboard_worker.py), не
+    panel.db/Neon (старый WP-417 Ф3.4 источник superseded архитектурным пивотом
+    18.08-01.09, см. inbox/WP-417/WP-417.md "Актуализация и решение пилота о
+    составе табло"). Идемпотентно -- старый блок <!-- panel-tile --> вырезается
+    и заменяется свежим (повторный Day Open не дублирует). Деградирует мягко:
+    нет PD-dashboard/файла на сегодня -> тайл пропускается, открытие дня не
+    падает (P4: причина в лог). Общий scaffold не трогаем -- врезка только в
+    локальном пайплайне ${IWE_GOVERNANCE_REPO:-DS-strategy}.
     """
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
     try:
-        from panel_render import PANEL_BEGIN, PANEL_END, read_panel, render_panel_block
-    except Exception:  # noqa: BLE001 — panel-модулей нет → тайл просто не показываем
-        print("[inject_panel_tile] panel-модули недоступны — тайл пропущен", file=sys.stderr)
+        from dashboard_render import (
+            PANEL_BEGIN, PANEL_END, read_dashboard_snapshot, render_dashboard_panel_block,
+        )
+    except Exception:  # noqa: BLE001 — dashboard-модули недоступны → тайл просто не показываем
+        print("[inject_panel_tile] dashboard-модули недоступны — тайл пропущен", file=sys.stderr)
         return text
 
     marker = "---END-COMPACT-DASHBOARD---"
     if marker not in text:
         return text  # нет дашборда (необычный scaffold) — некуда врезать
 
-    account_id = os.environ.get("PANEL_ACCOUNT_ID", "local")
     try:
-        panel = read_panel(account_id)
-    except Exception:  # noqa: BLE001 — БД недоступна → тайл пропускаем, день не валим
-        print("[inject_panel_tile] чтение panel.db не удалось — тайл пропущен", file=sys.stderr)
+        snapshot = read_dashboard_snapshot(_fault_profile_workspace())
+    except Exception:  # noqa: BLE001 — PD-dashboard недоступен → тайл пропускаем, день не валим
+        print("[inject_panel_tile] чтение PD-dashboard не удалось — тайл пропущен", file=sys.stderr)
         return text
 
-    block = render_panel_block(panel, _panel_yesterday_iso())
+    block = render_dashboard_panel_block(snapshot, _dashboard_today_iso())
     text = _strip_panel_block(text, PANEL_BEGIN, PANEL_END)
     idx = text.find(marker)
     return text[:idx] + block + "\n" + text[idx:]

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2145,7 +2145,7 @@
     },
     {
       "path": "scripts/day-open-llm-fill.py",
-      "sha256": "0cd2567d6f6066d3dc0af23e30d1acc3b7a896bfc59a425895a1a2ae3fb63e1a"
+      "sha256": "c1c4592e652db242ec2698b157d70e2e649e9ae38b2543b850198d913e048da9"
     },
     {
       "path": "scripts/day-open-multiplier-backfill-patch.py",
@@ -2809,7 +2809,7 @@
     },
     {
       "path": "seed/strategy/scripts/day-open-llm-fill.py",
-      "sha256": "c9e59fc04fa83950662cb3c266313387a9642fafa031294b3cee0adad8b0f4c2"
+      "sha256": "21fdc689599ba88fff4215cf590e5baaa0efa1d0f552e7c7e9be311bab7e41cf"
     },
     {
       "path": "seed/strategy/scripts/generate-executor-catalog.py",


### PR DESCRIPTION
## Summary
- `inject_panel_tile()` в `day-open-llm-fill.py` (канонический + seed-снимок) переключён с `panel.db`/Neon (`panel_render.py`) на `PD-dashboard` (git, `dashboard_worker.py`) — старый источник табло superseded архитектурным пивотом WP-417 (18.08-01.09.2026).
- Личное авторское использование (табло пилота, DS-my-strategy). У обычных пользователей шаблона `scripts/lib/dashboard_render.py` отсутствует — деградация мягкая, тайл просто не показывается, как и раньше с `panel_render.py`.
- Синхронизация canonical ↔ seed выполнена через `check-seed-drift.sh --fix` (диффы идентичны).

## Test plan
- [x] `scripts/lib/test_dashboard.py`, `scripts/lib/test_dashboard_render.py`, `scripts/test_panel_calc.py`, `scripts/test_panel_dayopen_inject.py` (DS-my-strategy) — все зелёные
- [x] Живой смоук: `inject_panel_tile()` на реальном PD-dashboard пилота — корректно рендерит блок с реальными данными
- [x] `check-seed-drift.sh` — seed и canonical идентичны после `--fix`

Refs: peer-session DS-my-strategy `2026-09-02-18-finish-wp417-close`

🤖 Generated with [Claude Code](https://claude.com/claude-code)