### PR TITLE
feat(extractor): mount Packs read-only in isolated inbox-check sandbox (WP-5)

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -679,6 +679,13 @@ jobs:
       - name: Test the orphan-hook guard itself (marker + allowlist + real orphan)
         run: bash scripts/tests/test_check_orphan_hooks.sh
 
+      # АрхГейт 03.09 (WP-5): изолированная песочница inbox-check теперь
+      # монтирует Pack-репозитории для проверки дублей — read-only должен быть
+      # реальным (файловая система), не только текстом промпта, иначе тот же
+      # класс дыры, что в bug-2026-07-07-r15-decisions-bypassed-pilot.md.
+      - name: Test read-only Pack mount is filesystem-enforced
+        run: bash scripts/tests/test_mount_readonly_packs.sh
+
       # WP-529 Ф6 (находки Евгения 18.08): PyYAML — заявленная зависимость
       # (requirements.txt, #463), но CI её не гарантировал, а вся семья
       # scripts/tests/test_issue_*.sh лежала в репо не подключённой — тот же

--- a/roles/extractor/scripts/extractor.sh
+++ b/roles/extractor/scripts/extractor.sh
@@ -489,6 +489,19 @@ cleanup_isolated_inbox_worktree() {
         log "WARN: published inbox-check branch was preserved for review: $branch_name"
     fi
 
+    # Read-only Pack clones (see mount_readonly_packs()) are chmod a-w
+    # recursively, including the directories themselves -- removing entries
+    # from a directory needs write permission on that directory, so restore
+    # it (owner-only, u+w) before rm -rf, or cleanup silently fails and the
+    # final rmdir below leaves the whole run_root behind as a "cannot remove"
+    # WARN forever.
+    local pack_clone
+    for pack_clone in "$isolated_workspace"/PACK-*; do
+        [ -d "$pack_clone" ] || continue
+        chmod -R u+w "$pack_clone" 2>/dev/null
+        rm -rf "$pack_clone"
+    done
+
     rm -f "$isolated_workspace/$repo_name" \
         "$isolated_workspace/FMT-exocortex-template/roles/extractor/config/routing.md" \
         "$isolated_workspace/FMT-exocortex-template/roles/extractor/prompts/session-close.md"
@@ -499,6 +512,36 @@ cleanup_isolated_inbox_worktree() {
     rmdir "$isolated_workspace/FMT-exocortex-template" 2>/dev/null || true
     rmdir "$isolated_workspace" 2>/dev/null || log "WARN: cannot remove isolated workspace shell: $isolated_workspace"
     rmdir "$run_root" 2>/dev/null || log "WARN: cannot remove isolated run directory: $run_root"
+}
+
+# AR-gate 03.09 (архгейт, см. bug-2026-07-07-r15-decisions-bypassed-pilot.md):
+# inbox-check.md never writes into a Pack -- headless steps only ever vote
+# accept/reject/defer into the report, the actual write happens exclusively
+# in the separate, pilot-triggered "Применение отчёта" session. Mounting
+# Packs here only lets the headless vote be an informed one (duplicate/
+# bounded-context checks Step 2d already requires) instead of blanket defer
+# for "not mounted". Read-only is enforced by the filesystem (chmod), not
+# prompt wording -- run_claude launches Claude with
+# --dangerously-skip-permissions and Write/Edit in --allowedTools, so a
+# prompt-only "don't write here" instruction is not a real control (the
+# exact class of gap the cited bug found in a different skill). Each Pack
+# gets its own disposable shallow clone, never the live checkout, so even a
+# stray write attempt lands on a throwaway copy, not shared state other
+# sessions might be editing concurrently.
+mount_readonly_packs() {
+    local canonical_workspace="$1"
+    local isolated_workspace="$2"
+    local pack_dir pack_name
+    for pack_dir in "$canonical_workspace"/PACK-*; do
+        [ -d "$pack_dir/.git" ] || continue
+        pack_name=$(basename "$pack_dir")
+        if git clone -q --depth 1 --no-tags "$pack_dir" "$isolated_workspace/$pack_name" >> "$LOG_FILE" 2>&1; then
+            chmod -R a-w "$isolated_workspace/$pack_name"
+            log "Mounted read-only Pack for duplicate-check: $pack_name"
+        else
+            log "WARN: could not clone $pack_name for read-only mount; inbox-check will see it as absent"
+        fi
+    done
 }
 
 pending_capture_count() {
@@ -606,6 +649,8 @@ run_inbox_check_isolated() {
         return 0
     fi
     log "Found $actual_pending pending captures in refreshed inbox"
+
+    mount_readonly_packs "$canonical_workspace" "$isolated_workspace"
 
     local WORKSPACE="$isolated_workspace"
     local IWE_WORKSPACE="$isolated_workspace"

--- a/scripts/tests/test_mount_readonly_packs.sh
+++ b/scripts/tests/test_mount_readonly_packs.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Regression test for read-only Pack mounting in the isolated inbox-check
+# sandbox (WP-5, ArchGate 03.09): inbox-check.md never writes into a Pack by
+# design (only the separate, pilot-triggered apply session does) -- but
+# run_claude launches Claude with --dangerously-skip-permissions and
+# Write/Edit tools allowed, so "don't write here" as prompt text alone is
+# not a real control (same gap class as
+# inbox/bugs/bug-2026-07-07-r15-decisions-bypassed-pilot.md). This test
+# verifies the mount is actually read-only at the filesystem level, and that
+# the real cleanup function can still remove it afterward.
+#
+# Extracts the functions straight out of the real extractor.sh (instead of
+# sourcing the whole file, which guards against direct execution from the
+# raw FMT checkout and requires a built runtime) via awk, and calls the real
+# cleanup_isolated_inbox_worktree() -- not a hand-rolled equivalent -- so a
+# regression in its actual pack-removal loop would fail this test (cold
+# review 03.09 found the first version of this test didn't do that).
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/roles/extractor/scripts/extractor.sh"
+extract_fn() {
+    awk -v fn="$1" '$0 ~ "^"fn"\\(\\) \\{" {p=1} p {print} p && /^}/ {exit}' "$SCRIPT"
+}
+MOUNT_FN=$(extract_fn mount_readonly_packs)
+CLEANUP_FN=$(extract_fn cleanup_isolated_inbox_worktree)
+if [ -z "$MOUNT_FN" ]; then
+    echo "FAIL: mount_readonly_packs() not found in $SCRIPT"
+    exit 1
+fi
+if [ -z "$CLEANUP_FN" ]; then
+    echo "FAIL: cleanup_isolated_inbox_worktree() not found in $SCRIPT"
+    exit 1
+fi
+eval "$MOUNT_FN"
+eval "$CLEANUP_FN"
+
+# Both extracted functions call log() and append to $LOG_FILE -- stub both so
+# they run standalone without the rest of extractor.sh.
+LOG_FILE=/dev/null
+log() { :; }
+
+FAIL=0
+TMP=$(mktemp -d)
+trap 'chmod -R u+w "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+WORKSPACE="$TMP/workspace"
+ISOLATED="$TMP/isolated"
+mkdir -p "$WORKSPACE" "$ISOLATED"
+
+git init -q -b main "$WORKSPACE/PACK-test"
+git -C "$WORKSPACE/PACK-test" config user.email "test@example.invalid"
+git -C "$WORKSPACE/PACK-test" config user.name "Pack mount regression"
+echo "original content" > "$WORKSPACE/PACK-test/00-pack-manifest.md"
+git -C "$WORKSPACE/PACK-test" add 00-pack-manifest.md
+git -C "$WORKSPACE/PACK-test" commit -q -m init
+
+mount_readonly_packs "$WORKSPACE" "$ISOLATED"
+
+if [ -f "$ISOLATED/PACK-test/00-pack-manifest.md" ]; then
+    echo "PASS: Pack content is readable in the isolated mount"
+else
+    echo "FAIL: expected $ISOLATED/PACK-test/00-pack-manifest.md to exist"
+    FAIL=1
+fi
+
+if echo "tampered" > "$ISOLATED/PACK-test/00-pack-manifest.md" 2>/dev/null; then
+    echo "FAIL: writing into the mounted Pack succeeded — filesystem is not actually read-only"
+    FAIL=1
+else
+    echo "PASS: writing into the mounted Pack fails at the filesystem level"
+fi
+
+if touch "$ISOLATED/PACK-test/new-file.md" 2>/dev/null; then
+    echo "FAIL: creating a new file inside the mounted Pack succeeded"
+    FAIL=1
+else
+    echo "PASS: creating a new file inside the mounted Pack fails (directory itself is read-only)"
+fi
+
+# Live checkout must be untouched by the mount (it's a clone, not a symlink).
+if [ "$(cat "$WORKSPACE/PACK-test/00-pack-manifest.md")" = "original content" ]; then
+    echo "PASS: the live Pack checkout is untouched"
+else
+    echo "FAIL: the live Pack checkout was modified"
+    FAIL=1
+fi
+
+# Exercise the REAL cleanup_isolated_inbox_worktree() end to end, with the
+# same shape of arguments run_inbox_check_isolated() actually passes it --
+# not a hand-rolled chmod+rm -rf standing in for it.
+GOV_REPO="$WORKSPACE/DS-my-strategy"
+git init -q -b main "$GOV_REPO"
+git -C "$GOV_REPO" config user.email "test@example.invalid"
+git -C "$GOV_REPO" config user.name "Pack mount regression"
+git -C "$GOV_REPO" commit -q --allow-empty -m init
+GOV_WORKTREE="$TMP/run_root/DS-my-strategy"
+mkdir -p "$TMP/run_root"
+git -C "$GOV_REPO" worktree add -q -b extractor/inbox-check-test "$GOV_WORKTREE" main
+
+cleanup_isolated_inbox_worktree "$GOV_REPO" "$GOV_WORKTREE" "extractor/inbox-check-test" \
+    "$ISOLATED" "DS-my-strategy" "$TMP/run_root"
+
+if [ -d "$ISOLATED/PACK-test" ]; then
+    echo "FAIL: cleanup_isolated_inbox_worktree() left the read-only Pack clone behind"
+    FAIL=1
+else
+    echo "PASS: cleanup_isolated_inbox_worktree() removes the read-only Pack clone"
+fi
+
+if [ -d "$ISOLATED" ]; then
+    echo "FAIL: cleanup_isolated_inbox_worktree() left the isolated workspace shell behind"
+    FAIL=1
+else
+    echo "PASS: cleanup_isolated_inbox_worktree() removes the now-empty isolated workspace"
+fi
+
+exit $FAIL

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1641,7 +1641,7 @@
     },
     {
       "path": "roles/extractor/scripts/extractor.sh",
-      "sha256": "212a74c11af1882a763fb3d857878bde54030a5ce6f795532f2a927ad645e29b"
+      "sha256": "c451b60b6f6ce18011007ba19fd232dd23eefe6d7d2391772f62cc6a07d19c66"
     },
     {
       "path": "roles/extractor/scripts/launchd/com.extractor.inbox-check.plist",
@@ -2934,6 +2934,7 @@
     "scripts/tests/test_issue_596_weekreport_filename.sh",
     "scripts/tests/test_issue_python_resolver_contract.sh",
     "scripts/tests/test_manifest_coverage_local.py",
+    "scripts/tests/test_mount_readonly_packs.sh",
     "scripts/tests/test_pending_phases_sweep.sh",
     "scripts/tests/test_release_receipt.sh",
     "scripts/tests/test_residency_gate_skill_adapter.py",


### PR DESCRIPTION
## Summary
- The headless inbox-check sandbox never had access to the actual Pack knowledge-base repositories, so every candidate always fell back to `defer` with "Pack repositories not mounted" — regardless of how clear-cut the candidate actually was, since the duplicate/bounded-context check the prompt's own Step 2d requires was structurally impossible.
- ArchGate review (WP-5, 03.09): full autonomous accept-and-commit into Pack was considered and **rejected** — R15 knowledge-acceptance decisions are an explicit platform principle reserved for a living pilot, with a documented precedent incident (`inbox/bugs/bug-2026-07-07-r15-decisions-bypassed-pilot.md`). That gate is untouched by this PR.
- What ships: `mount_readonly_packs()` clones each `PACK-*` repo (local, depth-1) into the isolated sandbox and `chmod -R a-w`'s it — a real filesystem control, not prompt wording, since `run_claude()` launches Claude with `--dangerously-skip-permissions` and `Write`/`Edit` in `--allowedTools`. The headless report's vote gets better-informed; applying it to Pack stays exclusively the separate, pilot-triggered flow.

## Test plan
- [x] `scripts/tests/test_mount_readonly_packs.sh` (new, wired as explicit CI step) — verifies write and file-creation both fail at the filesystem level on the mounted clone, the live Pack checkout is untouched, and calls the real `cleanup_isolated_inbox_worktree()` end-to-end (not a hand-rolled equivalent)
- [x] Manually reintroduced the exact regression the test targets (commented out the cleanup loop in a scratch copy) — test failed as expected, confirming it's load-bearing
- [x] `shellcheck -S error` — 0 issues
- [x] Cold-context security-focused code review (independent subagent) — 0 Critical; 1 High (test didn't exercise the real cleanup function) fixed and reverified; Medium items are informational (documented in the commit, not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
