### PR TITLE
fix(extractor): resolve governance branch instead of hardcoding main (#633)

### DIFF
--- a/roles/extractor/scripts/extractor.sh
+++ b/roles/extractor/scripts/extractor.sh
@@ -282,11 +282,37 @@ extractor_scope_close() {  # <strategy_dir> <agent> <reason>
     bash "$guard" close --housekeeping "$reason" --agent "$agent" >> "$LOG_FILE" 2>&1
 }
 
+# issue #633: 'main' used to be hardcoded as the governance repo's default
+# branch in eight places across this file. A repo whose real default branch
+# is something else (e.g. master) silently never got fetched/pushed/read --
+# inbox-check exited immediately on every run, no capture ever processed.
+# Resolve it once per repo, in order: explicit override -> the repo's real
+# remote-tracking default -> whatever is currently checked out -> the
+# historical 'main' default as a last resort (keeps old repos working
+# unchanged).
+resolve_governance_branch() {
+    local repo="$1"
+    if [ -n "${IWE_GOVERNANCE_BRANCH:-}" ]; then
+        printf '%s\n' "$IWE_GOVERNANCE_BRANCH"
+        return 0
+    fi
+    local ref
+    if ref=$(git -C "$repo" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null); then
+        printf '%s\n' "${ref#origin/}"
+        return 0
+    fi
+    if ref=$(git -C "$repo" branch --show-current 2>/dev/null) && [ -n "$ref" ]; then
+        printf '%s\n' "$ref"
+        return 0
+    fi
+    printf '%s\n' "main"
+}
+
 commit_extractor_changes() {
     local strategy_dir="$1"
     local repo_name="$2"
     local commit_mode="${3:-main}"
-    local branch head_before head_after target_changes
+    local branch head_before head_after target_changes gov_branch
 
     EXTRACTOR_COMMIT_RESULT=""
 
@@ -295,9 +321,10 @@ commit_extractor_changes() {
         EXTRACTOR_COMMIT_RESULT="blocked"
         return 0
     fi
-    if [ "$branch" != "main" ] && \
+    gov_branch=$(resolve_governance_branch "$strategy_dir")
+    if [ "$branch" != "$gov_branch" ] && \
        { [ "$commit_mode" != "isolated-inbox" ] || [[ "$branch" != extractor/inbox-check-* ]]; }; then
-        log "SKIP: $repo_name is on branch '$branch', expected 'main'"
+        log "SKIP: $repo_name is on branch '$branch', expected '$gov_branch'"
         EXTRACTOR_COMMIT_RESULT="blocked"
         return 0
     fi
@@ -396,7 +423,7 @@ commit_extractor_changes() {
     local publish_gate="$strategy_dir/scripts/lib/publish-gate.sh"
     if [ ! -f "$publish_gate" ]; then
         log "WARN: publish-gate.sh not found at $publish_gate; falling back to raw push for $repo_name"
-        if git -C "$strategy_dir" push origin "$head_after:refs/heads/main" >> "$LOG_FILE" 2>&1; then
+        if git -C "$strategy_dir" push origin "$head_after:refs/heads/$gov_branch" >> "$LOG_FILE" 2>&1; then
             log "Pushed $repo_name ($head_after)"
             EXTRACTOR_COMMIT_RESULT="published"
         else
@@ -535,7 +562,7 @@ run_inbox_check_isolated() {
     local repo_name="${IWE_GOVERNANCE_REPO:-DS-strategy}"
     local canonical_repo="$canonical_workspace/$repo_name"
     local lock_dir="${IWE_EXTRACTOR_INBOX_LOCK_DIR:-${TMPDIR:-/tmp}/iwe-extractor-inbox-check.lock}"
-    local run_root worktree isolated_workspace branch_name run_id isolated_template actual_pending
+    local run_root worktree isolated_workspace branch_name run_id isolated_template actual_pending gov_branch
 
     case "$repo_name" in
         ""|.*|*/*)
@@ -551,8 +578,9 @@ run_inbox_check_isolated() {
         return 0
     fi
 
-    if ! git -C "$canonical_repo" fetch origin main >> "$LOG_FILE" 2>&1; then
-        log "WARN: cannot refresh origin/main; isolated inbox-check was not started"
+    gov_branch=$(resolve_governance_branch "$canonical_repo")
+    if ! git -C "$canonical_repo" fetch origin "$gov_branch" >> "$LOG_FILE" 2>&1; then
+        log "WARN: cannot refresh origin/$gov_branch; isolated inbox-check was not started"
         release_inbox_lock "$lock_dir"
         return 1
     fi
@@ -568,12 +596,12 @@ run_inbox_check_isolated() {
     branch_name="extractor/inbox-check-$run_id"
     isolated_template="${IWE_TEMPLATE:-$canonical_workspace/FMT-exocortex-template}"
 
-    if ! git -C "$canonical_repo" worktree add -b "$branch_name" "$worktree" origin/main >> "$LOG_FILE" 2>&1; then
+    if ! git -C "$canonical_repo" worktree add -b "$branch_name" "$worktree" "origin/$gov_branch" >> "$LOG_FILE" 2>&1; then
         log "WARN: cannot create isolated inbox-check worktree; run directory preserved: $run_root"
         release_inbox_lock "$lock_dir"
         return 1
     fi
-    git -C "$worktree" branch --set-upstream-to=origin/main "$branch_name" >> "$LOG_FILE" 2>&1 || true
+    git -C "$worktree" branch --set-upstream-to="origin/$gov_branch" "$branch_name" >> "$LOG_FILE" 2>&1 || true
 
     if ! mkdir "$isolated_workspace" || \
        ! ln -s "$worktree" "$isolated_workspace/$repo_name" || \

--- a/scripts/tests/test_issue_633_resolve_governance_branch.sh
+++ b/scripts/tests/test_issue_633_resolve_governance_branch.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Regression test for issue #633: extractor.sh hardcoded 'main' as the
+# governance repo's default branch in eight places, so inbox-check silently
+# never ran on a repo whose real default branch was e.g. 'master'.
+#
+# Extracts resolve_governance_branch() straight out of the real extractor.sh
+# (instead of sourcing the whole file) because that file guards against
+# direct execution from the raw FMT checkout and requires a built runtime
+# with an authenticated claude CLI -- neither of which this test needs.
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/roles/extractor/scripts/extractor.sh"
+FUNC_SRC=$(awk '/^resolve_governance_branch\(\) \{/,/^}/' "$SCRIPT")
+if [ -z "$FUNC_SRC" ]; then
+    echo "FAIL: resolve_governance_branch() not found in $SCRIPT"
+    exit 1
+fi
+eval "$FUNC_SRC"
+
+FAIL=0
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+git init -q -b master "$TMP/bare-src"
+git -C "$TMP/bare-src" config user.email "test@example.invalid"
+git -C "$TMP/bare-src" config user.name "Issue 633 regression"
+git -C "$TMP/bare-src" commit -q --allow-empty -m init
+git clone -q "$TMP/bare-src" "$TMP/clone"
+resolved=$(unset IWE_GOVERNANCE_BRANCH; resolve_governance_branch "$TMP/clone")
+if [ "$resolved" = "master" ]; then
+    echo "PASS: resolves 'master' from origin/HEAD when no override is set"
+else
+    echo "FAIL: expected 'master', got '$resolved'"
+    FAIL=1
+fi
+
+git init -q -b main "$TMP/main-repo"
+resolved=$(IWE_GOVERNANCE_BRANCH=custom resolve_governance_branch "$TMP/main-repo")
+if [ "$resolved" = "custom" ]; then
+    echo "PASS: IWE_GOVERNANCE_BRANCH override takes precedence"
+else
+    echo "FAIL: expected 'custom', got '$resolved'"
+    FAIL=1
+fi
+
+git init -q -b feature-x "$TMP/no-remote"
+resolved=$(unset IWE_GOVERNANCE_BRANCH; resolve_governance_branch "$TMP/no-remote")
+if [ "$resolved" = "feature-x" ]; then
+    echo "PASS: falls back to the checked-out branch when there is no origin/HEAD"
+else
+    echo "FAIL: expected 'feature-x', got '$resolved'"
+    FAIL=1
+fi
+
+exit $FAIL

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1641,7 +1641,7 @@
     },
     {
       "path": "roles/extractor/scripts/extractor.sh",
-      "sha256": "212a74c11af1882a763fb3d857878bde54030a5ce6f795532f2a927ad645e29b"
+      "sha256": "7bcf1d6bc39ef4d5dac790504c85aac61c8ee5cb215a6d25d43f0cf8d05c69a4"
     },
     {
       "path": "roles/extractor/scripts/launchd/com.extractor.inbox-check.plist",
@@ -2932,6 +2932,7 @@
     "scripts/tests/test_issue_583_dayopen_yaml.sh",
     "scripts/tests/test_issue_584_build_version.sh",
     "scripts/tests/test_issue_596_weekreport_filename.sh",
+    "scripts/tests/test_issue_633_resolve_governance_branch.sh",
     "scripts/tests/test_issue_python_resolver_contract.sh",
     "scripts/tests/test_manifest_coverage_local.py",
     "scripts/tests/test_pending_phases_sweep.sh",


### PR DESCRIPTION
## Summary
- `extractor.sh` hardcoded the governance repo's default branch as literally `main` in eight places (commit-mismatch check, its log message, a raw-push fallback, and the isolated inbox-check worktree flow's fetch/worktree-add/upstream). On a repo whose real default branch is something else (e.g. `master`), the pipeline silently never processed a single capture. Filed live by an external template user with a full repro — closes #633.
- Added `resolve_governance_branch()`: explicit `IWE_GOVERNANCE_BRANCH` override → the repo's real `origin/HEAD` (set automatically by `git clone`) → the currently checked-out branch → the historical `main` literal as a last resort.

## Test plan
- [x] `scripts/tests/test_issue_633_resolve_governance_branch.sh` — new regression test (named to match `run-issue-tests.sh`'s `test_issue_*` glob so it actually runs in CI), exercises all three resolution paths against real throwaway git repos
- [x] `shellcheck -S error` — 0 issues (both the modified file and the new test)
- [x] Cold-context code review (independent subagent) — found 2 Critical issues (test not wired into CI's runner, missing git identity config for a clean CI runner), both fixed and re-verified before this PR

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)
