### PR TITLE
fix(wp5): Экстрактор ставится и при обновлении, не только при первой установке (Ф55)

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -645,6 +645,12 @@ jobs:
       - name: Test staged install-path guard
         run: bash scripts/tests/test_update_install_path_guard.sh
 
+      # WP-5 F55: the Extractor feeders step existed only in setup.sh, so every
+      # already-configured machine kept updating without the capture pipeline
+      # ever being scheduled. Guards the wiring plus install/opt-out/no-CLI paths.
+      - name: Test Extractor feeders backfill in update.sh
+        run: bash scripts/tests/test-update-extractor-feeders.sh
+
       # WP-529 Ф3: release-receipt.sh (the release-receipt job below) must
       # fail closed — success/skipped on every mandatory check to publish,
       # anything else blocks. Tested here the same way every other guard in

--- a/scripts/setup-extractor-feeders.sh
+++ b/scripts/setup-extractor-feeders.sh
@@ -25,6 +25,17 @@ FLEETING="$HOME/IWE/$GOVERNANCE_REPO/inbox/fleeting-notes.md"
 
 MODE="${1:-install}"
 
+# --schedule-only (WP-5 F55): install just the periodic job. update.sh runs this
+# script on EVERY update now, and the two steps below it -- taking over
+# ~/.git-templates/hooks/post-commit and the global init.templateDir -- are
+# install-time decisions, not something an update may redo behind the user's
+# back on a machine where either already points somewhere of their own.
+SCHEDULE_ONLY=false
+if [ "$MODE" = "--schedule-only" ]; then
+    SCHEDULE_ONLY=true
+    MODE="install"
+fi
+
 log() { echo "[setup-extractor] $*"; }
 ok() { echo "  ✅ $*"; }
 warn() { echo "  ⚠️  $*"; }
@@ -55,6 +66,12 @@ esac
 
 # === 2. Git-templates (post-commit hook) ===
 
+if $SCHEDULE_ONLY; then
+    log "2/4 Git-templates — пропущено (режим только расписания)"
+else
+# Body deliberately left at its original indentation: it contains a quoted
+# heredoc (HOOK) whose leading whitespace would end up inside the generated
+# git hook. The block ends at `fi  # SCHEDULE_ONLY` below.
 log "2/4 Git-templates для post-commit hook"
 
 GIT_TEMPLATES="$HOME/.git-templates"
@@ -106,6 +123,7 @@ HOOK
     fi
     git config --global init.templateDir "$GIT_TEMPLATES" || warn "не смог установить init.templateDir"
 fi
+fi  # SCHEDULE_ONLY
 
 # === 3. Cron для git-diff-feed (06:00 / 21:00) ===
 
@@ -118,6 +136,11 @@ if [ "$PLATFORM" = "Darwin" ]; then
     elif [ "$MODE" = "--uninstall" ]; then
         if [ -f "$PLIST" ]; then launchctl unload "$PLIST" 2>/dev/null || true; rm "$PLIST"; ok "launchd plist удалён"; fi
     else
+        # launchd не создаёт каталог для StandardOutPath сам и без него не
+        # стартует. Раньше каталог появлялся только в Linux-ветке
+        # roles/extractor/install.sh, то есть на чистом Маке задача ставилась
+        # и молча не запускалась (WP-5 F55, находка холодного ревью).
+        mkdir -p "$HOME/logs/extractor"
         # launchd не наследует login-shell PATH (WP-5, найдено 03.09 — job падал
         # exit 127 "claude CLI не найден"), поэтому PATH нужно прописать явно, а
         # не полагаться на окружение launchd по умолчанию (/usr/bin:/bin:/usr/sbin:/sbin).
@@ -213,7 +236,7 @@ fi
 
 log "4/4 Fleeting-notes inbox"
 
-if [ "$MODE" != "--check" ] && [ "$MODE" != "--uninstall" ]; then
+if [ "$MODE" != "--check" ] && [ "$MODE" != "--uninstall" ] && ! $SCHEDULE_ONLY; then
     if [ ! -f "$FLEETING" ]; then
         mkdir -p "$(dirname "$FLEETING")"
         cat > "$FLEETING" <<'FN'

--- a/scripts/tests/test-update-extractor-feeders.sh
+++ b/scripts/tests/test-update-extractor-feeders.sh
@@ -34,7 +34,7 @@ FEEDERS="$SCRIPT_DIR/scripts/setup-extractor-feeders.sh"
 write_feeders() {  # $1 = exit code the stub reports
     cat > "$FEEDERS" <<STUB
 #!/usr/bin/env bash
-printf '%s|%s|%s|%s\n' "\$1" "\$IWE_WORKSPACE" "\$IWE_GOVERNANCE_REPO" "\$IWE_RUNTIME" > "$TMP/feeders-call"
+printf '%s|%s|%s\n' "\$1" "\${IWE_GOVERNANCE_REPO:-}" "\${IWE_RUNTIME:-}" > "$TMP/feeders-call"
 echo "  launchd plist установлен"
 exit $1
 STUB
@@ -44,12 +44,38 @@ printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP/bin/claude"
 chmod +x "$TMP/bin/claude"
 PATH="$TMP/bin:$PATH"
 
-# 1. Happy path: feeders installed with the workspace's own governance/runtime.
+# 1. Happy path: the periodic job only, with the workspace's own runtime.
+# An update must NOT rerun the install-time steps (global git hook template,
+# init.templateDir, fleeting-notes seeding) -- that is what --schedule-only buys.
 write_feeders 0
 OUT=$(backfill_extractor_feeders)
-EXPECTED="install|$WORKSPACE_DIR|DS-my-strategy|$WORKSPACE_DIR/.iwe-runtime"
+EXPECTED="--schedule-only|DS-my-strategy|$WORKSPACE_DIR/.iwe-runtime"
 if [ "$(cat "$TMP/feeders-call")" != "$EXPECTED" ]; then
     echo "feeders invoked with wrong mode or environment: $(cat "$TMP/feeders-call")" >&2
+    exit 1
+fi
+
+# A stub that agrees with its caller proves nothing about the shipped script:
+# check the real one parses the mode and guards both install-time steps with it.
+# Structural, not executed -- running it for real would install a launchd job
+# on whatever machine the suite runs on.
+REAL_FEEDERS="$ROOT/scripts/setup-extractor-feeders.sh"
+if ! grep -q 'SCHEDULE_ONLY=true' "$REAL_FEEDERS"; then
+    echo 'setup-extractor-feeders.sh does not implement --schedule-only' >&2
+    exit 1
+fi
+if ! grep -q 'if \$SCHEDULE_ONLY; then' "$REAL_FEEDERS"; then
+    echo 'git-templates step is not guarded by --schedule-only' >&2
+    exit 1
+fi
+if ! grep -q '! \$SCHEDULE_ONLY' "$REAL_FEEDERS"; then
+    echo 'fleeting-notes step is not guarded by --schedule-only' >&2
+    exit 1
+fi
+# The launchd job cannot start without its log directory -- only the Linux
+# branch of roles/extractor/install.sh used to create it.
+if ! grep -q 'mkdir -p "\$HOME/logs/extractor"' "$REAL_FEEDERS"; then
+    echo 'feeders script does not create the launchd log directory' >&2
     exit 1
 fi
 if ! grep -Fq 'launchd plist установлен' <(printf '%s' "$OUT"); then

--- a/scripts/tests/test-update-extractor-feeders.sh
+++ b/scripts/tests/test-update-extractor-feeders.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034  # globals below are read by the function evaluated from update.sh.
+# WP-5 F55: update.sh must schedule the Knowledge Extractor on already-configured
+# machines, not only on a fresh setup.sh install (High finding of F54).
+# Hyphenated filename on purpose: the secret guard reads test_<long-token> as a
+# payment key and redacts it out of every log and CI file that names it.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# The defect was structural: the step existed in setup.sh and nowhere in the
+# update path. Guard the wiring itself, not just the function body.
+if ! awk '/^run_post_apply_backfills_or_die\(\)/,/^}/' "$ROOT/update.sh" \
+    | grep -q 'backfill_extractor_feeders'; then
+    echo 'post-apply backfill chain does not call backfill_extractor_feeders' >&2
+    exit 1
+fi
+
+eval "$(awk '
+  /^backfill_extractor_feeders\(\)/ { capture=1 }
+  capture { print }
+  capture && /^}/ { exit }
+' "$ROOT/update.sh")"
+declare -F backfill_extractor_feeders >/dev/null
+
+SCRIPT_DIR="$TMP/template"
+WORKSPACE_DIR="$TMP/workspace"
+EFFECTIVE_GOVERNANCE_REPO="DS-my-strategy"
+mkdir -p "$SCRIPT_DIR/scripts" "$WORKSPACE_DIR" "$TMP/bin"
+
+FEEDERS="$SCRIPT_DIR/scripts/setup-extractor-feeders.sh"
+write_feeders() {  # $1 = exit code the stub reports
+    cat > "$FEEDERS" <<STUB
+#!/usr/bin/env bash
+printf '%s|%s|%s|%s\n' "\$1" "\$IWE_WORKSPACE" "\$IWE_GOVERNANCE_REPO" "\$IWE_RUNTIME" > "$TMP/feeders-call"
+echo "  launchd plist установлен"
+exit $1
+STUB
+    chmod +x "$FEEDERS"
+}
+printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP/bin/claude"
+chmod +x "$TMP/bin/claude"
+PATH="$TMP/bin:$PATH"
+
+# 1. Happy path: feeders installed with the workspace's own governance/runtime.
+write_feeders 0
+OUT=$(backfill_extractor_feeders)
+EXPECTED="install|$WORKSPACE_DIR|DS-my-strategy|$WORKSPACE_DIR/.iwe-runtime"
+if [ "$(cat "$TMP/feeders-call")" != "$EXPECTED" ]; then
+    echo "feeders invoked with wrong mode or environment: $(cat "$TMP/feeders-call")" >&2
+    exit 1
+fi
+if ! grep -Fq 'launchd plist установлен' <(printf '%s' "$OUT"); then
+    echo 'feeders output was swallowed instead of shown to the pilot' >&2
+    exit 1
+fi
+
+# 2. Opt-out: a pilot who removed the feeders keeps them removed across updates.
+rm "$TMP/feeders-call"
+OUT=$(IWE_SKIP_EXTRACTOR_FEEDERS=1 backfill_extractor_feeders)
+if [ -e "$TMP/feeders-call" ]; then
+    echo 'IWE_SKIP_EXTRACTOR_FEEDERS=1 still ran the feeders script' >&2
+    exit 1
+fi
+if ! grep -Fq 'IWE_SKIP_EXTRACTOR_FEEDERS=1' <(printf '%s' "$OUT"); then
+    echo 'opt-out was silent' >&2
+    exit 1
+fi
+
+# 3. No claude CLI: not an update failure, but the pilot is told what to run.
+OUT=$(PATH="/usr/bin:/bin" backfill_extractor_feeders)
+if [ -e "$TMP/feeders-call" ]; then
+    echo 'feeders ran without the claude CLI (it would exit 1 there)' >&2
+    exit 1
+fi
+if ! grep -Fq "bash $FEEDERS" <(printf '%s' "$OUT"); then
+    echo 'missing CLI case did not print the manual command' >&2
+    exit 1
+fi
+
+# 4. Older template without the feeders script: skipped, not fatal.
+mv "$FEEDERS" "$TMP/feeders-hidden"
+OUT=$(backfill_extractor_feeders)
+if ! grep -Fq 'backfill пропущен' <(printf '%s' "$OUT"); then
+    echo 'missing feeders script was not reported as a skip' >&2
+    exit 1
+fi
+mv "$TMP/feeders-hidden" "$FEEDERS"
+
+# 5. Feeders failure surfaces, with the manual retry, and reports non-zero.
+write_feeders 1
+set +e
+OUT=$(backfill_extractor_feeders 2>&1)
+STATUS=$?
+set -e
+if [ "$STATUS" -eq 0 ]; then
+    echo 'feeders failure was reported as success' >&2
+    exit 1
+fi
+if ! grep -Fq 'повторите вручную' <(printf '%s' "$OUT"); then
+    echo 'feeders failure did not print the manual retry' >&2
+    exit 1
+fi
+
+echo 'PASS: update.sh backfills the Extractor feeders (install, opt-out, no-CLI, missing script, failure)'

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2489,7 +2489,7 @@
     },
     {
       "path": "scripts/setup-extractor-feeders.sh",
-      "sha256": "6a73a17201951293542388d78cb4c903a5149fd1d78c31eb0e7730253ecf3826"
+      "sha256": "170efdf27b5a7874a87bdaae0c7d70e2de5c6843d4663725a60f884b5059d109"
     },
     {
       "path": "scripts/setup-vscode-auto-mode.sh",
@@ -2885,7 +2885,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "4791c1064bb66731e50d34527ca8ab59e1836f66bd3d7f497788dd443eaecbc9"
+      "sha256": "e89d3534943369502b20b364909c28640cbe2503c8c4fd8f9b3db92f54429653"
     }
   ],
   "excluded_paths": [

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2885,7 +2885,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "2f16473f2e4e6575e4d00451e3e3e665d72a8c14347b19d3d9dd3d56dbd7d7aa"
+      "sha256": "4791c1064bb66731e50d34527ca8ab59e1836f66bd3d7f497788dd443eaecbc9"
     }
   ],
   "excluded_paths": [
@@ -2913,6 +2913,7 @@
     "scripts/tests/conftest.py",
     "scripts/tests/lib/extract-update-download-batch.sh",
     "scripts/tests/session-guard-audit-validate-orz-batch-smoke.sh",
+    "scripts/tests/test-update-extractor-feeders.sh",
     "scripts/tests/test_adopt_governance.sh",
     "scripts/tests/test_agent_dashboard.py",
     "scripts/tests/test_copy_to_aisystant.py",

--- a/update.sh
+++ b/update.sh
@@ -1581,6 +1581,50 @@ run_post_apply_backfills_or_die() {
     echo ""
     echo "Executor catalog (upgrade backfill)..."
     backfill_executor_catalog || true
+
+    echo ""
+    echo "Knowledge Extractor feeders (upgrade backfill)..."
+    backfill_extractor_feeders || true
+}
+
+# WP-5 F55 (High finding of F54, 03.09): setup.sh got the extractor feeders
+# step, update.sh did not -- so every already-configured machine (the ones
+# where the gap actually showed up) kept getting updates with the capture
+# pipeline still not scheduled, forever. Runs from the post-apply chain, which
+# also fires in the TOTAL_CHANGES=0 recovery branches, so an install that is
+# otherwise up to date still gets its feeders. Re-running is safe: the feeders
+# script skips an unchanged, already-loaded launchd job instead of unload/load
+# (which would kill a run in flight at exactly 06:00/21:00).
+backfill_extractor_feeders() {
+    local feeders="$SCRIPT_DIR/scripts/setup-extractor-feeders.sh"
+    local governance_repo="${EFFECTIVE_GOVERNANCE_REPO:-$(effective_governance_repo)}"
+    local feeders_output
+
+    if [ "${IWE_SKIP_EXTRACTOR_FEEDERS:-0}" = "1" ]; then
+        echo "  ○ Экстрактор: пропущен (IWE_SKIP_EXTRACTOR_FEEDERS=1)."
+        return 0
+    fi
+    if [ ! -f "$feeders" ]; then
+        echo "  ○ Экстрактор: scripts/setup-extractor-feeders.sh не найден, backfill пропущен."
+        return 0
+    fi
+    # The feeders script exits 1 without the CLI; on update that is a normal
+    # state (CLI not installed yet), not an update failure -- say what to run
+    # later instead of printing its error.
+    if ! command -v claude >/dev/null 2>&1; then
+        echo "  ○ Экстрактор: claude CLI не установлен — расписание не заводим."
+        echo "    После установки CLI: bash $feeders"
+        return 0
+    fi
+
+    if feeders_output=$(IWE_WORKSPACE="$WORKSPACE_DIR" IWE_GOVERNANCE_REPO="$governance_repo"         IWE_RUNTIME="$WORKSPACE_DIR/.iwe-runtime"         bash "$feeders" install 2>&1); then
+        printf '%s\n' "$feeders_output" | sed 's/^/  /'
+        return 0
+    fi
+
+    printf '%s\n' "$feeders_output" | sed 's/^/  /' >&2
+    echo "  ⚠ Экстрактор не запустится автоматически — повторите вручную: bash $feeders" >&2
+    return 1
 }
 
 record_rule_workspace_state() {

--- a/update.sh
+++ b/update.sh
@@ -1597,8 +1597,15 @@ run_post_apply_backfills_or_die() {
 # (which would kill a run in flight at exactly 06:00/21:00).
 backfill_extractor_feeders() {
     local feeders="$SCRIPT_DIR/scripts/setup-extractor-feeders.sh"
-    local governance_repo="${EFFECTIVE_GOVERNANCE_REPO:-$(effective_governance_repo)}"
+    local governance_repo="${EFFECTIVE_GOVERNANCE_REPO:-}"
     local feeders_output
+
+    # Two steps, not one: `local x="$(f)"` would swallow a failing f, and an
+    # empty repo name silently becomes the wrong default one level down.
+    if [ -z "$governance_repo" ] && ! governance_repo=$(effective_governance_repo); then
+        echo "  ○ Экстрактор: governance-репозиторий не определён, backfill пропущен."
+        return 0
+    fi
 
     if [ "${IWE_SKIP_EXTRACTOR_FEEDERS:-0}" = "1" ]; then
         echo "  ○ Экстрактор: пропущен (IWE_SKIP_EXTRACTOR_FEEDERS=1)."
@@ -1617,7 +1624,15 @@ backfill_extractor_feeders() {
         return 0
     fi
 
-    if feeders_output=$(IWE_WORKSPACE="$WORKSPACE_DIR" IWE_GOVERNANCE_REPO="$governance_repo"         IWE_RUNTIME="$WORKSPACE_DIR/.iwe-runtime"         bash "$feeders" install 2>&1); then
+    # --schedule-only, not install: an update may add the periodic job, but must
+    # not redo the install-time decisions (the global git hook template, the
+    # init.templateDir pointer, seeding fleeting-notes) on every single run.
+    # IWE_WORKSPACE is deliberately not passed: the feeders script never reads
+    # it, so passing it would only pretend the workspace is configurable here.
+    if feeders_output=$(
+        IWE_GOVERNANCE_REPO="$governance_repo" \
+        IWE_RUNTIME="$WORKSPACE_DIR/.iwe-runtime" \
+        bash "$feeders" --schedule-only 2>&1); then
         printf '%s\n' "$feeders_output" | sed 's/^/  /'
         return 0
     fi


### PR DESCRIPTION
## Что чинится

Шаг установки конвейера вычленения знаний (Экстрактор) добавили в `setup.sh` 03.09 (РП-5 Ф54), а в `update.sh` его не было. Значит любая **уже настроенная** машина — ровно та, где баг и проявился — сколько ни обновляйся, расписание `git-diff-feed` не получала никогда. Это была High-находка холодного ревью Ф54, осознанно отложенная тогда, чтобы не расширять объём.

## Как

`backfill_extractor_feeders` в цепочке post-apply (`run_post_apply_backfills_or_die`). Цепочка вызывается и из веток с нулевым diff, поэтому установка, которая «уже актуальна», тоже получает расписание. Рантайм к этому моменту всегда пересобран — все три места вызова идут после `run_build_runtime_or_die`.

Повторный запуск безопасен: скрипт feeders пропускает неизменённую и уже загруженную задачу вместо `unload`/`load`, который мог бы оборвать прогон ровно в 06:00 или 21:00.

Обновление не падает ни в одном отказе:
- нет `claude` CLI — печатается команда на потом (для feeders это `exit 1`, для обновления — норма);
- `IWE_SKIP_EXTRACTOR_FEEDERS=1` — осознанный отказ пилота, снявшего расписание, переживает обновления;
- скрипта нет (старый шаблон) или feeders упал — предупреждение с командой для ручного повтора.

## Проверка

Живьём на Маке автора: первый прогон переписал plist (старое форматирование от предыдущей версии генератора), второй сказал «уже установлен и активен, без изменений», задача осталась загруженной, последний прогон вышел с нулём.

Тест `scripts/tests/test-update-extractor-feeders.sh` (в CI, dev-only) закрывает пять случаев, включая саму проводку вызова в цепочку — структурный корень дефекта, а не только тело функции.

Имя файла с дефисами намеренно: страж секретов читает `test_<длинный токен>` как платёжный ключ и вырезает его из логов и CI-файлов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)