### PR TITLE
fix(paths): portable IWE_ROOT + dry-run-gate anchoring, not $HOME/IWE

### DIFF
--- a/.claude/hooks/dry-run-gate.sh
+++ b/.claude/hooks/dry-run-gate.sh
@@ -285,7 +285,7 @@ if [ ! -f "$SENTINEL" ]; then
                 echo "[dry-run-gate] BLOCKED: dry-run sentinel missing while state gate_id=$gate_id is still active"
                 echo "Reason: owner alive or orphanhood not proven — fail-closed per contract"
                 printf 'Recovery (pilot terminal only, after confirming no dry-run is actually active):\n  bash %q %s manual-recovery\n' \
-                    "$HOME/IWE/FMT-exocortex-template/scripts/dry-run-complete.sh" "$gate_id"
+                    "$IWE_ROOT_GUESS/FMT-exocortex-template/scripts/dry-run-complete.sh" "$gate_id"
             } >&2
             exit 2
         fi
@@ -510,16 +510,22 @@ if [ "$TOOL_NAME" = "Bash" ]; then
     # (подтверждено code review: без этого фикс путь 5 блокирует день. close на
     # первом же шаге — читай-только скрипты, а не место реального write).
     #
-    # Точный `$HOME`-путь в паттерне, НЕ wildcard: `[^}]*` вместо конкретного
+    # Точный путь в паттерне, НЕ wildcard: `[^}]*` вместо конкретного
     # default-значения разрешал бы `${IWE_TEMPLATE:-$(cmd)}/...` — command
     # substitution внутри default оказывался бы проглочен маркером ДО того, как
     # шаг 2 успевает его сегментировать и опознать (round-2 review, живое
     # воспроизведение: `${IWE_TEMPLATE:-$(touch /tmp/PWNED)}/...` проходил как
     # allow). Тот же урок, что уже применён к `WL_ABS`/`WL_ABS2` ниже (review-01
     # High/review-02 H1) — whitelist только по точной строке, не по glob.
-    WL_TEMPLATE_ABS="$HOME/IWE/FMT-exocortex-template"
+    # issue #694: якорь — $IWE_ROOT_GUESS (путь самого хука, вычислен строкой
+    # ~27 из BASH_SOURCE), не $HOME/IWE — тот же приём, что уже используется
+    # для GATE_LOG выше. Не env-переменная (IWE_WORKSPACE/IWE_TEMPLATE
+    # инжектируемы вызывающим окружением — тот самый обход, который
+    # review-01/review-02 закрыли отказом от env-default в этом whitelist).
+    WL_TEMPLATE_ABS="$IWE_ROOT_GUESS/FMT-exocortex-template"
     NORM=$(printf '%s' "$CMD" | sed -E \
         -e 's@"\$IWE_SCRIPTS/day-close-prepare\.sh"@ __WL_DAY_CLOSE_PREPARE__ @g' \
+        -e 's@"\$IWE_SCRIPTS/dry-run-complete\.sh"@ __WL_DRY_RUN_COMPLETE__ @g' \
         -e "s@\\\$\\{IWE_TEMPLATE:-${WL_TEMPLATE_ABS//\//\\/}\\}/\\.claude/scripts/memory-drift-scan\\.py@ __WL_PY_MDS__ @g" \
         -e "s@\\\$\\{IWE_TEMPLATE:-${WL_TEMPLATE_ABS//\//\\/}\\}/\\.claude/scripts/check-index-health\\.py@ __WL_PY_CIH__ @g" \
         -e "s/'[^']*'/ QSTR /g" \
@@ -607,25 +613,30 @@ if [ "$TOOL_NAME" = "Bash" ]; then
                 # payload инспектируем по коду скрипта (write-путей нет).
                 # Список синхронизирован с memory/dry-run-contract.md §Bash matchers;
                 # добавление = правка контракта + этого case + code review.
-                # Абсолютный путь привязан к $HOME/IWE и захардкожен (review-01 High,
-                # review-02 H1): glob */.claude/... пропускал /tmp-подделку, а
-                # ${IWE_ROOT:-...} открывал тот же обход через env-инъекцию.
+                # Абсолютный путь захардкожен по точной строке, не по glob
+                # (review-01 High, review-02 H1): glob */.claude/... пропускал
+                # /tmp-подделку, а ${IWE_ROOT:-...}/${IWE_WORKSPACE:-...} открывал
+                # тот же обход через env-инъекцию (вызывающее окружение может
+                # подставить произвольный env перед Bash-вызовом). Якорь —
+                # $IWE_ROOT_GUESS (issue #694): путь самого хука через
+                # BASH_SOURCE (строка ~27), нестандартный WORKSPACE_DIR
+                # резолвится сам, инъекция через env невозможна.
                 shift
-                WL_ABS="$HOME/IWE/.claude/scripts/load-extensions.sh"
+                WL_ABS="$IWE_ROOT_GUESS/.claude/scripts/load-extensions.sh"
                 # Реальный deployed путь — вложенный клон, не workspace-root
                 # (scripts/ не копируется в $WORKSPACE_DIR, в отличие от .claude/;
                 # см. IWE_SCRIPTS default в .claude/lib/iwe-env-bootstrap.sh:86).
-                WL_ABS2="$HOME/IWE/FMT-exocortex-template/scripts/day-close-prepare.sh"
+                WL_ABS2="$IWE_ROOT_GUESS/FMT-exocortex-template/scripts/day-close-prepare.sh"
                 # issue #549 stage 2: штатное завершение репетиции — переход
                 # active→completed через helper (rm sentinel внутри него идёт
                 # уже после completed, поэтому сам он безопасен под гейтом;
                 # его внутренний `rm -f "$SENTINEL"` покрыт cleanup-исключением
                 # ветки rm выше).
-                WL_ABS3="$HOME/IWE/FMT-exocortex-template/scripts/dry-run-complete.sh"
+                WL_ABS3="$IWE_ROOT_GUESS/FMT-exocortex-template/scripts/dry-run-complete.sh"
                 case "${1:-}" in
                     .claude/scripts/load-extensions.sh|"$WL_ABS") ;;
                     scripts/day-close-prepare.sh|"$WL_ABS2"|__WL_DAY_CLOSE_PREPARE__) ;;
-                    scripts/dry-run-complete.sh|"$WL_ABS3") ;;
+                    scripts/dry-run-complete.sh|"$WL_ABS3"|__WL_DRY_RUN_COMPLETE__) ;;
                     *) block "$CMD (indirect execution under dry-run)" ;;
                 esac
                 ;;

--- a/setup/install-iwe-paths.sh
+++ b/setup/install-iwe-paths.sh
@@ -65,6 +65,7 @@ cat > "$IWE_ENV_FILE" <<IWEENV_EOF
 # Do not edit manually — changes will be lost.
 
 export IWE_WORKSPACE="$WORKSPACE_DIR"
+export IWE_ROOT="\$IWE_WORKSPACE"
 export IWE_TEMPLATE="\$IWE_WORKSPACE/FMT-exocortex-template"
 export IWE_SCRIPTS="\$IWE_TEMPLATE/scripts"
 export IWE_ROLES="\$IWE_TEMPLATE/roles"

--- a/setup/test-update-edge-cases.sh
+++ b/setup/test-update-edge-cases.sh
@@ -1676,8 +1676,8 @@ EOF
 HOME="$T25_HOME" bash "$TEMPLATE_DIR/setup/install-iwe-paths.sh" --workspace "$T25_WS" --governance GOV --quiet
 if grep -qF "_IWE_ROOT=\"$T25_WS\"" "$T25_HOME/.zshenv" && \
    ! grep -qF '[ -f "$HOME/.iwe-paths" ]' "$T25_HOME/.zshenv" && \
-   [ "$(grep -c '^export IWE_' "$T25_WS/.iwe-paths")" -eq 6 ]; then
-    pass "T25: legacy HOME source is replaced by the six-variable workspace SoT"
+   [ "$(grep -c '^export IWE_' "$T25_WS/.iwe-paths")" -eq 7 ]; then
+    pass "T25: legacy HOME source is replaced by the seven-variable workspace SoT"
 else
     fail "T25: install-iwe-paths left the legacy source or incomplete workspace env"
 fi

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -69,7 +69,7 @@
     },
     {
       "path": ".claude/hooks/dry-run-gate.sh",
-      "sha256": "1f3f2d75cd688dceddfc407eafc3f8bec4075beeb5d618fe30ae6e92e6589a10"
+      "sha256": "2e3dd292d23af97801d664565f6add12cad1b39030b110ed21e20c944372241a"
     },
     {
       "path": ".claude/hooks/extensions-gate.sh",
@@ -2853,7 +2853,7 @@
     },
     {
       "path": "setup/install-iwe-paths.sh",
-      "sha256": "523cd10448bbd0a2bf8a5458e26d2d56bacc9c7ab72bb9fc7d1690d3ee7f6aab"
+      "sha256": "8f4839935293ecfcbf8c981619d2d24832291a646f943a37ee34cf077a92bb67"
     },
     {
       "path": "setup/optional/setup-cloud-scheduler.sh",


### PR DESCRIPTION
## Summary

- `setup/install-iwe-paths.sh` now exports `IWE_ROOT` alongside `IWE_WORKSPACE` — 77 scripts under `scripts/`/`.claude/scripts/` read `IWE_ROOT` with a `$HOME/IWE` default, which is wrong on any non-default workspace location (#695).
- `.claude/hooks/dry-run-gate.sh`'s Bash write-tool whitelist anchors on `$IWE_ROOT_GUESS` (already computed from the hook's own `BASH_SOURCE`, used elsewhere in the same file for `GATE_LOG`) instead of a literal `$HOME/IWE`. This is a security-sensitive path — a prior review (review-01/review-02, comments preserved) explicitly rejected using an env-var default (`${IWE_ROOT:-...}`) here because a caller-controlled env var could retarget the whitelist to an attacker-planted script. `$IWE_ROOT_GUESS` isn't read from the environment, so it fixes the portability bug without reopening that hole (#694).
- Added the missing quote-collapse marker for `dry-run-complete.sh` (the same point-fix `day-close-prepare.sh` already had) — the documented rehearsal-completion command was always falling through to the generic QSTR collapse and getting blocked as "indirect execution under dry-run" (#687).

## Test plan
- [x] `bash -n` on the modified hook
- [x] `shellcheck` clean (no new warnings vs. baseline)
- [x] Standalone test of the normalize+whitelist logic: the documented `dry-run-complete.sh` invocation now passes; an attacker-supplied `/tmp/evil/...` path is still blocked
- [x] Simulated a non-default `WORKSPACE_DIR` (`/home/user/Github`) through the same logic — whitelist resolves correctly

Closes #695, #694, #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)