### PR TITLE
fix(skills): source ~/.iwe-paths explicitly, don't rely on shell rc files

### DIFF
--- a/.claude/skills/audit-installation/SKILL.md
+++ b/.claude/skills/audit-installation/SKILL.md
@@ -48,6 +48,14 @@ Verdict выносит subagent в роли Аудитора, читая отч�
 Найти и запустить `iwe-audit.sh` через fallback-цепочку (author-mode → workspace, user-mode → `$IWE_SCRIPTS` из `~/.iwe-paths`):
 
 ```bash
+# issue #688: a non-interactive top-level Bash call doesn't go through
+# .bashrc/.zshenv (interactive-shell guard) or BASH_ENV (read before the
+# harness can set it) — $IWE_SCRIPTS is unset here on plenty of real
+# installs even though ~/.iwe-paths exists and is correct. Source it
+# directly, in this same shell, before reading the variable — `.` doesn't
+# depend on interactive/BASH_ENV machinery at all.
+IWE_PATHS="${IWE_PATHS_FILE:-$HOME/.iwe-paths}"
+[ -r "$IWE_PATHS" ] && . "$IWE_PATHS"
 if [ -n "${IWE_SCRIPTS:-}" ] && [ -f "$IWE_SCRIPTS/iwe-audit.sh" ]; then
     # $IWE_SCRIPTS first (#566): the hardcoded workspace copy, when it exists at
     # all, is a stale leftover — the installer points IWE_SCRIPTS at the template.
@@ -55,7 +63,7 @@ if [ -n "${IWE_SCRIPTS:-}" ] && [ -f "$IWE_SCRIPTS/iwe-audit.sh" ]; then
 elif [ -f "$HOME/IWE/scripts/iwe-audit.sh" ]; then
     AUDIT_SCRIPT="$HOME/IWE/scripts/iwe-audit.sh"
 else
-    echo "iwe-audit.sh не найден. Если \$IWE_SCRIPTS не выставлен — выполни 'source \$HOME/.iwe-paths' (или перезапусти shell), затем повтори. Если файла .iwe-paths нет — запусти setup.sh из FMT-шаблона."
+    echo "iwe-audit.sh не найден. \$IWE_PATHS ($IWE_PATHS) не даёт рабочий \$IWE_SCRIPTS — проверь, что файл существует и содержит export IWE_SCRIPTS=... (запусти setup.sh из FMT-шаблона, если файла нет)."
     exit 1
 fi
 bash "$AUDIT_SCRIPT" $([ "${ARGUMENTS:-}" = "--critical" ] && echo "--critical")

--- a/.claude/skills/day-close/SKILL.md
+++ b/.claude/skills/day-close/SKILL.md
@@ -32,7 +32,7 @@ Day Close = протокол. Блокирующее требование — н
 `bash .claude/scripts/load-extensions.sh day-close before` → exit 0: `Read` каждый файл из вывода (alphabetic) → выполнить как первые шаги. Exit 1/3 (нет совпадений / нет каталога `extensions/` — штатно для новой установки, либо каталог повреждён) → пропустить молча. Поддерживает `extensions/day-close.before.md` И `extensions/day-close.before.<suffix>.md`.
 
 ### 0б. Дайджест — token discipline (issue #234)
-`bash "$IWE_SCRIPTS/day-close-prepare.sh"` — один вызов вместо ~10 скан-запросов. Пронумерованные секции дайджеста ЗАМЕНЯЮТ скан-команды внутри шагов ниже (сами шаги исполняются — но берут данные из дайджеста, не перезапускают сканы): §1→шаг 1, §2→10b, §3→2d, §4→4б, §5→4в, §6→4, §7→6, §8→6 (prerequisite), §9-10→3, §11→2f. Реагировать только на flagged-пункты; drift-хит, который реально «ждёт X», — не drift. Скрипт отсутствует → legacy: inline-команды шагов.
+`. "${IWE_PATHS_FILE:-$HOME/.iwe-paths}" 2>/dev/null; bash "$IWE_SCRIPTS/day-close-prepare.sh"` — источник переменных явный (issue #688: верхнеуровневый Bash-вызов не проходит `.bashrc`/`.zshenv`/`BASH_ENV`, `$IWE_SCRIPTS` может быть пуст без явного `.`), один вызов вместо ~10 скан-запросов. Пронумерованные секции дайджеста ЗАМЕНЯЮТ скан-команды внутри шагов ниже (сами шаги исполняются — но берут данные из дайджеста, не перезапускают сканы): §1→шаг 1, §2→10b, §3→2d, §4→4б, §5→4в, §6→4, §7→6, §8→6 (prerequisite), §9-10→3, §11→2f. Реагировать только на flagged-пункты; drift-хит, который реально «ждёт X», — не drift. Скрипт отсутствует → legacy: inline-команды шагов.
 **Субагентное исполнение (рекомендуется при большой сессии дня):** родитель выполняет только дайджест → диспетчеризацию → согласование (шаг 8) → верификацию; шаги 1-7 исполняет ОДИН general-purpose субагент (sonnet, context isolation) с дайджестом в промпте, шаги 9-10b — субагент-финализатор с `day-close-prepare.sh --verify` вместо inline-grep 9a/9b; шаг 11 (R23) диспетчеризует родитель — субагент не может звать субагентов. Fallback: Agent tool недоступен / субагент упал дважды → исполнять inline, всё равно с дайджестом.
 <!-- Детали фаз: day-close-details.md § Шаг 0б -->
 
@@ -65,20 +65,20 @@ Day Close = протокол. Блокирующее требование — н
 
 ### 4б. Memory Drift Scan
 Две независимые проверки (issue #326 — лексическая одна пропускала расхождения статуса без триггерных слов):
-1. **Структурная:** `T="${IWE_TEMPLATE:-$HOME/IWE/FMT-exocortex-template}"; PY3="$(bash "$T/.claude/lib/find-python3.sh")" && "$PY3" "$T/.claude/scripts/memory-drift-scan.py"` — сверяет колонку «Статус» MEMORY.md с полем `status` WP-context по номеру РП. Exit 1 → для каждой найденной строки обновить устаревшее.
+1. **Структурная:** `. "${IWE_PATHS_FILE:-$HOME/.iwe-paths}" 2>/dev/null; T="${IWE_TEMPLATE:-$HOME/IWE/FMT-exocortex-template}"; PY3="$(bash "$T/.claude/lib/find-python3.sh")" && "$PY3" "$T/.claude/scripts/memory-drift-scan.py"` — сверяет колонку «Статус» MEMORY.md с полем `status` WP-context по номеру РП. Exit 1 → для каждой найденной строки обновить устаревшее.
 2. **Лексическая:** Grep MEMORY.md на паттерны «ждёт/блокер/blocked/остановлен» (ловит текстовые блокеры без изменения статуса — отдельный класс, скрипт п.1 их не видит). Для каждого: найти WP-context, проверить статус, обновить устаревшее.
 Анонс при 0 расхождений по обеим проверкам: *«Drift-scan: N паттернов + M структурных, устаревших нет»*.
 <!-- Детали: day-close-details.md § Шаг 4б -->
 
 ### 4в. Index Health Check
-`T="${IWE_TEMPLATE:-$HOME/IWE/FMT-exocortex-template}"; PY3="$(bash "$T/.claude/lib/find-python3.sh")" && "$PY3" "$T/.claude/scripts/check-index-health.py"` — для каждого FAIL/WARN: диагностика (дамп vs жанр) → перенести или пометить skip.
+`. "${IWE_PATHS_FILE:-$HOME/.iwe-paths}" 2>/dev/null; T="${IWE_TEMPLATE:-$HOME/IWE/FMT-exocortex-template}"; PY3="$(bash "$T/.claude/lib/find-python3.sh")" && "$PY3" "$T/.claude/scripts/check-index-health.py"` — для каждого FAIL/WARN: диагностика (дамп vs жанр) → перенести или пометить skip.
 <!-- Детали: day-close-details.md § Шаг 4в -->
 
 ### 4. Lesson Hygiene
 Просмотреть «Уроки» в MEMORY.md. Не применялся >1 нед и есть в `lessons_*.md` → удалить. Новый урок → строка в MEMORY.md + `lessons_*.md`. Цель: ≤8 уроков.
 
 ### 5. Автоматические шаги
-`"$IWE_SCRIPTS/day-close.sh"` — Linear sync, downstream sync (update.sh), backup (memory/ + CLAUDE.md).
+`. "${IWE_PATHS_FILE:-$HOME/.iwe-paths}" 2>/dev/null; "$IWE_SCRIPTS/day-close.sh"` — источник переменных явный (issue #688, см. шаг 0б), Linear sync, downstream sync (update.sh), backup (memory/ + CLAUDE.md).
 
 ### 6. Мультипликатор IWE
 > Условный шаг: если `params.yaml → multiplier_enabled: false` → пропустить и

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -325,7 +325,7 @@
     },
     {
       "path": ".claude/skills/audit-installation/SKILL.md",
-      "sha256": "650596be95602ce2398c0ace07ac2332e0235e50dc32ab5b4f5374ac1476eedf"
+      "sha256": "0d1e7dfb68f71fca83fd71e21947573e34835ba06c5c7b0f1a16cfdecf4de23e"
     },
     {
       "path": ".claude/skills/author-mode/SKILL.md",
@@ -349,7 +349,7 @@
     },
     {
       "path": ".claude/skills/day-close/SKILL.md",
-      "sha256": "a8100ce0dc32e67c699e8e35200af75f8daa7f61330929584dce7ac5d559c220"
+      "sha256": "03d5467543065220642d6fe03838015a48b5ca4cf4945c4b6c5000f9d48f4609"
     },
     {
       "path": ".claude/skills/day-close/day-close-details.md",


### PR DESCRIPTION
## Summary
A top-level, non-interactive Bash tool call never goes through `.bashrc`'s interactive-shell guard or `.zshenv`, and `BASH_ENV` set via `.claude/settings.local.json` is read before Claude Code's harness can populate it — so `$IWE_SCRIPTS`/`$IWE_TEMPLATE` come up empty at the top level on real installs even though `~/.iwe-paths` exists and is correct, per the issue's own live repro.

The issue's own suggested fix (anchor on the SKILL.md's own file location) doesn't actually work: SKILL.md is prose an LLM reads, not a script with `$BASH_SOURCE`. `bash -c` doesn't fix it either — a child bash still won't read `~/.iwe-paths` on its own, it only forwards `BASH_ENV`, the same implicit dependency one level down.

Real fix: explicitly `source ~/.iwe-paths` (or `$IWE_PATHS_FILE` override) in the same shell before reading the variable — `.` doesn't depend on interactive/`BASH_ENV` timing. Applied to `audit-installation/SKILL.md` step 1 and all four `$IWE_SCRIPTS`/`$IWE_TEMPLATE` top-level reads in `day-close/SKILL.md` (steps 0б/4б/4в/5 — same class of bug at each site, not just the two the issue cited). A full audit of every `SKILL.md` for this pattern is a separate, larger task.

This diagnosis and fix direction were worked out in a peer session with Codex (session `2026-09-07-04-fmt-issues-remaining-triage`).

## Test plan
- [x] `bash scripts/verify-manifest.sh` — manifest in sync
- [x] `sha256sum` on both changed files matches the regenerated manifest entries

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)