### PR TITLE
fix(changelog): require explicit write target

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -703,6 +703,7 @@ jobs:
           python3 -m pytest -q \
             scripts/tests/test_issue_*.py \
             scripts/tests/test_install_hooks.py \
+            scripts/tests/test_skill_promote.py \
             scripts/tests/test_residency_gate_skill_adapter.py
           # The skill directory contains a hyphen, so pytest cannot import it
           # as a package reliably; both files are executable unit suites.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ Refs: WP-NNN
 
 ### Fixed
 
+- fix(changelog): режим записи `changelog-append.sh` теперь требует явный `IWE_TEMPLATE` и не может молча изменить канонический FMT из изолированного worktree; штатные promote-скрипты передают выбранную цель явно
 - `f896701` fix(skills): personal-guide -> DS-personal-guide в шаблонных скиллах (#585)
   - `personal-guide-start`, `personal-guide-render`, `lesson-close`, `week-close-pilot` — литеральное имя личного репозитория новых пользователей переведено на канон `DS-personal-guide`; `docs/SETUP-GUIDE.md` и её тест-контракт обновлены вместе с манифестом
 - `91b7a2e` fix(day-open/day-close): читатели журналов сессий следуют контракту писателя + единый источник календаря (#545, #581)

--- a/scripts/changelog-append.sh
+++ b/scripts/changelog-append.sh
@@ -7,21 +7,33 @@
 # Идемпотентен: можно вызывать сколько угодно раз подряд — дубликатов не будет.
 #
 # Использование:
-#   bash changelog-append.sh [--dry-run]
+#   IWE_TEMPLATE=/path/to/FMT bash changelog-append.sh
+#   bash changelog-append.sh --dry-run
 #
 # Для фиксации версии (Unreleased → X.Y.Z):
 #   bash changelog-flush.sh --version 0.32.0
 
 set -uo pipefail
 
-FMT_DIR="${IWE_TEMPLATE:-${IWE_WORKSPACE:-$HOME/IWE}/FMT-exocortex-template}"
-CHANGELOG="$FMT_DIR/CHANGELOG.md"
 dry_run=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in --dry-run) dry_run=true ;; esac
     shift
 done
+
+# Write mode must never guess the target checkout. In author worktrees the
+# historical fallback pointed at the canonical clone and silently modified it.
+FMT_DIR="${IWE_TEMPLATE:-}"
+if [[ -z "$FMT_DIR" ]]; then
+    if ! $dry_run; then
+        echo "❌ Режим записи требует явную цель: IWE_TEMPLATE=/path/to/FMT" >&2
+        exit 2
+    fi
+    FMT_DIR="${IWE_WORKSPACE:-$HOME/IWE}/FMT-exocortex-template"
+    echo "⚠️  IWE_TEMPLATE не задан; dry-run читает fallback: $FMT_DIR" >&2
+fi
+CHANGELOG="$FMT_DIR/CHANGELOG.md"
 
 if [[ ! -f "$CHANGELOG" ]]; then
     echo "❌ CHANGELOG.md не найден: $CHANGELOG" >&2

--- a/scripts/changelog-flush.sh
+++ b/scripts/changelog-flush.sh
@@ -38,7 +38,7 @@ UNRELEASED_CONTENT=$(awk '
     in_u && NF { print }
 ' "$CHANGELOG" 2>/dev/null)
 if [ -z "$UNRELEASED_CONTENT" ]; then
-    echo "⚠️  Секция [Unreleased] пуста или отсутствует. Сначала запусти: bash changelog-append.sh" >&2
+    echo "⚠️  Секция [Unreleased] пуста или отсутствует. Сначала запусти: IWE_TEMPLATE=\"$FMT_DIR\" bash \"$FMT_DIR/scripts/changelog-append.sh\"" >&2
     exit 1
 fi
 

--- a/scripts/hook-promote.sh
+++ b/scripts/hook-promote.sh
@@ -84,7 +84,7 @@ rm -rf "$tmp_dir"
 echo "✅ Промотирован: FMT/.claude/hooks/$fname"
 
 CHANGELOG_SCRIPT="$FMT_DIR/scripts/changelog-append.sh"
-if [[ -f "$CHANGELOG_SCRIPT" ]]; then bash "$CHANGELOG_SCRIPT"; fi
+if [[ -f "$CHANGELOG_SCRIPT" ]]; then IWE_TEMPLATE="$FMT_DIR" bash "$CHANGELOG_SCRIPT"; fi
 
 MANIFEST_SCRIPT="$FMT_DIR/generate-manifest.sh"
 if [[ -f "$MANIFEST_SCRIPT" ]]; then

--- a/scripts/script-promote.sh
+++ b/scripts/script-promote.sh
@@ -171,7 +171,7 @@ promote_one() {
 
 finalize() {
     local changelog_script="$FMT_DIR/scripts/changelog-append.sh"
-    [[ -f "$changelog_script" ]] && bash "$changelog_script"
+    [[ -f "$changelog_script" ]] && IWE_TEMPLATE="$FMT_DIR" bash "$changelog_script"
 
     local manifest_script="$FMT_DIR/generate-manifest.sh"
     if [[ -f "$manifest_script" ]]; then

--- a/scripts/settings-promote.sh
+++ b/scripts/settings-promote.sh
@@ -116,7 +116,7 @@ if ! bash "$FMT_DIR/scripts/validate-fmt-scripts.sh" --settings-json; then
 fi
 
 CHANGELOG_SCRIPT="$FMT_DIR/scripts/changelog-append.sh"
-if [[ -f "$CHANGELOG_SCRIPT" ]]; then bash "$CHANGELOG_SCRIPT"; fi
+if [[ -f "$CHANGELOG_SCRIPT" ]]; then IWE_TEMPLATE="$FMT_DIR" bash "$CHANGELOG_SCRIPT"; fi
 
 echo "✅ Зарегистрирован: $HOOK_PATH → $EVENT"
 echo "Следующий шаг:"

--- a/scripts/skill-promote.sh
+++ b/scripts/skill-promote.sh
@@ -229,7 +229,7 @@ if [[ -f "$CATALOG_SCRIPT" ]]; then
 fi
 
 CHANGELOG_SCRIPT="$FMT_DIR/scripts/changelog-append.sh"
-if [[ -f "$CHANGELOG_SCRIPT" ]]; then bash "$CHANGELOG_SCRIPT"; fi
+if [[ -f "$CHANGELOG_SCRIPT" ]]; then IWE_TEMPLATE="$FMT_DIR" bash "$CHANGELOG_SCRIPT"; fi
 
 # ── Шаг 8. Запись в promotion-status.yaml (WP-7/PZ-6) ────────────────────────
 PROMOTE_COMMON="$FMT_DIR/scripts/promote-common.sh"

--- a/scripts/tests/test_skill_promote.py
+++ b/scripts/tests/test_skill_promote.py
@@ -91,14 +91,28 @@ def make_test_skill(tmp_path: Path, name: str = "test-skill") -> Path:
     return skill_dir
 
 
-def run_promote(skill_src: Path, tmp_fmt: Path, dry_run: bool = False) -> subprocess.CompletedProcess:
+def run_promote(
+    skill_src: Path,
+    tmp_fmt: Path,
+    dry_run: bool = False,
+    explicit_template: bool = True,
+) -> subprocess.CompletedProcess:
     """Запускает skill-promote.sh в изолированном окружении."""
     env = os.environ.copy()
     tmp_iwe = tmp_fmt.parent / "iwe"
     tmp_iwe.mkdir(parents=True, exist_ok=True)
     (tmp_iwe / ".claude" / "skills").mkdir(parents=True, exist_ok=True)
     env["IWE_WORKSPACE"] = str(tmp_iwe)
-    env["IWE_TEMPLATE"] = str(tmp_fmt)
+    if explicit_template:
+        env["IWE_TEMPLATE"] = str(tmp_fmt)
+        expected_changelog_target = tmp_fmt
+    else:
+        env.pop("IWE_TEMPLATE", None)
+        fallback_template = tmp_iwe / "FMT-exocortex-template"
+        if not fallback_template.exists():
+            fallback_template.symlink_to(tmp_fmt, target_is_directory=True)
+        expected_changelog_target = fallback_template
+    env["EXPECTED_CHANGELOG_TARGET"] = str(expected_changelog_target)
     # Pin HOME so the personal-path substitution ($HOME/IWE -> ${IWE:-$HOME/IWE}) has a
     # deterministic match for the /Users/testuser/IWE paths the fixtures hard-code,
     # independent of the runner's real HOME (/home/runner in CI, /Users/<dev> locally).
@@ -170,3 +184,114 @@ def test_git_status_warning_when_dirty(isolated_env):
     result = run_promote(skill_src, tmp_fmt)
     assert result.returncode == 0, result.stderr + result.stdout
     assert "FMT-репо имеет незакоммиченные изменения" in result.stdout
+
+
+def test_real_promote_passes_fallback_target_explicitly_to_changelog(isolated_env):
+    skill_src, tmp_fmt = isolated_env
+    (tmp_fmt / "scripts" / "changelog-append.sh").write_text(
+        """#!/usr/bin/env bash
+if [[ "${IWE_TEMPLATE:-}" != "${EXPECTED_CHANGELOG_TARGET:-}" ]]; then
+    echo "wrong changelog target: ${IWE_TEMPLATE:-unset}" >&2
+    exit 91
+fi
+echo "TARGET_HANDOFF_OK"
+""",
+        encoding="utf-8",
+    )
+
+    result = run_promote(skill_src, tmp_fmt, explicit_template=False)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "TARGET_HANDOFF_OK" in result.stdout
+
+
+def make_changelog_worktrees(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Create a canonical clone and a linked worktree containing the helper."""
+    fake_home = tmp_path / "home"
+    canonical = fake_home / "IWE" / "FMT-exocortex-template"
+    canonical.mkdir(parents=True)
+    shutil.copy2(FMT_ROOT / "scripts" / "changelog-append.sh", canonical / "changelog-append.sh")
+    (canonical / "CHANGELOG.md").write_text(CHANGELOG_HEADER, encoding="utf-8")
+    (canonical / "feature.txt").write_text("candidate\n", encoding="utf-8")
+
+    subprocess.run(["git", "init", "-q", str(canonical)], check=True)
+    subprocess.run(["git", "-C", str(canonical), "add", "--", "CHANGELOG.md", "changelog-append.sh", "feature.txt"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(canonical),
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-q",
+            "-m",
+            "feat: changelog target fixture",
+        ],
+        check=True,
+    )
+
+    isolated = tmp_path / "isolated-worktree"
+    subprocess.run(
+        ["git", "-C", str(canonical), "worktree", "add", "-q", "-b", "isolated-test", str(isolated)],
+        check=True,
+    )
+    return fake_home, canonical, isolated
+
+
+def run_changelog(script: Path, fake_home: Path, *args: str, target: Path | None = None) -> subprocess.CompletedProcess:
+    """Run changelog-append without inheriting an author's checkout variables."""
+    env = os.environ.copy()
+    env.pop("IWE_TEMPLATE", None)
+    env.pop("IWE_WORKSPACE", None)
+    env["HOME"] = str(fake_home)
+    if target is not None:
+        env["IWE_TEMPLATE"] = str(target)
+    return subprocess.run(
+        ["bash", str(script), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_changelog_append_write_without_explicit_template_fails_closed(tmp_path):
+    fake_home, canonical, isolated = make_changelog_worktrees(tmp_path)
+    canonical_before = (canonical / "CHANGELOG.md").read_bytes()
+    isolated_before = (isolated / "CHANGELOG.md").read_bytes()
+
+    result = run_changelog(isolated / "changelog-append.sh", fake_home)
+
+    assert result.returncode == 2
+    assert "IWE_TEMPLATE=/path/to/FMT" in result.stderr
+    assert (canonical / "CHANGELOG.md").read_bytes() == canonical_before
+    assert (isolated / "CHANGELOG.md").read_bytes() == isolated_before
+
+
+def test_changelog_append_dry_run_without_template_warns_and_preserves_files(tmp_path):
+    fake_home, canonical, isolated = make_changelog_worktrees(tmp_path)
+    canonical_before = (canonical / "CHANGELOG.md").read_bytes()
+    isolated_before = (isolated / "CHANGELOG.md").read_bytes()
+
+    result = run_changelog(isolated / "changelog-append.sh", fake_home, "--dry-run")
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "dry-run читает fallback" in result.stderr
+    assert (canonical / "CHANGELOG.md").read_bytes() == canonical_before
+    assert (isolated / "CHANGELOG.md").read_bytes() == isolated_before
+
+
+def test_changelog_append_explicit_template_updates_only_target(tmp_path):
+    fake_home, canonical, isolated = make_changelog_worktrees(tmp_path)
+    canonical_before = (canonical / "CHANGELOG.md").read_bytes()
+    isolated_before = (isolated / "CHANGELOG.md").read_bytes()
+
+    result = run_changelog(isolated / "changelog-append.sh", fake_home, target=isolated)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert (canonical / "CHANGELOG.md").read_bytes() == canonical_before
+    assert (isolated / "CHANGELOG.md").read_bytes() != isolated_before
+    assert "## [Unreleased]" in (isolated / "CHANGELOG.md").read_text(encoding="utf-8")

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -765,7 +765,7 @@
     },
     {
       "path": "CHANGELOG.md",
-      "sha256": "bcb3abc9c2e6ab3003411e6125791419d10791346c876fa3e47461ac31d20f43"
+      "sha256": "a24abd1e011dcfe38bc3b43c057a34515f711459ea770b54f2a421092146d556"
     },
     {
       "path": "CLAUDE.md",
@@ -2001,7 +2001,7 @@
     },
     {
       "path": "scripts/changelog-append.sh",
-      "sha256": "c559e833e45c8c68e0386971f5518e05c943992d40c4b7cf5a3cdf0b3294a1ac"
+      "sha256": "53fd0abc41b738a69f9e85607c09918f552fe8eb071404b098706bf7f1514884"
     },
     {
       "path": "scripts/changelog-diff-lines.sh",
@@ -2009,7 +2009,7 @@
     },
     {
       "path": "scripts/changelog-flush.sh",
-      "sha256": "0b20d2a3e268c49ed6ad5098c5d847486de46997993f9523ffbc665da434bcb7"
+      "sha256": "853e53618ac0776ba23cbbbdba051a26110004f0b1c4efdac49f4725253e69eb"
     },
     {
       "path": "scripts/check-claude-md-links.py",
@@ -2245,7 +2245,7 @@
     },
     {
       "path": "scripts/hook-promote.sh",
-      "sha256": "6f4b6a151d5b2ae0f6c251ead840321bad1decbebfccca0fcc54a60bfbad4d48"
+      "sha256": "9279d09adf07d3fe065b71d4292808888c0a6f20c8256d769cfceb0ef9172d4c"
     },
     {
       "path": "scripts/hot-files.list",
@@ -2469,7 +2469,7 @@
     },
     {
       "path": "scripts/script-promote.sh",
-      "sha256": "769bf6c659d27ef4b6775db03bbf3ed880bfdf85f9ace2243b8a7d4d9a425e5a"
+      "sha256": "1d92da239f78e9225a7a2f651c977ce5956050d52576ebb066429fe336f43da9"
     },
     {
       "path": "scripts/server-calendar.sh",
@@ -2485,7 +2485,7 @@
     },
     {
       "path": "scripts/settings-promote.sh",
-      "sha256": "20b3e2bdadc0439b5920f5f788a04794b14e21d89a38a1f23901bd020fa80df8"
+      "sha256": "1ac13a8ed2345257c53f4fb3ce5f37637663bfaf3e321d651087066dc61f0082"
     },
     {
       "path": "scripts/setup-extractor-feeders.sh",
@@ -2493,7 +2493,7 @@
     },
     {
       "path": "scripts/skill-promote.sh",
-      "sha256": "59c22f6dbea6a85fac523693b351e807a9d115c795b2aa3f4ac0cf5571b58511"
+      "sha256": "b3f0a897e18ed6294f23b33dc408794a1594afcc1a08d611f00c408b63c90512"
     },
     {
       "path": "scripts/skills-pull.sh",


### PR DESCRIPTION
## Что исправлено

- режим записи `changelog-append.sh` теперь требует явную цель `IWE_TEMPLATE` и не может молча изменить канонический checkout из изолированного worktree;
- четыре штатных promote-скрипта явно передают уже выбранную цель;
- dry-run сохраняет безопасный fallback с заметным предупреждением;
- регрессия воспроизводится настоящей парой canonical checkout + linked worktree и включена в обязательный CI;
- обновлены CHANGELOG и хеши манифеста.

Контекст: WP-545, пир-сессия Codex + Kimi `2026-09-03-02-wp529-template-sync-tsekh1`.

## Проверки

- 8 pytest-сценариев прошли;
- Bash syntax и ShellCheck error-level прошли;
- validate-fmt-scripts прошёл;
- verify-manifest прошёл;
- validate-template прошёл;
- два независимых холодных ревью: APPROVE.
