### PR TITLE
fix(diagnose): чтение профиля тоже переключено на канон (доследование за PR #648)

### DIFF
--- a/.claude/skills/diagnose/SKILL.md
+++ b/.claude/skills/diagnose/SKILL.md
@@ -50,12 +50,11 @@ gates_rationale: "операционный скилл; WP Gate применим 
 
 ### Браузерный режим
 
-Вызвать `mcp__claude_ai_IWE__dt_read_digital_twin` с path `1_declarative/cp_profile`.
+Вызвать `mcp__claude_ai_IWE__learning_ctx_get_onboarding_state` (читает из того же канона `learning.cp_assessments`, куда пишет Шаг 5).
 
-Если возвращает данные с полем `assessed_at` — проверить возраст:
-- Профиль есть и моложе 7 дней → показать, предложить пройти заново (кнопка «Повторить»).
+- `has_diagnosis: true` → показать текущий `cp_stage`, предложить пройти заново (кнопка «Повторить»). Инструмент не отдаёт `assessed_at` — точный 7-дневный кулдаун (как в VS Code режиме) здесь не проверить; решение «повторять или нет» оставить пилоту.
 - `--check` → показать и завершить.
-- Нет профиля или старше 7 дней → продолжить с Шага 1.
+- `has_diagnosis: false` → продолжить с Шага 1.
 
 ### VS Code режим
 
@@ -379,7 +378,7 @@ if not saved:
 ## Проактивный триггер
 
 Claude должен предложить `/diagnose` **без явного запроса** когда:
-1. В `dt_read_digital_twin` по path `1_declarative/cp_profile` нет данных или `stage = null`
+1. В `learning_ctx_get_onboarding_state` — `has_diagnosis: false` или `cp_stage = null`
 2. В `day-open` IWE-данные пустые или `stage = null`
 3. Пилот говорит «с чего начать», «как мне развиваться», «что делать дальше» — без контекста ступени
 

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -377,7 +377,7 @@
     },
     {
       "path": ".claude/skills/diagnose/SKILL.md",
-      "sha256": "2d81483161958c24d996c8aef7b0c5c2ac0e53b7286b6a557532dc8874aab76e"
+      "sha256": "9d84704a2f1bb0adc62c7d60d053582f2aead82b916ddf74aaa69d914984b20e"
     },
     {
       "path": ".claude/skills/discovery-session/SKILL.md",


### PR DESCRIPTION
## Что меняется
PR #648 переключил запись браузерной диагностики на канонический журнал `learning.cp_assessments`, но чтение (Шаг 0 — проверка существующего профиля, и проактивный триггер) осталось на `dt_read_digital_twin`. После #648 путь чтения перестал совпадать с путём записи: новая диагностика больше не появлялась бы в цифровом двойнике.

Переключает оба места чтения на `learning_ctx_get_onboarding_state`.

## Откуда
Найдено cold-context ревью субагента внутри той же пир-сессии РП553, сразу после мержа #648.

## Известное ограничение
`learning_ctx_get_onboarding_state` не отдаёт `assessed_at` — точный 7-дневный кулдаун (как в VS Code режиме через прямой SQL) в браузере больше не проверяется автоматически, решение «повторять диагностику или нет» явно оставлено пилоту в тексте скилла.

🤖 Generated with [Claude Code](https://claude.com/claude-code)