### PR TITLE
fix(hooks): agent-status path + check-secret AWS/base64-secret gap

### DIFF
--- a/.claude/hooks/session-end-status.sh
+++ b/.claude/hooks/session-end-status.sh
@@ -9,7 +9,7 @@ CLAUDE_DIR="$(cd "${HOOK_DIR}/.." && pwd)"
 # shellcheck source=../lib/iwe-env-bootstrap.sh
 source "$CLAUDE_DIR/lib/iwe-env-bootstrap.sh" 2>/dev/null || { echo '{}'; exit 0; }
 
-STATUS_SCRIPT="$IWE_ROOT/scripts/agent-status-report.sh"
+STATUS_SCRIPT="$IWE_SCRIPTS/agent-status-report.sh"
 [ -x "$STATUS_SCRIPT" ] && bash "$STATUS_SCRIPT" claude-code idle 2>/dev/null
 
 echo '{}'

--- a/.claude/skills/check-secret/check.sh
+++ b/.claude/skills/check-secret/check.sh
@@ -49,7 +49,8 @@ declare -a patterns=(
   "Anthropic API key|sk-ant-api[0-9]{2}-[A-Za-z0-9_-]{30,}"
   "GitHub token|gh[poshru]_[A-Za-z0-9]{30,}"
   "AWS access key|AKIA[0-9A-Z]{16}"
-  "Generic 40+ char API token|(_API_KEY|_TOKEN|_KEY)[[:space:]]*=[[:space:]]*\"?[A-Za-z0-9_-]{40,}\"?"
+  "AWS secret key|[Aa][Ww][Ss].{0,24}([Ss]ecret|[Pp]rivate).{0,24}[=:][[:space:]]*[\"']?[A-Za-z0-9/+=]{40}"
+  "Generic 40+ char API token|(_API_KEY|_TOKEN|_KEY)[[:space:]]*=[[:space:]]*\"?[A-Za-z0-9_/+=-]{40,}\"?"
 )
 
 violations=""

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -145,7 +145,7 @@
     },
     {
       "path": ".claude/hooks/session-end-status.sh",
-      "sha256": "07b157c5d7614939f027aa50080cabe4531aba4ebae8886038f167620daba6b9"
+      "sha256": "6b54f91929897e8416d82b14454e301290dd90b6af87a7596fd71765404aa2af"
     },
     {
       "path": ".claude/hooks/session-start-hooks-bootstrap.sh",
@@ -341,7 +341,7 @@
     },
     {
       "path": ".claude/skills/check-secret/check.sh",
-      "sha256": "7c5dace7bf1e9bd8769c87d6115a7a917f837db872bc2069af64562d4744da5c"
+      "sha256": "8cf83e63b49b05ed5ed4bbb9bd79c83c1af34dde0e5aaec770ffc66e79864e55"
     },
     {
       "path": ".claude/skills/consent/SKILL.md",


### PR DESCRIPTION
## Summary
- `.claude/hooks/session-end-status.sh` looked for `agent-status-report.sh` at `$IWE_ROOT/scripts/` (the workspace root), but the script actually ships at `$IWE_SCRIPTS` (`$WORKSPACE_DIR/FMT-exocortex-template/scripts/`) — already bootstrapped one line earlier in the same file. Silent no-op on every session end (#690). The separate question of whether Agent Status Registry should be an MCP tool at all stays open for the pilot; this only fixes the unambiguous path bug.
- `check-secret`'s "Generic 40+ char API token" pattern required `[A-Za-z0-9_-]{40,}`, one character class short of an AWS secret key (exactly 40 chars from the base64 alphabet, which includes `/` and `+`). Widened that pattern's charset and added a dedicated AWS-secret pattern (context: "aws...secret/private") as a second, independent net (#696).

## Test plan
- [x] Traced `IWE_SCRIPTS`'s actual bootstrap value against where `agent-status-report.sh` lives in the tree — confirmed the mismatch
- [x] Reproduced the issue's exact secret string against `check.sh` before/after — now blocks
- [x] Confirmed no false positive on benign prose mentioning "AWS" and "secret"
- [x] `shellcheck` clean

Closes #690, #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)