### PR TITLE
fix(paths): resolve workspace/template paths for non-default installs

### DIFF
--- a/.claude/scripts/memory-drift-scan.py
+++ b/.claude/scripts/memory-drift-scan.py
@@ -220,17 +220,30 @@ def scan(memory_path: Path, governance_repo: Path) -> list[str]:
     return drifts
 
 
+def _default_workspace() -> Path:
+    """Resolve the workspace root the same way the shell tooling does
+    (iwe-env-bootstrap.sh): explicit env var wins, ~/IWE is only a last
+    resort. Without this, an install at a non-default path always fails
+    with "MEMORY.md не найден" (issue #638)."""
+    for var in ("IWE_WORKSPACE", "IWE_ROOT", "WORKSPACE_DIR"):
+        value = os.environ.get(var)
+        if value:
+            return Path(value)
+    return Path.home() / "IWE"
+
+
 def main() -> int:
+    workspace = _default_workspace()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--memory",
         type=Path,
-        default=Path.home() / "IWE" / "memory" / "MEMORY.md",
+        default=workspace / "memory" / "MEMORY.md",
     )
     parser.add_argument(
         "--governance-repo",
         type=Path,
-        default=Path.home() / "IWE" / os.environ.get("IWE_GOVERNANCE_REPO", "DS-strategy"),
+        default=workspace / os.environ.get("IWE_GOVERNANCE_REPO", "DS-strategy"),
     )
     args = parser.parse_args()
 

--- a/scripts/day-open-checks-runner.sh
+++ b/scripts/day-open-checks-runner.sh
@@ -13,6 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/lib/day-open-hooks.sh"
 
 IWE="${IWE_ROOT:-$HOME/IWE}"
+IWE_TEMPLATE="${IWE_TEMPLATE:-$IWE/FMT-exocortex-template}"
 EXT_DIR="$IWE/extensions"
 DAYPLAN="${1:-}"
 
@@ -37,8 +38,24 @@ export IWE
 CHECKS_FILES=$(find_day_open_hook_files "$EXT_DIR" "checks")
 FIND_STATUS=$?
 
+# extensions/ is deliberately empty until the user adds a customization
+# (extensions/README.md: "update.sh never touches this dir") — setup.sh does
+# not seed it, so a fresh install has no $EXT_DIR/day-open.checks*.md at all.
+# The template still ships its own universal-invariant default (WP-529 Ф7);
+# fall back to it ONLY when the workspace copy has nothing, so a pilot who
+# has customized their own extensions/day-open.checks.md keeps using theirs
+# unchanged (issue #635).
 if [ "$FIND_STATUS" -ne 0 ] || [ -z "$CHECKS_FILES" ]; then
-  echo "❌ day-open-checks-runner: no day-open.checks*.md found in $EXT_DIR — nothing to check"
+  TEMPLATE_EXT_DIR="$IWE_TEMPLATE/extensions"
+  CHECKS_FILES=$(find_day_open_hook_files "$TEMPLATE_EXT_DIR" "checks")
+  FIND_STATUS=$?
+  if [ "$FIND_STATUS" -eq 0 ] && [ -n "$CHECKS_FILES" ]; then
+    echo "  ℹ️  $EXT_DIR has no day-open.checks*.md — using template default from $TEMPLATE_EXT_DIR"
+  fi
+fi
+
+if [ "$FIND_STATUS" -ne 0 ] || [ -z "$CHECKS_FILES" ]; then
+  echo "❌ day-open-checks-runner: no day-open.checks*.md found in $EXT_DIR or $IWE_TEMPLATE/extensions — nothing to check"
   exit 1
 fi
 

--- a/scripts/route-task.sh
+++ b/scripts/route-task.sh
@@ -18,6 +18,7 @@
 set -euo pipefail
 
 IWE_DIR="${IWE_DIR:-$HOME/IWE}"
+IWE_TEMPLATE="${IWE_TEMPLATE:-$IWE_DIR/FMT-exocortex-template}"
 GOV_REPO="${IWE_GOVERNANCE_REPO:-DS-strategy}"
 CATALOG="${IWE_EXECUTOR_CATALOG:-${IWE_DIR}/${GOV_REPO}/scripts/executor-catalog.yaml}"
 AUDIT_LOG="${IWE_ROUTER_AUDIT:-${IWE_DIR}/${GOV_REPO}/logs/routing-path-distribution.tsv}"
@@ -163,9 +164,11 @@ run_script() {
     local allow_fallback="${4:-true}"
     local routing_path="${5:-$skill_name → script}"
 
-    # Resolve relative path from IWE_DIR
+    # executor-catalog.yaml is generated from template SKILL.md frontmatter,
+    # so relative script_path is relative to the template root, not the
+    # workspace root (issue #634).
     if [[ "$script_path" != /* ]]; then
-        script_path="$IWE_DIR/$script_path"
+        script_path="$IWE_TEMPLATE/$script_path"
     fi
 
     if [[ ! -f "$script_path" ]]; then

--- a/scripts/tests/test_issue_533_agent_fault_delivery.py
+++ b/scripts/tests/test_issue_533_agent_fault_delivery.py
@@ -1429,12 +1429,12 @@ def test_real_route_records_multi_token_russian_fault_exactly(tmp_path: Path):
     workspace, governance_dir = _install_seed(tmp_path, "DS-custom")
     catalog = governance_dir / "scripts" / "executor-catalog.yaml"
     _write_catalog(catalog, _skill_script_path())
-    # route-task.sh resolves a relative script_path against IWE_DIR (the
-    # synthetic workspace here), not IWE_SCRIPTS — mirror that layout by
-    # installing the real skill script where a genuine deployment would have
-    # it, same pattern as _install_workspace_cli() below.
+    # route-task.sh resolves a relative script_path against IWE_TEMPLATE
+    # (defaults to $IWE_DIR/FMT-exocortex-template, issue #634 fix) - mirror
+    # that nested layout, same pattern used by
+    # test_protocol_extensions_execute_cli_from_template_runtime above.
     real_skill_script = ROOT / _skill_script_path()
-    installed_skill_script = workspace / _skill_script_path()
+    installed_skill_script = workspace / "FMT-exocortex-template" / _skill_script_path()
     installed_skill_script.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(real_skill_script, installed_skill_script)
     fault = "агент потерял многословное русское описание ошибки"

--- a/seed/strategy/scripts/day-open-checks-runner.sh
+++ b/seed/strategy/scripts/day-open-checks-runner.sh
@@ -14,6 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/lib/day-open-hooks.sh"
 
 IWE="${IWE_ROOT:-$HOME/IWE}"
+IWE_TEMPLATE="${IWE_TEMPLATE:-$IWE/FMT-exocortex-template}"
 EXT_DIR="$IWE/extensions"
 DAYPLAN="${1:-}"
 
@@ -38,8 +39,24 @@ export IWE
 CHECKS_FILES=$(find_day_open_hook_files "$EXT_DIR" "checks")
 FIND_STATUS=$?
 
+# extensions/ is deliberately empty until the user adds a customization
+# (extensions/README.md: "update.sh never touches this dir") — setup.sh does
+# not seed it, so a fresh install has no $EXT_DIR/day-open.checks*.md at all.
+# The template still ships its own universal-invariant default (WP-529 Ф7);
+# fall back to it ONLY when the workspace copy has nothing, so a pilot who
+# has customized their own extensions/day-open.checks.md keeps using theirs
+# unchanged (issue #635).
 if [ "$FIND_STATUS" -ne 0 ] || [ -z "$CHECKS_FILES" ]; then
-  echo "❌ day-open-checks-runner: no day-open.checks*.md found in $EXT_DIR — nothing to check"
+  TEMPLATE_EXT_DIR="$IWE_TEMPLATE/extensions"
+  CHECKS_FILES=$(find_day_open_hook_files "$TEMPLATE_EXT_DIR" "checks")
+  FIND_STATUS=$?
+  if [ "$FIND_STATUS" -eq 0 ] && [ -n "$CHECKS_FILES" ]; then
+    echo "  ℹ️  $EXT_DIR has no day-open.checks*.md — using template default from $TEMPLATE_EXT_DIR"
+  fi
+fi
+
+if [ "$FIND_STATUS" -ne 0 ] || [ -z "$CHECKS_FILES" ]; then
+  echo "❌ day-open-checks-runner: no day-open.checks*.md found in $EXT_DIR or $IWE_TEMPLATE/extensions — nothing to check"
   exit 1
 fi
 

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2677,7 +2677,7 @@
     },
     {
       "path": "scripts/tests/test_issue_533_agent_fault_delivery.py",
-      "sha256": "521093c91327e96abbf67f28d367a40788f638f543a0dfcc7162858b831b39fd"
+      "sha256": "749983afa7e82590c905615fb002a148b277bb02657e82efb147c1c189d5a358"
     },
     {
       "path": "scripts/tests/test_issue_536_day_close_backup.sh",

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -269,7 +269,7 @@
     },
     {
       "path": ".claude/scripts/memory-drift-scan.py",
-      "sha256": "8c0b5d81add179ca03aa3e590a33a9b92c36b97b49d9030f0c2eba808a29fea0"
+      "sha256": "65200a4f0e2f496d59c9206840cdb323eeb3e7e66fdbbc05a0612975af26f33c"
     },
     {
       "path": ".claude/scripts/settings-merge-apply.sh",
@@ -2129,7 +2129,7 @@
     },
     {
       "path": "scripts/day-open-checks-runner.sh",
-      "sha256": "e6e03924c9fd59cceb5104e1ef240b1a99233138e4789d66a9de1cc64fa2cefd"
+      "sha256": "b16b1357161a0a94ac855541f94cef7016d708a38d69c37af1a157b8ec6d19bf"
     },
     {
       "path": "scripts/day-open-close-error-patch.py",
@@ -2461,7 +2461,7 @@
     },
     {
       "path": "scripts/route-task.sh",
-      "sha256": "e82346bbb334e2bcce42b24546282a886e31648ece8a19b0b6777bab9eb8fe69"
+      "sha256": "b1b6c165cf378ced7c5a9b2b69c84b0b70d98ff57c8fd3e81f7c60b05b642b44"
     },
     {
       "path": "scripts/run-regression-tests.sh",


### PR DESCRIPTION
## Summary

Three external-user bug reports (#634, #635, #638) traced to the same root cause: scripts assumed the author's own topology (workspace at `~/IWE`, single install) instead of using the workspace/template split that already exists elsewhere in the platform (`.claude/lib/iwe-env-bootstrap.sh`).

- **route-task.sh** (#634): `script_path` from `executor-catalog.yaml` is relative to the template root (generated from template `SKILL.md` frontmatter), not the workspace root — now resolves against `IWE_TEMPLATE`.
- **day-open-checks-runner.sh** (#635, EXT_DIR part): `extensions/` is deliberately empty until a user customizes it (`update.sh` never touches it per `extensions/README.md`), so a fresh install has no `day-open.checks*.md` there and every Day Open commit was blocked with "nothing to check". Falls back to the template's own default checks (WP-529 Ф7) only when the workspace copy has nothing — an already-customized `extensions/day-open.checks.md` is untouched.
- **memory-drift-scan.py** (#638): default `--memory`/`--governance-repo` paths now resolve via `IWE_WORKSPACE`/`IWE_ROOT`/`WORKSPACE_DIR` before falling back to `~/IWE`, instead of hardcoding it.

**Not included:** the H1-check part of #635 (frontmatter incompatibility) — the current `extensions/day-open.checks.md` already uses `grep -m1 '^# '`, which is frontmatter-compatible, not the `head -1 | grep` pattern the issue describes. No change needed unless the reporter confirms it reproduces on the current file.

**Not included:** #636 (Day Open self-development topic UX gap) and #637 (day-close backup / Claude project key) — routed to РП-484 queue, not path-resolution bugs. #633 (extractor.sh hardcoded `main` branch) — routed to РП-5 (extractor owner), git-branch config, not a path bug.

## Test plan

- [x] `bash -n` syntax check on both shell scripts
- [x] `python3 -c "compile(...)"` on the Python script
- [x] Live regression run of `day-open-checks-runner.sh` on an installation with a customized `extensions/day-open.checks.md` (22 checks) — unchanged, fallback not triggered
- [x] Live simulated fresh-install run (empty `extensions/`) — falls back to template default, 3 checks pass instead of blocking with exit 1
- [x] Live run of `route-task.sh --skill agent-fault` — script now found and executed instead of falling back to Haiku
- [x] Live run of `memory-drift-scan.py` with `IWE_WORKSPACE` set — no longer fails with "MEMORY.md не найден"
- [x] Cold-context code review (independent subagent) — no Critical/High/Medium findings

Refs: peer-session `2026-09-03-04-bot-signals-wp484-wp560` (Kimi + Codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)