### PR TITLE
fix(onboarding): wire Knowledge Extractor into setup.sh (WP-5)

### DIFF
--- a/scripts/migrate-to-runtime-target.sh
+++ b/scripts/migrate-to-runtime-target.sh
@@ -160,7 +160,7 @@ if [ "$DIRTY_COUNT" -gt 0 ]; then
 
         # Unload launchd-агенты (предотвращает запуск битых substituted-скриптов)
         if command -v launchctl >/dev/null 2>&1; then
-            for plist in com.strategist.morning com.strategist.weekreview com.extractor.inbox-check com.exocortex.scheduler; do
+            for plist in com.strategist.morning com.strategist.weekreview com.extractor.inbox-check com.extractor.git-diff-feed com.exocortex.scheduler; do
                 launchctl unload "$HOME/Library/LaunchAgents/${plist}.plist" 2>/dev/null || true
             done
             echo "  ✓ launchd: IWE-агенты выгружены"

--- a/scripts/setup-extractor-feeders.sh
+++ b/scripts/setup-extractor-feeders.sh
@@ -124,12 +124,7 @@ if [ "$PLATFORM" = "Darwin" ]; then
         CLAUDE_BIN_DIR="$(dirname "$(command -v claude)")"
         PLIST_PATH="$CLAUDE_BIN_DIR:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"
         IWE_TEMPLATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-        # Unload ДО перезаписи файла: unload читает Label из ТЕКУЩЕГО содержимого
-        # на диске. Если Label когда-нибудь изменится в heredoc ниже, unload
-        # после перезаписи снял бы задачу по НОВОМУ Label (которого ещё нет в
-        # реестре launchd), и старая задача осталась бы висеть орфаном.
-        launchctl unload "$PLIST" 2>/dev/null || warn "launchctl unload: задача не была загружена (норма при первой установке)"
-        cat > "$PLIST" <<PLIST
+        NEW_PLIST_CONTENT=$(cat <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
@@ -160,8 +155,28 @@ if [ "$PLATFORM" = "Darwin" ]; then
     </dict>
 </dict></plist>
 PLIST
-        launchctl load "$PLIST" 2>/dev/null || warn "launchctl load failed (повторите вручную)"
-        ok "launchd plist установлен в $PLIST"
+)
+        # Idempotency (WP-5, found 03.09 — setup.sh now calls this on every
+        # run, not just a one-off manual invocation): re-installing an
+        # unchanged, already-loaded job would still unload/reload it, which
+        # could kill a run in flight at exactly 06:00/21:00. Skip only when
+        # content is unchanged AND the job is actually loaded -- content
+        # unchanged but not loaded (e.g. a prior `launchctl unload` left it
+        # stopped) must still fall through to `load`.
+        if [ -f "$PLIST" ] && [ "$(cat "$PLIST")" = "$NEW_PLIST_CONTENT" ] \
+            && launchctl list "com.extractor.git-diff-feed" >/dev/null 2>&1; then
+            ok "launchd plist уже установлен и активен, без изменений"
+        else
+            # Unload ДО перезаписи файла: unload читает Label из ТЕКУЩЕГО
+            # содержимого на диске. Если Label когда-нибудь изменится в
+            # heredoc выше, unload после перезаписи снял бы задачу по НОВОМУ
+            # Label (которого ещё нет в реестре launchd), и старая задача
+            # осталась бы висеть орфаном.
+            launchctl unload "$PLIST" 2>/dev/null || warn "launchctl unload: задача не была загружена (норма при первой установке)"
+            printf '%s\n' "$NEW_PLIST_CONTENT" > "$PLIST"
+            launchctl load "$PLIST" 2>/dev/null || warn "launchctl load failed (повторите вручную)"
+            ok "launchd plist установлен в $PLIST"
+        fi
     fi
 elif [ "$PLATFORM" = "Linux" ]; then
     UNIT_DIR="$HOME/.config/systemd/user"

--- a/setup.sh
+++ b/setup.sh
@@ -1148,6 +1148,26 @@ else
     done
 fi
 
+# === 8. Enable Knowledge Extractor feeders (WP-5) ===
+# Onboarding gap found live 03.09: setup.sh never called this script, so a
+# fresh install never got git-diff-feed/inbox-check running at all -- the
+# whole automated capture-to-Pack pipeline (Ф46-Ф52) silently never started
+# for a new user, with nothing in setup's own output to say so.
+echo "[8/8] Enabling Knowledge Extractor feeders..."
+if $CORE_ONLY; then
+    echo "  пропущено (core mode)"
+else
+    EXTRACTOR_MODE="install"
+    $DRY_RUN && EXTRACTOR_MODE="--check"
+    if IWE_WORKSPACE="$WORKSPACE_DIR" IWE_GOVERNANCE_REPO="$GOVERNANCE_REPO" IWE_RUNTIME="$IWE_RUNTIME_PATH" \
+        bash "$TEMPLATE_DIR/scripts/setup-extractor-feeders.sh" "$EXTRACTOR_MODE"; then
+        :
+    else
+        echo "  ⚠ setup-extractor-feeders.sh завершился с ошибкой — Экстрактор не запустится автоматически"
+        echo "    Повторить вручную: bash $TEMPLATE_DIR/scripts/setup-extractor-feeders.sh"
+    fi
+fi
+
 # === Done ===
 echo ""
 if $DRY_RUN; then

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2421,7 +2421,7 @@
     },
     {
       "path": "scripts/migrate-to-runtime-target.sh",
-      "sha256": "ca08e524cad094189a133f51cd9d802ee89ad8d4f74ab26ad2dbda3b37247fed"
+      "sha256": "108012b32f8783027c08e3395c640c9fe55d8ce2907a3766d9578d1996de7ac0"
     },
     {
       "path": "scripts/pack-ci-install.sh",
@@ -2489,7 +2489,7 @@
     },
     {
       "path": "scripts/setup-extractor-feeders.sh",
-      "sha256": "37c698a49413f1466d9ef7ec67dbba9c2eb015051e89a5181d7f462e16e19642"
+      "sha256": "6a73a17201951293542388d78cb4c903a5149fd1d78c31eb0e7730253ecf3826"
     },
     {
       "path": "scripts/skill-promote.sh",
@@ -2841,7 +2841,7 @@
     },
     {
       "path": "setup.sh",
-      "sha256": "224ca399b3923f9c5caa259c8cdd52d606d6eb18db1f7ac819a379cbe276321f"
+      "sha256": "4393a39c0a75c10a23ed11c8a5b4e52fd1d02b73977e4b190bf2e5e01863d737"
     },
     {
       "path": "setup/build-runtime.sh",


### PR DESCRIPTION
## Summary
- `setup.sh` never called `scripts/setup-extractor-feeders.sh` — a fresh install got zero Knowledge Extractor automation (no git-diff-feed cron, no inbox-check hook). Confirmed via grep: zero references anywhere in the 1228-line file before this change.
- Adds step `[8/8]` (after Base-repos, before `# === Done ===`) calling the feeder script, skipped in `--core` mode, `--check` under `--dry-run` (verified zero side effects).
- Made the git-diff-feed plist install idempotent: a re-run of `setup.sh` on an already-configured machine used to unconditionally unload/rewrite/reload it every time — a re-run landing at 06:00/21:00 could kill a run in flight. Now skips only when content is unchanged **and** the job is actually loaded.
- `migrate-to-runtime-target.sh`'s unload-list also gained `com.extractor.git-diff-feed` (only had `com.extractor.inbox-check` before).

## Explicitly out of scope (left as open follow-ups, not silently expanded)
- `update.sh` (existing installs) does not gain this step — only `setup.sh` does. Decided in peer-session with Codex (WP-5) rather than expand this PR's scope.
- The periodic 3-hourly `inbox-check` timer stays a separate, manual opt-in role (`roles/extractor/role.yaml`, `install.auto: false`) — unchanged.

## Test plan
- [x] `shellcheck -S error` — 0 issues on all 3 changed scripts
- [x] Simulated the new `setup.sh` step's exact invocation of `setup-extractor-feeders.sh --check` — matches real machine state, zero writes
- [x] Idempotency: ran install twice back-to-back in a scratch workspace — first run installs, second run correctly reports "already installed, unchanged" and skips unload/reload
- [x] Cold-context code review (independent subagent) — 0 Critical, findings (update.sh scope, periodic-timer scope, idempotency) addressed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
