### PR TITLE
fix(issue-funnel): close 4 template bugs from 2-day issue triage (#677-680)

### DIFF
--- a/.claude/hooks/rule-engine.sh
+++ b/.claude/hooks/rule-engine.sh
@@ -12,6 +12,11 @@
 # Использование (как hook): event-specific обёртки делают source этого файла и вызывают
 # dispatch_event. Прямой запуск тоже доступен — для тестов.
 #
+# CLI exit codes: dispatch/list-rules/session-summary/session-clear/test — 0.
+# check-trace-satisfaction|list-gates|mark-gate — 3 (NOT_IMPLEMENTED, issue #678:
+# protocol-close.md ссылается на них, механика ещё не реализована). Неизвестная
+# подкоманда — 1 (usage).
+#
 # REGISTRY: ~/IWE/.claude/rules-registry.yaml (генерируется из PACK-agent-rules/)
 
 set -uo pipefail
@@ -1750,6 +1755,18 @@ PYEOF
         echo ""
         echo "=== Results: $PASS PASS / $FAIL FAIL (total $((PASS+FAIL))) ==="
         [ "$FAIL" -eq 0 ] && exit 0 || exit 1
+        ;;
+    check-trace-satisfaction|list-gates|mark-gate)
+        # issue #678: memory/protocol-close.md ссылается на эти три
+        # подкоманды (Quick/Week/Month Close, gate-трассировка WP-481 Ф5.1),
+        # но механика никогда не была реализована. Раньше это падало в
+        # безымянную ветку *) ниже с generic usage — на практике неотличимо
+        # от опечатки в имени подкоманды и не сообщает, что именно не
+        # работает. Явная ветка с понятным сообщением вместо тихой догадки:
+        # проверка гейтов реально не произошла, это не «прошла с exit 1».
+        echo "NOT_IMPLEMENTED: '$1' (rule-engine.sh) — gate-трассировка (WP-481 Ф5.1) описана в protocol-close.md, но не реализована (issue #678)." >&2
+        echo "Гейты этой секции НЕ проверены автоматически — Close-протокол должен считать этот шаг непройденным, не пропущенным." >&2
+        exit 3
         ;;
     *)
         echo "Usage: rule-engine.sh {dispatch|list-rules|test|session-summary|session-clear}"

--- a/.claude/scripts/check-index-health.py
+++ b/.claude/scripts/check-index-health.py
@@ -183,7 +183,11 @@ def check_file(path: Path) -> dict:
     return out
 
 
-def classify(findings: dict, size_warn: int, size_fail: int) -> str:
+def classify(findings: dict, size_warn: int = SIZE_WARN, size_fail: int = SIZE_FAIL) -> str:
+    # Defaults keep the pre-#677 single-arg call signature working for
+    # existing external callers (setup/test-update-edge-cases.sh T20) that
+    # never needed MEMORY.md's separate thresholds — main() below still
+    # passes them explicitly for that one filename.
     size = 0 if findings["size_skip"] else findings["size"]
     max_line = max((n for _, n in findings["long_lines"]), default=0)
     max_cell = max((n for _, _, n in findings["long_cells"]), default=0)

--- a/.claude/scripts/check-index-health.py
+++ b/.claude/scripts/check-index-health.py
@@ -25,6 +25,16 @@ CATALOG.md, TOC.md, MAPSTRATEGIC.md, Projects.md, *-registry.md, *-index.md,
     OK: всё под порогами.
     Размер сам по себе — слабый маркер: реестр 300 РП × 100 ch = 30KB.
 
+    MEMORY.md — отдельные пороги: FAIL на пределе загрузчика контекста
+    (~24.4 KiB символов), WARN — запас до него (issue #677: живой индекс
+    памяти обрезается загрузчиком раньше, чем срабатывают общие пороги).
+
+Обход дерева следует symlink'ам (issue #677: `memory/` на типовой установке —
+symlink на auto-memory) с защитой от циклов. Каталог, где лежит живой
+MEMORY.md, считается хранилищем памяти — заметки вида *-index.md/*-catalog.md
+внутри него не считаются реестрами (иначе это новый класс ложных срабатываний
+после включения symlink'ов).
+
 Пропуск файлов через комментарий в начале файла:
     <!-- index-health: skip --> — не сканировать
     <!-- index-health: skip-cells --> — не проверять ячейки таблиц
@@ -32,6 +42,7 @@ CATALOG.md, TOC.md, MAPSTRATEGIC.md, Projects.md, *-registry.md, *-index.md,
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
 from pathlib import Path
@@ -74,6 +85,13 @@ CELL_FAIL = 400
 # Размер сам по себе — слабый маркер: реестр из 300 РП × 100 chars = 30KB, норма.
 # Настоящие маркеры — длинные строки/ячейки.
 
+# MEMORY.md — отдельные пороги (issue #677): SIZE_WARN/FAIL выше предела
+# загрузчика контекста, поэтому для живого индекса памяти он недостижим по
+# конструкции — файл раньше обрежется загрузчиком, чем сработает этот порог.
+# FAIL = сам предел загрузчика (~24.4 KiB символов), WARN = запас до него.
+MEMORY_SIZE_FAIL = 24986
+MEMORY_SIZE_WARN = int(MEMORY_SIZE_FAIL * 0.85)
+
 
 def _plain_table_cell(cell: str) -> str:
     return cell.strip("*~` \t").rstrip(".").casefold()
@@ -101,9 +119,8 @@ def _status_cell(cells: list[str], status_column: int | None) -> str | None:
 
 
 def check_file(path: Path) -> dict:
-    size = path.stat().st_size
     out = {
-        "size": size,
+        "size": 0,
         "long_lines": [],      # list of (lineno, char_len)
         "long_cells": [],      # list of (lineno, cell_idx, char_len)
         "done_no_strike": [],  # list of (lineno, wp_number) — ✅ без зачёркивания
@@ -116,6 +133,10 @@ def check_file(path: Path) -> dict:
     except (UnicodeDecodeError, OSError):
         out["skip"] = True
         return out
+    # Символы, не байты (issue #677) — докстринг обещает char count, а
+    # кириллица в UTF-8 весит вдвое больше символа: порог, сверенный по
+    # байтам, срабатывает не на том объёме, который считает загрузчик.
+    out["size"] = len(text)
 
     head = text[:512]
     # index-health: skip отключает проверки РАЗДУТИЯ (размер/длина/ячейки),
@@ -162,29 +183,69 @@ def check_file(path: Path) -> dict:
     return out
 
 
-def classify(findings: dict) -> str:
+def classify(findings: dict, size_warn: int, size_fail: int) -> str:
     size = 0 if findings["size_skip"] else findings["size"]
     max_line = max((n for _, n in findings["long_lines"]), default=0)
     max_cell = max((n for _, _, n in findings["long_cells"]), default=0)
-    if size > SIZE_FAIL or max_line > LINE_FAIL or max_cell > CELL_FAIL:
+    if size > size_fail or max_line > LINE_FAIL or max_cell > CELL_FAIL:
         return "FAIL"
-    if size > SIZE_WARN or max_line > LINE_WARN or max_cell > CELL_WARN \
+    if size > size_warn or max_line > LINE_WARN or max_cell > CELL_WARN \
             or findings["done_no_strike"]:
         return "WARN"
     return "OK"
 
 
+def _walk_dirs(root: Path):
+    """os.walk with followlinks, guarded against symlink cycles.
+
+    rglob() does not descend into symlinked directories at all (issue #677) —
+    live indexes under `memory/` (a symlink to auto-memory on a standard
+    install) never reach the scanner. followlinks=True fixes that, at the
+    cost of needing an explicit cycle guard: a symlink loop would otherwise
+    walk forever.
+    """
+    visited_real_dirs: set[str] = set()
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=True):
+        real_dir = os.path.realpath(dirpath)
+        if real_dir in visited_real_dirs:
+            dirnames[:] = []
+            continue
+        visited_real_dirs.add(real_dir)
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        yield Path(dirpath), filenames
+
+
+def _find_memory_dirs(root: Path) -> set[Path]:
+    """Directories containing a live MEMORY.md — the memory store itself.
+
+    Notes inside it named like a registry (`*-index.md`, `*-catalog.md`) are
+    ordinary memory notes, not maintained indexes (issue #677) — flagging
+    them once symlinks are followed would be a new false-positive class.
+    """
+    return {
+        dirpath
+        for dirpath, filenames in _walk_dirs(root)
+        if "MEMORY.md" in filenames
+    }
+
+
 def iter_index_files(root: Path):
-    for path in root.rglob("*.md"):
-        if any(p in SKIP_DIRS for p in path.parts):
-            continue
-        if path.name in NAME_PATTERNS:
-            yield path
-            continue
-        for pat in GLOB_PATTERNS:
-            if path.match(pat):
+    memory_dirs = _find_memory_dirs(root)
+    for dirpath, filenames in _walk_dirs(root):
+        in_memory_dir = dirpath in memory_dirs
+        for filename in filenames:
+            if not filename.endswith(".md"):
+                continue
+            path = dirpath / filename
+            if filename in NAME_PATTERNS:
                 yield path
-                break
+                continue
+            if in_memory_dir:
+                continue
+            for pat in GLOB_PATTERNS:
+                if path.match(pat):
+                    yield path
+                    break
 
 
 def fmt_file_line(path: Path, root: Path, findings: dict) -> str:
@@ -215,7 +276,11 @@ def main() -> int:
         if findings["skip"]:
             buckets["SKIP"].append((path, findings))
             continue
-        buckets[classify(findings)].append((path, findings))
+        if path.name == "MEMORY.md":
+            size_warn, size_fail = MEMORY_SIZE_WARN, MEMORY_SIZE_FAIL
+        else:
+            size_warn, size_fail = SIZE_WARN, SIZE_FAIL
+        buckets[classify(findings, size_warn, size_fail)].append((path, findings))
 
     total = sum(len(v) for v in buckets.values())
     print(f"Index health scan — root: {root}")

--- a/scripts/route-task.sh
+++ b/scripts/route-task.sh
@@ -118,7 +118,13 @@ for entry in cat.get("entries", []):
     if entry["name"] == skill_name:
         r = entry["routing"]
         print(f"executor={r['executor']}")
-        print(f"deterministic={r.get('deterministic', 'false')}")
+        # YAML `true`/`false` parse as Python bool — an f-string prints
+        # "True"/"False" (capitalized), which the bash-side comparison
+        # `[[ "$deterministic" == "true" ]]` (issue #679 deterministic-gate)
+        # never matches. Every real entry in executor-catalog.yaml writes
+        # the plain YAML boolean, not a quoted string, so this silently
+        # disabled the gate for 100% of deterministic:true entries.
+        print(f"deterministic={'true' if r.get('deterministic') else 'false'}")
         if "script_path" in r:
             print(f"script_path={r['script_path']}")
         if "model" in r:

--- a/scripts/route-task.sh
+++ b/scripts/route-task.sh
@@ -199,7 +199,44 @@ run_script() {
     fi
     local script_exit=0
     if [[ -n "$args" ]]; then
-        read -r -a ARGS_ARRAY <<< "$args"
+        # issue #679: `read -r -a` splits только по IFS — не понимает кавычки
+        # внутри $args, поэтому `--fault "текст с пробелами"` рассыпался на 4
+        # элемента массива вместо 2. Первая попытка фикса (`eval`) отклонена
+        # на ревью: исполняет ЛЮБОЙ shell-синтаксис в $args ($(...), `` ` ``,
+        # ;, &&), а $args может прийти из agent-fault SKILL.md, где --fault —
+        # свободный текст описания косяка агента, не фиксированный литерал.
+        # Вторая попытка (shlex.split + newline-delimited + mapfile) тоже
+        # отклонена: mapfile — bash4+, системный /bin/bash на macOS без
+        # Homebrew — 3.2; и newline-разделитель ломает токен с буквальным
+        # переносом строки внутри (многоабзацное --fault-описание).
+        # NUL — единственный байт, которого не бывает ни в одном bash-токене
+        # и который shlex-токен тоже не может содержать, поэтому безопасен
+        # как разделитель; временный файл (не $()) — NUL не переживает
+        # command substitution. `while read -d ''` — bash3.2-совместимо.
+        local ARGS_ARRAY=() shlex_tmp shlex_err
+        shlex_tmp=$(mktemp "${TMPDIR:-/tmp}/route-task-args.XXXXXX") || die "mktemp failed"
+        if ! shlex_err=$(python3 -c '
+import shlex, sys
+try:
+    toks = shlex.split(sys.argv[1])
+except ValueError as exc:
+    print(f"unbalanced quotes: {exc}", file=sys.stderr)
+    sys.exit(1)
+with open(sys.argv[2], "wb") as f:
+    for tok in toks:
+        f.write(tok.encode())
+        f.write(b"\0")
+' "$args" "$shlex_tmp" 2>&1); then
+            rm -f "$shlex_tmp"
+            warn "failed to parse args for $skill_name: $shlex_err"
+            emit_error "$skill_name" "EXEC_FAILED" "args parse error: $shlex_err"
+            emit_result "$skill_name" "script" "EXEC_FAILED" "$routing_path"
+            return 1
+        fi
+        while IFS= read -r -d '' tok; do
+            ARGS_ARRAY+=("$tok")
+        done < "$shlex_tmp"
+        rm -f "$shlex_tmp"
         "$interpreter" "$script_path" "${ARGS_ARRAY[@]}" || script_exit=$?
     else
         "$interpreter" "$script_path" || script_exit=$?
@@ -294,11 +331,21 @@ dispatch_skill() {
         die "catalog lookup failed (exit=$lookup_exit)"
     fi
 
-    local executor script_path="" model=""
+    local executor script_path="" model="" deterministic=""
     executor=$(echo "$lookup_result" | grep "^executor=" | cut -d= -f2)
     script_path=$(echo "$lookup_result" | grep "^script_path=" | cut -d= -f2- || true)
     model=$(echo "$lookup_result" | grep "^model=" | cut -d= -f2- || true)
+    deterministic=$(echo "$lookup_result" | grep "^deterministic=" | cut -d= -f2- || true)
     routing_path="${routing_path}${executor}"
+
+    # issue #679: deterministic:true в каталоге раньше ничего не решал — LLM-
+    # фоллбек при ненайденном скрипте зависел только от того, каким флагом
+    # вызвали роутер (--skill/--tag), не от контракта самого skill-а. Запись,
+    # обещающая "без LLM", могла тихо получить LLM-подмену, если её позвали
+    # через --tag. Каталог теперь важнее выбора вызывающего.
+    if [[ "$deterministic" == "true" ]]; then
+        allow_fallback="false"
+    fi
 
     case "$executor" in
         script)

--- a/scripts/test-route-task.sh
+++ b/scripts/test-route-task.sh
@@ -34,7 +34,7 @@ chmod +x "$FIXTURE_IWE/scripts/consent-fixture.sh" "$FIXTURE_IWE/scripts/agent-f
 cat > "$FIXTURE_IWE/$FIXTURE_GOV/scripts/executor-catalog.yaml" <<'YAML'
 schema_version: '1.0'
 generated_at: '2026-08-24T00:00:00Z'
-total_entries: 3
+total_entries: 4
 entries:
   - name: consent
     routing:
@@ -46,6 +46,11 @@ entries:
       executor: script
       script_path: scripts/intentionally-missing.sh
       deterministic: true
+  - name: connect-guide-flex
+    routing:
+      executor: script
+      script_path: scripts/intentionally-missing.sh
+      deterministic: false
   - name: agent-fault
     routing:
       executor: script
@@ -92,8 +97,16 @@ run_test "T3: --tag unknown_skill (flex → fallback Sonnet, exit 0)" 0 --tag un
 # 4. Missing script — strict (--skill)
 run_test "T4: --skill connect-guide (missing script → exit 2)" 2 --skill connect-guide
 
-# 5. Missing script — flex (--tag)
-run_test "T5: --tag connect-guide (missing script → fallback Haiku, exit 0)" 0 --tag connect-guide
+# 5. Missing script, non-deterministic — flex (--tag)
+run_test "T5: --tag connect-guide-flex (missing script, deterministic:false → fallback Haiku, exit 0)" 0 --tag connect-guide-flex
+
+# 5b. Missing script, deterministic:true — flex (--tag). issue #679: the
+# catalog's deterministic flag must block LLM fallback regardless of which
+# CLI flag invoked the router, not only under --skill (which already forced
+# allow_fallback=false before this fix existed and so never exercised the
+# bug — a f-string bug printed Python's True/False instead of true/false,
+# so the bash-side comparison never matched a real YAML boolean).
+run_test "T5b: --tag connect-guide (missing script, deterministic:true → EXEC_FAILED, exit 2)" 2 --tag connect-guide
 
 # 6. Empty tag
 run_test "T6: --tag '' (empty → unknown → fallback Sonnet, exit 0)" 0 --tag ""

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -141,7 +141,7 @@
     },
     {
       "path": ".claude/hooks/rule-engine.sh",
-      "sha256": "3903cd2bb5eb8dd412cbf0e219cd6b676da2cbe0113765ea6920a43b58e48e83"
+      "sha256": "304caca86a807c7022911bd9091895015717d76aa2d785a4bd2d6e0410495533"
     },
     {
       "path": ".claude/hooks/session-end-status.sh",
@@ -253,7 +253,7 @@
     },
     {
       "path": ".claude/scripts/check-index-health.py",
-      "sha256": "348db830188a04e76c2ff02ca6f2d52c93072f628290c1ac4f2818c2a264269a"
+      "sha256": "1aa1b9ee4f0031d82164d616c30869cd90be1d5924fd8f12773472fd1313ad16"
     },
     {
       "path": ".claude/scripts/classify-workspace-copy.sh",
@@ -1433,7 +1433,7 @@
     },
     {
       "path": "memory/fpf-reference.md",
-      "sha256": "d753b57b1a500861034bdd4a522773979b1a8665135ba679afc02ecaeca9f3f9"
+      "sha256": "8e5eeecdf45745cabc8cca6ec69ec902f56922ad0e3bc96383864500d249db17"
     },
     {
       "path": "memory/fpf-term-map.yaml",
@@ -2461,7 +2461,7 @@
     },
     {
       "path": "scripts/route-task.sh",
-      "sha256": "b1b6c165cf378ced7c5a9b2b69c84b0b70d98ff57c8fd3e81f7c60b05b642b44"
+      "sha256": "e2e5ce2d1d52663e1bd6862fd7c97747997345c837b780c8fabab57cf22aa9d1"
     },
     {
       "path": "scripts/run-regression-tests.sh",
@@ -2541,7 +2541,7 @@
     },
     {
       "path": "scripts/test-route-task.sh",
-      "sha256": "8b42da27ee36905e4b426edfcd1dd9d66e3a70f851d07a8e558e03a38cbe3c94"
+      "sha256": "05c714c8dfe530f1954bcd87fa4b312c15e235c341f8ffd3e12b6aeca00afe9c"
     },
     {
       "path": "scripts/test_archive_cadence_sweep.py",
@@ -2885,7 +2885,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "60bf249aaf4a965b4d2b85361fc5c6a2a03602b01e682ae32e8f2c8d02a52a52"
+      "sha256": "2f16473f2e4e6575e4d00451e3e3e665d72a8c14347b19d3d9dd3d56dbd7d7aa"
     }
   ],
   "excluded_paths": [

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -253,7 +253,7 @@
     },
     {
       "path": ".claude/scripts/check-index-health.py",
-      "sha256": "1aa1b9ee4f0031d82164d616c30869cd90be1d5924fd8f12773472fd1313ad16"
+      "sha256": "2b12c530f0fa5ee19c349901807e0b9a55fb6ed4c37b7e8ed2d0ed4fe9e91203"
     },
     {
       "path": ".claude/scripts/classify-workspace-copy.sh",

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1433,7 +1433,7 @@
     },
     {
       "path": "memory/fpf-reference.md",
-      "sha256": "8e5eeecdf45745cabc8cca6ec69ec902f56922ad0e3bc96383864500d249db17"
+      "sha256": "d753b57b1a500861034bdd4a522773979b1a8665135ba679afc02ecaeca9f3f9"
     },
     {
       "path": "memory/fpf-term-map.yaml",

--- a/update.sh
+++ b/update.sh
@@ -3976,7 +3976,10 @@ for base in L1_DIRS:
     for root, dirs, files in os.walk(full_base):
         for fname in files:
             full = os.path.join(root, fname)
-            rel = os.path.relpath(full, script_dir)
+            # issue #680: manifest paths always use "/" (JSON convention);
+            # os.path.relpath returns "\" on Windows, so every file compared
+            # false-orphan there without this normalization.
+            rel = os.path.relpath(full, script_dir).replace(os.sep, "/")
             if rel not in all_known and not _locally_excluded(rel):
                 tag = "[maybe-L3]" if "extensions/" in rel else "[orphan]"
                 orphans.append((tag, rel))


### PR DESCRIPTION
## Summary
- `check-index-health.py` (#677): follow symlinks (`memory/` is one on a standard install) with a cycle guard, measure size in chars not bytes, separate thresholds for `MEMORY.md` tied to the context loader's limit.
- `rule-engine.sh` (#678): `protocol-close.md` calls `check-trace-satisfaction`/`list-gates`/`mark-gate`, never implemented — fell through to generic usage. Explicit `NOT_IMPLEMENTED` branch instead.
- `route-task.sh` (#679): `deterministic: true` in the catalog was parsed but never consulted — LLM fallback on a missing script depended only on the CLI flag used, not the skill's contract. Also replaces IFS-only arg splitting (broke quoted multi-word `--fault` text) with NUL-delimited `shlex.split` via temp file — portable to bash 3.2 and safe against embedded newlines.
- `update.sh` (#680, orphan-detection only): normalize path separators before comparing against the manifest (always `/`) — fixes false-positive orphans on Windows. The python3-stub half of #680 was already fixed earlier (issue #402, commit 0e58249).

Issues #681 (dry-run-gate.sh subagent bypass) and #682 (STAGING.md validated-rule promotion) intentionally not addressed here — #681 needs a live repro that risks disrupting other agents' concurrent sessions in this monorepo, #682 is a pilot decision per the issue's own "owner: human" note.

## Test plan
- [x] `bash -n` on all 3 shell files, `python3 -m py_compile` on the Python file
- [x] `shellcheck -S warning` on changed files — no new warnings beyond 2 pre-existing unrelated ones
- [x] `scripts/test-route-task.sh` — 15 PASS / 2 FAIL, identical baseline to pre-change (verified via stash)
- [x] check-index-health.py: live run against the real `~/IWE` tree (340 files, symlinked `memory/` correctly found) + synthetic symlink-cycle test (no hang)
- [x] route-task.sh: live tests on both `/bin/bash` 3.2.57 (macOS system bash) and Homebrew bash 5.3.15 — multiword quoted arg, command-injection attempt (`$(touch ...)`, blocked), unbalanced quote (graceful EXEC_FAILED, no crash), embedded-newline token (preserved as one token)
- [x] Peer-reviewed with Kimi (2 rounds) + independent cold-context code review (2 rounds) — first review caught a critical injection vector (`eval`) in an earlier draft of the #679 fix, second review caught a bash4-only `mapfile` regression in the immediate follow-up fix; both are absent from what's in this PR

Full session transcript: `MC-sessions/2026-09/06/2026-09-06-02-razobrat-6-novyh-zamechaniy/` (DS-my-strategy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)