### PR TITLE
fix(wp-sync-bundle): registry_status() — 5 багов разбора реестра

### DIFF
--- a/.claude/scripts/wp-sync-bundle.sh
+++ b/.claude/scripts/wp-sync-bundle.sh
@@ -191,12 +191,20 @@ registry_status_column() {
   local header
   header=$(grep -E '^\|[[:space:]]*#[[:space:]]*\|' "$REGISTRY_FILE" 2>/dev/null | head -1)
   [[ -z "$header" ]] && return 1
-  awk -F'|' -v h="$header" 'BEGIN {
+  # issue #717 follow-up (найдено при regression-тестах на этой же фазе, тот
+  # же класс бага, другой сбой): под некоторыми локалями (напр. en_US.UTF-8
+  # на macOS/awk-BWK 20200816) `==` в awk между двумя РАЗНЫМИ кириллическими
+  # строками возвращал true — не проблема регистра, а порча самого сравнения
+  # многобайтовых строк на уровне locale-aware коллации. `tolower()` для
+  # кириллицы при этом тоже locale-зависим (под голым `C` не сворачивает
+  # регистр вообще). Решение — не полагаться ни на `tolower()`, ни на
+  # locale-aware `==`: перечислить оба регистра литералом И считать байты под
+  # `LC_ALL=C`, где `==` — простое побайтовое сравнение без коллации.
+  LC_ALL=C awk -F'|' -v h="$header" 'BEGIN {
     n = split(h, cells, "|")
     for (i = 1; i <= n; i++) {
       c = cells[i]; gsub(/^[ \t]+|[ \t]+$/, "", c)
-      lc = tolower(c)
-      if (lc == "статус" || lc == "ст") { print i; exit }
+      if (c == "Статус" || c == "статус" || c == "СТАТУС" || c == "Ст" || c == "ст") { print i; exit }
     }
   }'
 }
@@ -213,6 +221,10 @@ registry_status() {
     echo "_некорректный номер РП: ${1}_"
     return
   fi
+  # issue #715: ведущие нули (WP-038) не совпадали с голым "38" в реестре —
+  # нормализуем ДО построения regex поиска строки. `10#` держит базу 10
+  # явно (иначе bash читает "038" как некорректный восьмеричный литерал).
+  num=$((10#$num))
   if [[ ! -f "$REGISTRY_FILE" ]]; then
     echo "_нет файла REGISTRY_"
     return
@@ -222,16 +234,27 @@ registry_status() {
   # "открыт как спин-офф WP-47" в статусе WP-49 возвращал статус WP-49 при
   # запросе WP-47). Строка опознаётся по СВОЕЙ первой ячейке (номер РП),
   # тем же приёмом, что ROW_RE в build-active-wp.py.
-  local line
-  line=$(grep -E "^\|[[:space:]]*(~~)?(\*\*)?${num}(\*\*)?(~~)?[[:space:]]*\|" "$REGISTRY_FILE" 2>/dev/null | head -1 || true)
-  if [[ -z "$line" ]]; then
+  # issue #716: пометка рядом с номером ("13★") не проходила прежний шаблон
+  # (требовал пробел/pipe сразу после числа) — поиск перескакивал на другую
+  # строку с тем же номером (например зачёркнутую предыдущую итерацию).
+  # `[^0-9|]*` разрешает произвольный суффикс между числом и разделителем
+  # колонки, но не цифру — иначе "13" совпал бы и с "138".
+  local regex="^\|[[:space:]]*(~~)?(\*\*)?${num}(\*\*)?(~~)?[^0-9|]*[[:space:]]*\|"
+  local match_count
+  match_count=$(grep -cE "$regex" "$REGISTRY_FILE" 2>/dev/null || true)
+  match_count=${match_count:-0}
+  if [[ "$match_count" -eq 0 ]]; then
     echo "_не в реестре_"
     return
   fi
-  if echo "$line" | grep -qE '~~'; then
-    echo "~~done~~ (зачёркнут)"
-    return
+  if [[ "$match_count" -gt 1 ]]; then
+    # issue #716: раньше молчаливый `head -1` без предупреждения мог отдать
+    # ПРОТИВОПОЛОЖНЫЙ действительности статус — теперь неоднозначность хотя
+    # бы видна в stderr, вместо тихой уверенной ошибки на первой строке.
+    echo "неоднозначно: $match_count совпадений по номеру ${num} в реестре, взята первая строка" >&2
   fi
+  local line
+  line=$(grep -E "$regex" "$REGISTRY_FILE" 2>/dev/null | head -1)
   local status_col status_cell
   status_col=$(registry_status_column)
   if [[ -z "$status_col" ]]; then
@@ -239,22 +262,48 @@ registry_status() {
     return
   fi
   # Статус берётся из СВОЕЙ ячейки, не грепом эмодзи по всей строке —
-  # эмодзи в описании соседней колонки раньше мог перебить вердикт.
+  # эмодзи в описании соседней колонки раньше мог перебить вердикт (issue #473).
   status_cell=$(echo "$line" | awk -F'|' -v col="$status_col" '{ v=$col; gsub(/^[ \t]+|[ \t]+$/, "", v); print v }')
-  if echo "$status_cell" | grep -q '✅'; then
-    echo "✅ done"
-  elif echo "$status_cell" | grep -q '🔄'; then
-    echo "🔄 in_progress"
-  elif echo "$status_cell" | grep -q '⏳'; then
-    echo "⏳ pending"
-  elif echo "$status_cell" | grep -q '📦'; then
-    echo "📦 archived"
-  elif echo "$status_cell" | grep -q '⏹'; then
-    echo "⏹ снят"
-  elif echo "$status_cell" | grep -q '🔁'; then
-    echo "🔁 свёрнут в спринт"
+  # issue #717: обычный `grep -q 'ЭМОДЗИ'` зависит от локали/сборки grep — на
+  # части машин (напр. GNU grep 3.0 + en_US.UTF-8) многобайтовый literal
+  # молча не матчился, хотя байты совпадали, и вся ось статуса слепла тихо.
+  # `LC_ALL=C grep -F` сравнивает как байтовую fixed-строку, не парсит эмодзи
+  # как regex-класс символов — не зависит от локали сборки. Область действия
+  # — только эти вызовы, не весь скрипт (глобальный `export LC_ALL=C` рискует
+  # сломать сортировку/срез многобайтовых строк в других местах файла, не
+  # относящихся к этой функции).
+  local resolved=""
+  if   LC_ALL=C grep -qF '✅' <<<"$status_cell"; then resolved="✅ done"
+  elif LC_ALL=C grep -qF '🔄' <<<"$status_cell"; then resolved="🔄 in_progress"
+  elif LC_ALL=C grep -qF '⏳' <<<"$status_cell"; then resolved="⏳ pending"
+  elif LC_ALL=C grep -qF '📦' <<<"$status_cell"; then resolved="📦 archived"
+  elif LC_ALL=C grep -qF '⏸' <<<"$status_cell"; then resolved="⏸ paused"
+  elif LC_ALL=C grep -qF '⏹' <<<"$status_cell"; then resolved="⏹ снят"
+  elif LC_ALL=C grep -qF '🔁' <<<"$status_cell"; then resolved="🔁 свёрнут в спринт"
+  fi
+  if [[ -n "$resolved" ]]; then
+    echo "$resolved"
+    return
+  fi
+  local text_status
+  text_status=$(echo "$status_cell" | grep -oE '(done|in_progress|pending|paused|archived|closed|open)' | head -1 || true)
+  if [[ -n "$text_status" ]]; then
+    echo "$text_status"
+    return
+  fi
+  # issue #714: зачёркивание — фолбэк ПОСЛЕ того, как своя колонка статуса не
+  # дала ответа, не проверка по всей строке раньше чтения колонки. Раньше
+  # зачёркнутое НАЗВАНИЕ при активном статусе в колонке (например 📦) давало
+  # ложный "~~done~~" — своя колонка теперь всегда главнее оформления строки.
+  # issue #713: код возврата пайплайна `grep | head` брался от `head`,
+  # который всегда завершается успешно даже на пустом входе — `||` был
+  # недостижим, и пустой результат утекал наружу как есть. Промежуточная
+  # переменная (text_status выше) — единственный надёжный способ отличить
+  # "нашли" от "не нашли" на пустом выводе grep.
+  if echo "$line" | grep -qE '~~'; then
+    echo "~~done~~ (зачёркнут)"
   else
-    echo "$status_cell" | grep -oE '(done|in_progress|pending|closed|open)' | head -1 || echo "_статус неизвестен_"
+    echo "_статус неизвестен_"
   fi
 }
 

--- a/scripts/tests/test_issue_713_registry_status.sh
+++ b/scripts/tests/test_issue_713_registry_status.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Regression coverage for the wp-sync-bundle.sh registry_status() cluster
+# found in the FMT-exocortex-template issue backlog (WP-7 F116, peer-session
+# with Kimi + Codex):
+#   #713 - "paused" status (⏸) fell through to an unreachable fallback and
+#          printed an empty line instead of a real status or "unknown".
+#   #714 - a strikethrough anywhere in the row overrode an active status
+#          column value (e.g. a struck-through title with a still-active 🔄
+#          status cell was reported as "done").
+#   #715 - a leading zero in the WP number (WP-038) failed to match the bare
+#          "38" stored in the registry.
+#   #716 - a marker glued to the number (e.g. "13★") fell outside the row
+#          regex and the lookup silently matched a different row sharing the
+#          same bare number.
+#   #717 - the status emoji comparison depended on the runtime locale; under
+#          some locale/awk combinations even the *column lookup* itself
+#          (registry_status_column, unrelated tolower()-based match) picked
+#          the wrong column entirely (found while regression-testing #717,
+#          not in the original report).
+# Each check below reproduces one issue's fixture from a single small
+# registry file and asserts the exact expected status string.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+TMP=$(mktemp -d)
+trap 'rm -rf -- "$TMP"' EXIT
+
+pass_count=0
+pass() { echo "  ✅ PASS: $*"; pass_count=$((pass_count + 1)); }
+fail() { echo "  ❌ FAIL: $*" >&2; exit 1; }
+
+REGISTRY_FILE="$TMP/registry.md"
+cat >"$REGISTRY_FILE" <<'EOF'
+| # | Название | Статус | Приоритет |
+|---|----------|--------|-----------|
+| 57 | Приостановленный | ⏸️ | P1 |
+| 39 | ~~Свёрнутый в архив~~ | 📦 | P2 |
+| 38 | **Резидентура МИМ R1 - R4** | 🔄 | P2 |
+| 13★ | Итерация 6 account_bot | 🔄 ждёт ответа | — |
+| ~~13~~ | ~~Итерация 5 account_bot~~ | ↗️ | — |
+| 100 | Обычный | 🔄 | P1 |
+EOF
+
+# Load only the two functions under test — sourcing the whole file would run
+# its CLI dispatch (same isolation pattern used by the update.sh issue tests).
+eval "$(awk '
+  /^registry_status_column\(\)/ { capture=1 }
+  capture { print }
+  capture && /^}/ { print ""; capture=0 }
+' "$ROOT/.claude/scripts/wp-sync-bundle.sh")"
+eval "$(awk '
+  /^registry_status\(\)/ { capture=1 }
+  capture { print }
+  capture && /^}/ { exit }
+' "$ROOT/.claude/scripts/wp-sync-bundle.sh")"
+declare -F registry_status >/dev/null
+
+check() {
+  local desc="$1" num="$2" expected="$3" got
+  got=$(registry_status "$num" 2>/dev/null)
+  if [ "$got" = "$expected" ]; then
+    pass "$desc (got: $got)"
+  else
+    fail "$desc: expected '$expected', got '$got'"
+  fi
+}
+
+echo "--- #713: paused status resolves instead of an empty line ---"
+check "WP-57 (⏸️) reports paused, not empty" 57 "⏸ paused"
+
+echo "--- #714: own status column outranks a strikethrough elsewhere in the row ---"
+check "WP-39 (struck-through title, active 📦 cell) reports archived, not done" 39 "📦 archived"
+
+echo "--- #715: leading zero in the query number is normalized ---"
+check "WP-038 matches the bare '38' row" 038 "🔄 in_progress"
+check "WP-38 sanity (same row, no leading zero)" 38 "🔄 in_progress"
+
+echo "--- #716: a marker glued to the number does not divert to a different row ---"
+out=$(registry_status 13 2>"$TMP/warn.txt")
+if [ "$out" = "🔄 in_progress" ]; then
+  pass "WP-13★ resolves to the active row, not the struck-through '~~13~~' row"
+else
+  fail "WP-13 ambiguity resolution regressed: expected the active row, got '$out'"
+fi
+if grep -qi "неоднозначно" "$TMP/warn.txt"; then
+  pass "ambiguous match (13★ + ~~13~~) is flagged on stderr instead of failing silently"
+else
+  fail "expected an ambiguity warning on stderr for the duplicate-number fixture"
+fi
+
+echo "--- #717: locale-independent status classification ---"
+for loc in "" C C.UTF-8 en_US.UTF-8 ru_RU.UTF-8; do
+  got=$(LC_ALL="$loc" registry_status 100 2>/dev/null)
+  if [ "$got" = "🔄 in_progress" ]; then
+    pass "LC_ALL='${loc:-<ambient>}': status resolves correctly"
+  else
+    fail "LC_ALL='${loc:-<ambient>}': expected '🔄 in_progress', got '$got'"
+  fi
+done
+
+echo "--- sanity: unknown number still reports 'not in registry' ---"
+check "WP-999 (absent) reports not-in-registry" 999 "_не в реестре_"
+
+echo "wp-sync-bundle registry_status guard: $pass_count checks passed"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -281,7 +281,7 @@
     },
     {
       "path": ".claude/scripts/wp-sync-bundle.sh",
-      "sha256": "431bed387ac29e09d5e568de3f308815b3def0d23a8e6d566c0b1df0fee29266"
+      "sha256": "8a9fb07aa39992a06a896a65f0307eff9bf9c9b6c61493b737f462603903b423"
     },
     {
       "path": ".claude/settings.json",
@@ -3029,6 +3029,7 @@
     "scripts/tests/test_issue_657.sh",
     "scripts/tests/test_issue_660.sh",
     "scripts/tests/test_issue_665.sh",
+    "scripts/tests/test_issue_713_registry_status.sh",
     "scripts/tests/test_issue_python_resolver_contract.sh",
     "scripts/tests/test_manifest_coverage_local.py",
     "scripts/tests/test_mount_readonly_packs.sh",


### PR DESCRIPTION
## Что чинит

`registry_status()` и `registry_status_column()` в `.claude/scripts/wp-sync-bundle.sh` (используется Sync Gate на каждом открытии рабочего продукта, `protocol-open.md` шаг 3a) неверно разбирали строки `WP-REGISTRY.md` в пяти связанных случаях:

- **#713** — статус ⏸ (пауза) не распознавался, отдавал пустую строку вместо `_статус неизвестен_`: код возврата пайплайна `grep | head` брался от `head`, который всегда успешен, поэтому `||`-фолбэк был недостижим ни при каком входе.
- **#714** — проверка зачёркивания (`~~`) шла по всей строке РАНЬШЕ чтения своей колонки статуса: зачёркнутое название с активным статусом в колонке (например 📦) давало ложный `~~done~~`.
- **#715** — ведущий ноль в номере (`WP-038`) не совпадал с голым `38` в реестре.
- **#716** — пометка рядом с номером (например `13★`) не проходила regex поиска строки, поиск перескакивал на другую строку с тем же номером (могла быть зачёркнутая предыдущая итерация) — вердикт получался **противоположным действительности**, без единого предупреждения.
- **#717** — сравнение эмодзи-статусов зависело от локали/сборки `grep`, на части машин вся ось статуса по реестру слепла молча.

**Найдено при regression-тестировании этой же фазы (сверх исходных issues):** `registry_status_column()` — под некоторыми локалями (`en_US.UTF-8` на macOS/awk-BWK 20200816) `==` в awk между двумя РАЗНЫМИ кириллическими строками возвращал `true` — колонка статуса резолвилась в соседнюю колонку. Исправлено тем же принципом: `LC_ALL=C` на конкретных сравнениях (не глобальный `export`, чтобы не задеть другой multibyte-разбор в файле), плюс литеральный список регистров вместо locale-зависимого `tolower()`.

Порядок правок внутри функции согласован в пир-сессии Kimi+Codex: нормализация номера (#715) объединена с обработкой суффикса (#716) в одну грамматику ID, чтение своей колонки — до проверки зачёркивания (#714), locale-независимая классификация — общая база для #713/#717.

Closes #713, #714, #715, #716, #717

## Test plan

- [x] `scripts/tests/test_issue_713_registry_status.sh` — 12 проверок, все 5 issue-кейсов + прогон под 5 разными `LC_ALL` (ambient, `C`, `C.UTF-8`, `en_US.UTF-8`, `ru_RU.UTF-8`)
- [x] `bash scripts/tests/run-issue-tests.sh` — 35 PASS, 0 FAIL (полный набор, без регрессий)
- [x] `shellcheck` чист на изменённом файле

---

Найдено и разобрано в пир-сессии Claude + Kimi + Codex (`2026-09-07-17-wp7-fmt-issues-triage`), WP-7 Ф116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)