### PR TITLE
feat(permissions): универсальное разрешение скриптов сессионного учёта (РП-544 Ф8)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,13 @@
       "Bash(git diff:*)",
       "Bash(git show:*)",
       "Bash(git branch:*)",
-      "Bash(git remote:*)"
+      "Bash(git remote:*)",
+      "Bash(bash ~/IWE/scripts/session-guard.sh open:*)",
+      "Bash(bash ~/IWE/scripts/session-guard.sh close:*)",
+      "Bash(bash ~/IWE/scripts/session-guard.sh renew:*)",
+      "Bash(bash ~/IWE/scripts/session-guard.sh note-file:*)",
+      "Bash(bash ~/IWE/scripts/session-guard.sh audit:*)",
+      "Bash(bash ~/IWE/scripts/agent-heartbeat.sh:*)"
     ],
     "additionalDirectories": []
   },

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -285,7 +285,7 @@
     },
     {
       "path": ".claude/settings.json",
-      "sha256": "280fa18d9d5e4188569c1a30e3dfe31e992975e295c9817e438dca3c66ae4b81"
+      "sha256": "13355f13f96a1cfaf7dc8f0856269d612ae624ce0b8dc3c82ac3157924f5bec2"
     },
     {
       "path": ".claude/skills-catalog.yaml",


### PR DESCRIPTION
По поручению пилота 05.09: служебные скрипты сессионного учёта (session-guard open/close/renew/note-file/audit, agent-heartbeat) не спрашивают подтверждения ни в одном раннере — ни в локальной установке, ни в шаблоне для новичков. freeze-canonical и прочие подкоманды session-guard сознательно НЕ включены (спрашивают). Симметричные правки: ~/.claude/settings.json (Клод, локально), ~/.kimi-code/config.toml (Kimi, 8 правил), Codex уже approval_policy=never.