### PR TITLE
fix(wp526): install-iwe-paths.sh generator missing IWE_SESSIONS_ROOT

### DIFF
--- a/setup/install-iwe-paths.sh
+++ b/setup/install-iwe-paths.sh
@@ -78,6 +78,7 @@ export IWE_SCRIPTS="\$IWE_TEMPLATE/scripts"
 export IWE_ROLES="\$IWE_TEMPLATE/roles"
 export IWE_RUNTIME="\$IWE_WORKSPACE/.iwe-runtime"
 export IWE_GOVERNANCE_REPO="$GOVERNANCE_REPO"
+export IWE_SESSIONS_ROOT="\$IWE_WORKSPACE/MC-sessions"
 IWEENV_EOF
 
 $QUIET || echo "  ✓ $IWE_ENV_FILE written (workspace=$WORKSPACE_DIR)"

--- a/setup/test-update-edge-cases.sh
+++ b/setup/test-update-edge-cases.sh
@@ -1697,8 +1697,8 @@ EOF
 HOME="$T25_HOME" bash "$TEMPLATE_DIR/setup/install-iwe-paths.sh" --workspace "$T25_WS" --governance GOV --quiet
 if grep -qF "_IWE_ROOT=\"$T25_WS\"" "$T25_HOME/.zshenv" && \
    ! grep -qF '[ -f "$HOME/.iwe-paths" ]' "$T25_HOME/.zshenv" && \
-   [ "$(grep -c '^export IWE_' "$T25_WS/.iwe-paths")" -eq 7 ]; then
-    pass "T25: legacy HOME source is replaced by the seven-variable workspace SoT"
+   [ "$(grep -c '^export IWE_' "$T25_WS/.iwe-paths")" -eq 8 ]; then
+    pass "T25: legacy HOME source is replaced by the eight-variable workspace SoT"
 else
     fail "T25: install-iwe-paths left the legacy source or incomplete workspace env"
 fi

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -3009,7 +3009,7 @@
     },
     {
       "path": "setup/install-iwe-paths.sh",
-      "sha256": "61525569e640828f028f25f419977fb9ba57b5c2d50ebbfa2838352a8f3d50ec"
+      "sha256": "6f0fa9ba968eb894a50028d18dc4457fbfb0701eb39d09346009fdb3942def8a"
     },
     {
       "path": "setup/optional/setup-cloud-scheduler.sh",


### PR DESCRIPTION
## Summary
- session-guard.sh and every script that writes session artifacts relies on ${IWE_SESSIONS_ROOT:-$IWE_ROOT/MC-sessions}, but the generator that writes .iwe-paths never emitted IWE_SESSIONS_ROOT -- no single source of truth for the MC-sessions home existed anywhere, everything ran on scattered per-script defaults.
- Found during a live audit of the post-РП526 structure (multi-repo sessions migration), pilot explicitly authorized this protected-path edit same session.

## Test plan
- [x] bash -n setup/install-iwe-paths.sh -- syntax OK
- [x] bash setup/install-iwe-paths.sh --workspace ~/IWE --governance DS-my-strategy --dry-run -- reports the write correctly
- [ ] Full non-dry-run apply on a real workspace (pilot's own Mac run pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)