### PR TITLE
feat(onboarding): default VS Code Claude Code extension to Auto mode on setup

### DIFF
--- a/scripts/setup-vscode-auto-mode.sh
+++ b/scripts/setup-vscode-auto-mode.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# routing: utility  deterministic=true
+# see DP.SC.159, DP.ROLE.059
+# setup-vscode-auto-mode.sh — default the VS Code Claude Code extension to
+# Auto permission mode for a fresh install (WP-406, VS Code onboarding track).
+#
+# Without this, every new VS Code window starts in Manual (ask before each
+# edit) regardless of the mode a person picked in a previous window, because
+# the extension's own default is Manual when the setting is unset.
+#
+# Only touches the person's own global VS Code settings.json:
+#  - Skips silently if VS Code is not installed (no User settings directory)
+#  - Adds claudeCode.initialPermissionMode only if the key is absent —
+#    never overwrites a choice the person already made
+#  - Backs up an existing file before writing; a file that fails to parse
+#    as JSON (e.g. hand-written comments) is left untouched
+#
+# Usage:
+#   bash scripts/setup-vscode-auto-mode.sh          # apply
+#   bash scripts/setup-vscode-auto-mode.sh --check  # dry run, no changes
+
+set -euo pipefail
+
+MODE="${1:-apply}"
+
+CANDIDATE_DIRS=(
+    "$HOME/Library/Application Support/Code/User"  # macOS
+    "$HOME/.config/Code/User"                       # Linux
+)
+
+for dir in "${CANDIDATE_DIRS[@]}"; do
+    [ -d "$dir" ] || continue
+    settings="$dir/settings.json"
+
+    if [ "$MODE" = "--check" ]; then
+        echo "  [vscode-auto-mode] [DRY RUN] Would ensure claudeCode.initialPermissionMode=auto in $settings"
+        continue
+    fi
+
+    python3 - "$settings" <<'PYEOF'
+import json
+import os
+import sys
+
+path = sys.argv[1]
+KEY = "claudeCode.initialPermissionMode"
+
+if os.path.exists(path):
+    with open(path, encoding="utf-8") as f:
+        raw = f.read()
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        print(f"  [vscode-auto-mode] {path}: не распарсен как JSON (возможно, комментарии) — пропущено")
+        sys.exit(0)
+    if not isinstance(data, dict):
+        print(f"  [vscode-auto-mode] {path}: верхний уровень не объект — пропущено")
+        sys.exit(0)
+    if KEY in data:
+        print(f"  [vscode-auto-mode] {path}: {KEY} уже задан ({data[KEY]!r}) — не трогаем")
+        sys.exit(0)
+    with open(path + ".bak", "w", encoding="utf-8") as f:
+        f.write(raw)
+else:
+    data = {}
+
+data[KEY] = "auto"
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+    f.write("\n")
+print(f"  [vscode-auto-mode] {path}: {KEY}=auto")
+PYEOF
+
+done

--- a/setup.sh
+++ b/setup.sh
@@ -1168,6 +1168,24 @@ else
     fi
 fi
 
+# === 8b. VS Code default permission mode (WP-406, onboarding VS Code track) ===
+# Without this, every new VS Code window starts the Claude Code extension in
+# Manual (ask before each edit) — a newcomer picking Auto in one window sees
+# it reset in the next, because the extension's own default is Manual.
+if $CORE_ONLY; then
+    :
+else
+    echo "[8b] Настройка VS Code (режим Auto по умолчанию)..."
+    VSCODE_AUTO_MODE_ARG="apply"
+    $DRY_RUN && VSCODE_AUTO_MODE_ARG="--check"
+    if bash "$TEMPLATE_DIR/scripts/setup-vscode-auto-mode.sh" "$VSCODE_AUTO_MODE_ARG"; then
+        :
+    else
+        echo "  ⚠ setup-vscode-auto-mode.sh завершился с ошибкой — Auto-режим не выставлен, VS Code не тронут"
+        echo "    Повторить вручную: bash $TEMPLATE_DIR/scripts/setup-vscode-auto-mode.sh"
+    fi
+fi
+
 # === Done ===
 echo ""
 if $DRY_RUN; then

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2492,6 +2492,10 @@
       "sha256": "6a73a17201951293542388d78cb4c903a5149fd1d78c31eb0e7730253ecf3826"
     },
     {
+      "path": "scripts/setup-vscode-auto-mode.sh",
+      "sha256": "7be9a3950bba650181f2134e57d97b29946b8ba50de7b0cf6c0b686d865d76c0"
+    },
+    {
       "path": "scripts/skill-promote.sh",
       "sha256": "b3f0a897e18ed6294f23b33dc408794a1594afcc1a08d611f00c408b63c90512"
     },
@@ -2841,7 +2845,7 @@
     },
     {
       "path": "setup.sh",
-      "sha256": "4393a39c0a75c10a23ed11c8a5b4e52fd1d02b73977e4b190bf2e5e01863d737"
+      "sha256": "31a75c3d8f7acc21a711ea4c40a037ec9ac3e81a868b8da4f56c95324bc0c0ba"
     },
     {
       "path": "setup/build-runtime.sh",


### PR DESCRIPTION
## Summary
- New installs (`setup.sh`) now write `claudeCode.initialPermissionMode: "auto"` into the newcomer's own global VS Code settings.json — otherwise every new VS Code window starts the Claude Code extension in Manual (ask before each edit), even after the person picks Auto in a previous window, because the extension's own default is Manual whenever the setting is unset.
- The setting is machine-scoped in VS Code, so it cannot ship via a repo-level `.vscode/settings.json` — `scripts/setup-vscode-auto-mode.sh` edits the person's actual global config instead: idempotent (only adds the key if absent), skips silently if VS Code isn't installed, never touches a file that fails to parse as JSON, and backs up before writing.
- Wired in as a new `setup.sh` step [8b], skipped in `--core` mode, guarded the same way the sibling Knowledge Extractor step is (a failure here warns instead of aborting the whole install).
- `update-manifest.json` updated: registered the new script, refreshed `setup.sh`'s hash.

## Test plan
- [x] Independent adversarial review by a separate agent (no shared context): 6 scenarios run live in isolated fake-HOME fixtures — no VS Code installed, missing key, key already set, idempotency, JSONC-with-comments, and the `setup.sh --core`/full/`--dry-run` control flow. Found one real gap (no failure guard on the new step) and one edge case (non-dict JSON) — both fixed.
- [x] Re-verified all fixes myself in isolated fixtures after the fix.
- [x] `shellcheck` clean on both changed scripts.
- [x] `scripts/check-setup-update-parity.sh` — all pairs OK.
- [x] `scripts/verify-manifest.sh` — manifest in sync with git tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)