### PR TITLE
fix(extractor): connect.sh no longer truncates a wrapped multi-line token paste

### DIFF
--- a/roles/extractor/scripts/connect.sh
+++ b/roles/extractor/scripts/connect.sh
@@ -62,9 +62,18 @@ save_token() {
 }
 
 read_token_interactively() {
-    local token
+    local token line
     read -rsp "Вставьте токен, напечатанный выше (ввод скрыт): " token
     echo >&2
+    # A long token wraps across several terminal lines when the window is
+    # narrow; pasting the whole block delivers all of them at once, so the
+    # rest is already sitting in the input buffer right behind the first
+    # line. Manual single-line entry leaves nothing queued, so the
+    # non-blocking read below times out immediately and changes nothing.
+    while IFS= read -rs -t 0.3 line; do
+        [ -n "$line" ] || break
+        token="${token}${line}"
+    done
     # Paste often carries a trailing newline or surrounding spaces.
     token="$(printf '%s' "$token" | tr -d '[:space:]')"
     [ -n "$token" ] || die "пусто — ничего не сохранено."

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1637,7 +1637,7 @@
     },
     {
       "path": "roles/extractor/scripts/connect.sh",
-      "sha256": "b3a93c3ac772e400d864af080242e79df6683895e91554868ceebf54ef7ef73d"
+      "sha256": "8a24dba34d40db361b793bd706187cb74c5ad03f99da2456f1b9ec36806ac6a1"
     },
     {
       "path": "roles/extractor/scripts/extractor.sh",


### PR DESCRIPTION
## Проблема
`read_token_interactively()` в `roles/extractor/scripts/connect.sh` читает только одну строку (`read -rsp`). Длинный токен (108 символов), напечатанный `claude setup-token`, в узком терминале переносится на несколько строк без явного разделителя — при вставке всего блока сохраняется только первая строка, и проверка длины (`TOKEN_MIN_LENGTH=40`) корректно отказывает, но без диагностики причины.

Живая находка: WP-170, 2026-09-02 — пилот получил `ERROR: строка слишком короткая для токена (29 символов)` при первой попытке подключения.

## Фикс
После первого `read`, докрутить неблокирующим чтением (`read -t 0.3`) остаток уже буферизованной вставки — паста доставляет все строки практически одновременно, а ручной ввод одной строки не оставляет после себя ничего, так что цикл завершается по таймауту без изменения поведения.

## Проверено
- Симуляция вставки в 4 строки (112 символов) → токен собирается полностью.
- Обычный однострочный ввод (43 символа) → поведение не изменилось.
- Слишком короткая строка → та же понятная ошибка, что и раньше.
- `shellcheck` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)