### PR TITLE
fix: manifest hash stale after cross-PR merge (day-open-scaffold.sh)

### DIFF
--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2857,7 +2857,7 @@
     },
     {
       "path": "seed/strategy/scripts/day-open-scaffold.sh",
-      "sha256": "ae3f40c40b31d5bdfa1c1c4e9a87a10415f731982ac5bf348d319d9503de1651"
+      "sha256": "82a95634eb0a2270847f2aa4a6cc7215662da0ea501e48e782b1a72f6a63b22b"
     },
     {
       "path": "seed/strategy/scripts/day-open-version-check-patch.py",


### PR DESCRIPTION
## Summary
Small follow-up after merging #700-#704: `main`'s CI (Validate Template) failed post-merge on `Check manifest completeness (B2)`.

Root cause is a cross-PR interaction neither individual PR's CI could see: #701 added `seed/strategy/scripts/day-open-scaffold.sh` to the manifest for the first time, hashing it against the file's *then-current* (unfixed) content. #704, on a separate branch, fixed that same file's actual bytes — but on #704's branch the file wasn't in the tracked array yet, so #704 had no manifest entry to update. Only after both merged did the stale hash (from #701) end up paired with the new content (from #704).

## Test plan
- [x] `bash generate-manifest.sh` on current `main` — confirms exactly this one entry is out of sync
- [x] `sha256sum` on the actual file, matches the new value independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)