### PR TITLE
fix(strategist): day-plan.md — git -C вместо голого cd

### DIFF
--- a/roles/strategist/prompts/day-plan.md
+++ b/roles/strategist/prompts/day-plan.md
@@ -87,11 +87,11 @@ fi
 ### Шаг 7 — сохранение и коммит
 
 ```bash
-cd "${IWE_WORKSPACE:-$HOME/IWE}/{{GOVERNANCE_REPO}}"
-git add current/DayPlan*.md
-git commit -m "day-plan: $DATE автономный полный (strategist morning)"
-git pull --rebase  # на случай если Mac тоже что-то закоммитил
-git push
+REPO_DIR="${IWE_WORKSPACE:-$HOME/IWE}/{{GOVERNANCE_REPO}}"
+git -C "$REPO_DIR" add current/DayPlan*.md
+git -C "$REPO_DIR" commit -m "day-plan: $DATE автономный полный (strategist morning)"
+git -C "$REPO_DIR" pull --rebase  # на случай если Mac тоже что-то закоммитил
+git -C "$REPO_DIR" push
 ```
 
 ## АВТОНОМНЫЙ РЕЖИМ (БЛОКИРУЮЩЕЕ)

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1689,7 +1689,7 @@
     },
     {
       "path": "roles/strategist/prompts/day-plan.md",
-      "sha256": "6c0977b3101e3bad10b743e472c003f8ce4ac2fcc4a7c119d8d206a99b7cc3b7"
+      "sha256": "5eac6a0d017c9ac0f9b924a8bba550a32c42e12b4d2f55527ff1d6a6f46fd4a0"
     },
     {
       "path": "roles/strategist/prompts/evening.md",


### PR DESCRIPTION
## Что чинит

Ночной сценарий Стратега (`roles/strategist/prompts/day-plan.md`, шаг 7 «сохранение и коммит») использовал голый `cd "$PATH"` перед серией git-команд. Хук `destructive-guard.sh` (введён v0.39.1, 30 августа) блокирует такой голый `cd` вне формы `(cd <path> && ...)` или `git -C <path>`. Автономный запуск `strategist.sh morning` падал на этом шаге несколько дней подряд на реальной пользовательской установке (5-7 сентября 2026).

Фикс: каждая git-команда шага теперь использует `git -C "$REPO_DIR"` — не меняет текущую директорию процесса, поэтому не триггерит хук.

Closes #712

## Test plan

- [x] Живой прогон агентом на реальном хуке `destructive-guard.sh` (сама структура команды теперь совпадает с уже разрешённой формой)
- [x] Смысл шага не изменился (add/commit/pull --rebase/push той же папки)

---

Найдено и разобрано в пир-сессии Claude + Kimi + Codex (`2026-09-07-17-wp7-fmt-issues-triage`), WP-7 Ф116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)