### PR TITLE
chore(release): weekly auto-bump to v0.39.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,8 @@ Refs: WP-NNN
 
 ## [Unreleased]
 
+## [0.39.2] — 2026-09-04
+
 ### Added
 
 - `c4bbbb4` feat(archgate): v3.1 — фильтр допуска, атрибут-сценарии, advice log, fitness-вопрос (#605)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # IWE — Intellectual Work Environment
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.39.1-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.39.2-blue.svg)](CHANGELOG.md)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows%20(Git%20Bash)-lightgrey.svg)]()
 [![EN sync](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/TserenTserenov/FMT-exocortex-template/en-draft/badge-data.json)](https://github.com/TserenTserenov/FMT-exocortex-template/tree/en-draft)
 

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Манифест платформенных файлов FMT-exocortex-template. Используется update.sh для доставки обновлений.",
   "files": [
     {
@@ -765,7 +765,7 @@
     },
     {
       "path": "CHANGELOG.md",
-      "sha256": "a24abd1e011dcfe38bc3b43c057a34515f711459ea770b54f2a421092146d556"
+      "sha256": "ee615b766d65bb420db79b055cb1687496b4f1f3447970bd775cbd5a2fc734c0"
     },
     {
       "path": "CLAUDE.md",


### PR DESCRIPTION
Еженедельный автобамп версии. Мердж запускает обычный релизный конвейер (validate → release) через штатный push-триггер.

Открыт вручную вместо бота — Actions пока не разрешено создавать pull request в этом репозитории (см. обсуждение).