### PR TITLE
fix(wp5): session-close-feed — блокировка от параллельных запусков

### DIFF
--- a/roles/extractor/scripts/extractor.sh
+++ b/roles/extractor/scripts/extractor.sh
@@ -430,14 +430,14 @@ commit_extractor_changes() {
     [ "$EXTRACTOR_COMMIT_RESULT" = "published" ] && return 0 || return 1
 }
 
-release_inbox_lock() {
-    local lock_dir="$1"
+release_inbox_lock() {  # <lock_dir> [label]
+    local lock_dir="$1" label="${2:-inbox-check}"
     rm -f "$lock_dir/pid"
-    rmdir "$lock_dir" 2>/dev/null || log "WARN: cannot release inbox-check lock: $lock_dir"
+    rmdir "$lock_dir" 2>/dev/null || log "WARN: cannot release $label lock: $lock_dir"
 }
 
-acquire_inbox_lock() {
-    local lock_dir="$1"
+acquire_inbox_lock() {  # <lock_dir> [label]
+    local lock_dir="$1" label="${2:-inbox-check}"
     local owner_pid=""
 
     if mkdir "$lock_dir" 2>/dev/null; then
@@ -449,7 +449,7 @@ acquire_inbox_lock() {
         owner_pid=$(tr -d '[:space:]' < "$lock_dir/pid")
     fi
     if [[ "$owner_pid" =~ ^[0-9]+$ ]] && kill -0 "$owner_pid" 2>/dev/null; then
-        log "SKIP: inbox-check is already running (pid $owner_pid)"
+        log "SKIP: $label is already running (pid $owner_pid)"
         return 1
     fi
 
@@ -458,17 +458,17 @@ acquire_inbox_lock() {
     if [ -n "$owner_pid" ]; then
         rm -f "$lock_dir/pid"
         if ! rmdir "$lock_dir" 2>/dev/null; then
-            log "SKIP: stale inbox-check lock needs manual review: $lock_dir"
+            log "SKIP: stale $label lock needs manual review: $lock_dir"
             return 1
         fi
         if mkdir "$lock_dir" 2>/dev/null; then
             printf '%s\n' "$$" > "$lock_dir/pid"
-            log "WARN: reclaimed stale inbox-check lock from pid $owner_pid"
+            log "WARN: reclaimed stale $label lock from pid $owner_pid"
             return 0
         fi
     fi
 
-    log "SKIP: inbox-check lock is unavailable: $lock_dir"
+    log "SKIP: $label lock is unavailable: $lock_dir"
     return 1
 }
 
@@ -695,9 +695,20 @@ case "$1" in
         # пишет ###-блоки в помесячный inbox/captures/YYYY-MM.md (ротация
         # WP-526; без ротации — в captures.md) с маркером [feed:session-close].
         # Не создаёт extraction-report — это работа inbox-check потом.
+        #
+        # WP-5 follow-up (02.09): quick-close's own handler (session-close-
+        # feeder.sh) now launches this call as a detached background job
+        # instead of waiting synchronously -- multiple session closes can fire
+        # in quick succession without one blocking on the other's completion.
+        # Without a lock they'd race writing the same monthly captures.md.
+        feed_lock_dir="${IWE_EXTRACTOR_FEED_LOCK_DIR:-${TMPDIR:-/tmp}/iwe-extractor-session-close-feed.lock}"
+        if ! acquire_inbox_lock "$feed_lock_dir" "session-close-feed"; then
+            exit 0
+        fi
         log "Running session-close FEED (non-interactive, writes to captures inbox)"
         run_claude "session-close-feed" "${2:-}"
         notify_telegram "session-close-feed"
+        release_inbox_lock "$feed_lock_dir" "session-close-feed"
         ;;
 
     "git-diff-feed")

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1641,7 +1641,7 @@
     },
     {
       "path": "roles/extractor/scripts/extractor.sh",
-      "sha256": "7e05b07761bafb3466cae7fa40c6efa85754cac0cb40f6aec2661a8c73740864"
+      "sha256": "3170919edd3c78700c0dfaf39a027671bd485ba9c2376f9b105ffd208ea8a01e"
     },
     {
       "path": "roles/extractor/scripts/launchd/com.extractor.inbox-check.plist",


### PR DESCRIPTION
## Summary
Дополняет фикс в DS-my-strategy (session-close-feeder.sh теперь запускает `session-close-feed` в фоне вместо синхронного ожидания 2 минут — см. соответствующий коммит там). Без блокировки два параллельных закрытия сессии могли одновременно писать в один и тот же помесячный `inbox/captures/YYYY-MM.md`.

Переиспользована уже существующая функция блокировки `inbox-check` (`acquire_inbox_lock`/`release_inbox_lock`) — параметризована меткой процесса вместо хардкода `"inbox-check"` в логах, применена вторым call site.

## Root cause связанного фикса (для контекста)
Живой замер по логам показал: до 31.07 (лимит времени отсутствовал) доля успешных завершений `session-close-feed` была 50-70%. После 31.07 (лимит 120с, выбранный под потолок инфраструктуры раннера — 180с, а не под реальное время анализа) доля упала до 17% за последние 4 дня. Порог `feeder_due` отбирает именно длинные сессии — у них больше материала, значит именно они чаще всего не укладывались в лимит.

## Test plan
- [x] `bash -n` — синтаксис ок
- [x] `shellcheck` — новых предупреждений нет
- [x] Живой тест обработчика с имитацией долгого вызова — обработчик возвращается мгновенно, фоновый процесс завершается и пишет результат независимо

🤖 Generated with [Claude Code](https://claude.com/claude-code)