### PR TITLE
fix(wp5): session-close-feed — trap освобождает замок на любом исходе

### DIFF
--- a/roles/extractor/scripts/extractor.sh
+++ b/roles/extractor/scripts/extractor.sh
@@ -705,10 +705,18 @@ case "$1" in
         if ! acquire_inbox_lock "$feed_lock_dir" "session-close-feed"; then
             exit 0
         fi
+        # Cold-context review (02.09): under this file's `set -e`, run_claude
+        # failing (exit 1 on a missing prompt file, or its own `return 1` on
+        # an AI CLI failure -- a live, not hypothetical, case per its own
+        # WP-5 Ф46 comment) aborted the script before release_inbox_lock ever
+        # ran, leaving the lock held by a now-dead PID until the next call's
+        # stale-reclaim path. Not a permanent deadlock, but a genuine
+        # concurrent run in between was wrongly told "already running", with
+        # nothing reported. The trap covers every exit path uniformly.
+        trap 'release_inbox_lock "$feed_lock_dir" "session-close-feed"' EXIT
         log "Running session-close FEED (non-interactive, writes to captures inbox)"
         run_claude "session-close-feed" "${2:-}"
         notify_telegram "session-close-feed"
-        release_inbox_lock "$feed_lock_dir" "session-close-feed"
         ;;
 
     "git-diff-feed")

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1641,7 +1641,7 @@
     },
     {
       "path": "roles/extractor/scripts/extractor.sh",
-      "sha256": "3170919edd3c78700c0dfaf39a027671bd485ba9c2376f9b105ffd208ea8a01e"
+      "sha256": "212a74c11af1882a763fb3d857878bde54030a5ce6f795532f2a927ad645e29b"
     },
     {
       "path": "roles/extractor/scripts/launchd/com.extractor.inbox-check.plist",


### PR DESCRIPTION
## Summary
Холодное ревью независимым субагентом (проверка PR #651 после слияния) нашло: под `set -e` падение `run_claude` (отсутствующий файл промпта, или собственный `return 1` при сбое AI CLI — живой случай) обрывало скрипт до `release_inbox_lock`, оставляя замок висеть на мёртвом PID до следующего вызова. Не постоянный deadlock (существующая логика переиспользования устаревшего замка самоисцеляет), но до этого параллельный запуск ошибочно получал «уже выполняется», и уведомления о сбое не было.

Фикс: `trap 'release_inbox_lock ...' EXIT` сразу после захвата замка — покрывает любой путь выхода, не только успешный.

## Test plan
- [x] `bash -n` — синтаксис ок
- [x] `shellcheck` — новых предупреждений нет
- [x] Живой тест: искусственный сбой `run_claude` (отсутствующий файл промпта) — без trap замок оставался висеть, с trap — корректно освобождается

🤖 Generated with [Claude Code](https://claude.com/claude-code)