### PR TITLE
fix(diagnose): браузерный режим пишет в канонический журнал, не в цифровой двойник

### DIFF
--- a/.claude/skills/diagnose/SKILL.md
+++ b/.claude/skills/diagnose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: diagnose
-description: "Диагностика ступени мастерства (Диагност R28, FORM.089 §6.1 v5.0) прямо в VS Code / claude.ai. До 6 вопросов, ~3 мин. Сохраняет cp-профиль в цифровой двойник (browser) или Neon (VS Code). Запускай когда: пилот говорит «пройди диагностику», «какая моя ступень», «/diagnose» — или ПРОАКТИВНО когда видишь пустой cp_profile или нового пользователя без данных."
+description: "Диагностика ступени мастерства (Диагност R28, FORM.089 §6.1 v5.0) прямо в VS Code / claude.ai. До 6 вопросов, ~3 мин. Сохраняет cp-профиль в канонический журнал learning.cp_assessments — через MCP-инструмент (browser) или напрямую в Neon (VS Code). Запускай когда: пилот говорит «пройди диагностику», «какая моя ступень», «/diagnose» — или ПРОАКТИВНО когда видишь пустой cp_profile или нового пользователя без данных."
 argument-hint: "[необязательно: --check для просмотра профиля без нового опроса]"
 related: [WP-318, WP-370, DP.ROLE.042, DP.SC.132, PD.FORM.089]
 version: 5.0.0
@@ -39,7 +39,7 @@ gates_rationale: "операционный скилл; WP Gate применим 
 
 ## Определить интерфейс (ПЕРВЫМ действием)
 
-**Браузер (claude.ai):** инструмент Bash недоступен → сохранение через `dt_write_digital_twin`.
+**Браузер (claude.ai):** инструмент Bash недоступен → сохранение через `learning_ctx_record_cp_assessment` (канонический журнал).
 **VS Code / локальный:** Bash доступен → сохранение в Neon через psycopg2 (+ локальный fallback).
 
 Проверка: попробовать Bash. Если недоступен — работаем в браузерном режиме.
@@ -270,32 +270,23 @@ cp.iwe [N] | cp.int [N] | cp.agt [N]
 
 Затем сохранить — путь зависит от интерфейса:
 
-### Браузерный режим (claude.ai) — сохранить через dt_write_digital_twin
+### Браузерный режим (claude.ai) — сохранить через learning_ctx_record_cp_assessment
 
-Вычислить `assessed_at` (сегодняшняя дата ISO) и `valid_until` (+180 дней).
+Вычислить `occurred_at` (сейчас, ISO UTC). Сгенерировать `event_id` для идемпотентности: `diagnose-browser-<occurred_at>` (ISO-время без разделителей допустимо, важно только не повторить в рамках одной сессии).
 
-Вызвать `mcp__claude_ai_IWE__dt_write_digital_twin`:
-- **path:** `1_declarative/cp_profile`
-- **data:**
-```json
-{
-  "stage": <N>,
-  "bottleneck_slot": "<cp.xxx или 'none'>",
-  "recommended_stream": "<SN или 'РР'>",
-  "skip_to_stage": <N>,
-  "cp_scores": {
-    "cp.rhy": <N>, "cp.wld": <N>, "cp.skl": <N>,
-    "cp.iwe": <N>, "cp.int": <N>, "cp.agt": <N>
-  },
-  "source": "self_report",
-  "interface": "browser",
-  "rcs_version": "v5.0",
-  "assessed_at": "YYYY-MM-DD",
-  "valid_until": "YYYY-MM-DD"
-}
-```
+Вызвать `mcp__claude_ai_IWE__learning_ctx_record_cp_assessment` (пишет в канонический журнал `learning.cp_assessments`, тот же, что и VS Code режим ниже — не в личный цифровой двойник):
+- **event_id:** `<сгенерированный>`
+- **stage:** `<N>`
+- **cp_scores:** `{"cp.rhy": <N>, "cp.wld": <N>, "cp.skl": <N>, "cp.iwe": <N>, "cp.int": <N>, "cp.agt": <N>}`
+- **bottleneck_slot:** `<cp.xxx или 'none'>`
+- **recommended_stream:** `<SN или 'РР'>`
+- **skip_to_stage:** `<N>`
+- **questions_count:** `<число заданных вопросов>`
+- **rcs_version:** `v5.0`
+- **occurred_at:** `<occurred_at>`
+- **written_by:** `browser`
 
-Если `dt_write_digital_twin` вернул успех → сообщить: `✅ Профиль сохранён в цифровой двойник`.
+Если вызов вернул успех → сообщить: `✅ Профиль сохранён` (без упоминания «цифровой двойник» — запись идёт в общий журнал).
 Если ошибка → показать профиль в чате и попросить пользователя скопировать его вручную.
 
 ### VS Code режим — сохранить в Neon через Bash
@@ -381,7 +372,7 @@ if not saved:
 | Пилот не отвечает числом 1-5 | Переспросить: «Выбери цифру от 1 до 5» |
 | Пилот хочет пропустить вопрос | Присвоить дефолт 2 (conservative), перейти дальше |
 | Менее 4 mandatory-ответов | Показать «Диагностика не завершена», предложить `/diagnose` заново |
-| dt_write_digital_twin недоступен | Показать профиль в чате, попросить скопировать |
+| learning_ctx_record_cp_assessment недоступен | Показать профиль в чате, попросить скопировать |
 | psycopg2 не установлен (VS Code) | Сохранить в `~/.aist/cp-assessments/YYYY-MM-DD.json` |
 | Профиль уже есть (< 7 дней) | Показать и спросить: «Пройти заново?» |
 

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -377,7 +377,7 @@
     },
     {
       "path": ".claude/skills/diagnose/SKILL.md",
-      "sha256": "9b5f55fee4692f841af68d92a76f44ef0eca7b7f304a0124654c5e6cfcb43f3d"
+      "sha256": "2d81483161958c24d996c8aef7b0c5c2ac0e53b7286b6a557532dc8874aab76e"
     },
     {
       "path": ".claude/skills/discovery-session/SKILL.md",


### PR DESCRIPTION
## Что меняется
Скилл `diagnose` в браузерном режиме (claude.ai) сохранял результат диагностики через `dt_write_digital_twin` (личный цифровой двойник пилота). Технический канал записи в общий канонический журнал `learning.cp_assessments` (`learning_ctx_record_cp_assessment`) уже развёрнут и бесплатен (gateway-mcp PR #44), но сам скилл его не использовал.

Правка переключает браузерный режим на `learning_ctx_record_cp_assessment` — тот же журнал, в который уже пишет VS Code режим напрямую через Neon.

## Откуда
Найдено пир-сессией РП553 (`2026-09-02-47-wp553-test-grant-and-account`, Claude+Kimi+Codex) при фактчеке готовности онбординга новичка к семинару 06.09.

## Проверка
- Live-прогон на чистом тестовом аккаунте не проводился (нет тестового аккаунта на момент правки) — это отдельный шаг РП553 Ф4.
- До мержа стоит хотя бы раз пройти `/diagnose` в браузере и проверить, что запись появилась в `learning.cp_assessments`, а не только в цифровом двойнике.

## Test plan
- [ ] Пройти диагностику в claude.ai (браузер)
- [ ] Проверить строку в `learning.cp_assessments` по `event_id`
- [ ] Убедиться, что `dt_write_digital_twin` больше не вызывается на этом пути

🤖 Generated with [Claude Code](https://claude.com/claude-code)