### PR TITLE
fix(update.sh): не продвигать .claude.md.base при неразрешённом конфликте

### DIFF
--- a/scripts/tests/test_issue_711_conflict_base.sh
+++ b/scripts/tests/test_issue_711_conflict_base.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #711: sync_workspace_claude_md() used to
+# advance `.claude.md.base` to the new upstream version unconditionally, even
+# when the 3-way merge left unresolved <<<<<<< markers in the workspace
+# CLAUDE.md. The next run then compared the (already-advanced) base against
+# the same upstream file, found no difference, and reported "Всё актуально"
+# while the pilot's file still contained literal conflict markers.
+#
+# This test drives sync_workspace_claude_md() directly across a realistic
+# multi-run sequence (peer-session mini-gate, WP-7 Ф116): clean install ->
+# genuine conflict -> unresolved repeat run -> manual resolution -> idempotent
+# rerun. Each step's outcome is the actual defect surface, not the specific
+# diff3 codepath, so the assertions are outcome-based like #555's guard.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+TMP=$(mktemp -d)
+trap 'rm -rf -- "$TMP"' EXIT
+
+pass_count=0
+pass() { echo "  ✅ PASS: $*"; pass_count=$((pass_count + 1)); }
+fail() { echo "  ❌ FAIL: $*" >&2; exit 1; }
+
+# Load only the functions under test — sourcing update.sh would execute the
+# updater (same isolation pattern as test_issue_555_claude_silent_loss.sh).
+eval "$(awk '
+  /^substitute_claude_placeholders\(\)/ { capture=1 }
+  capture { print }
+  capture && /^}/ { print ""; capture=0 }
+' "$ROOT/update.sh")"
+eval "$(awk '
+  /^detect_claude_silent_loss\(\)/ { capture=1 }
+  capture { print }
+  capture && /^}/ { print ""; capture=0 }
+' "$ROOT/update.sh")"
+eval "$(awk '
+  /^sync_workspace_claude_md\(\)/ { capture=1 }
+  capture { print }
+  capture && /^}/ { exit }
+' "$ROOT/update.sh")"
+declare -F sync_workspace_claude_md >/dev/null
+
+WORKSPACE_DIR="$TMP/workspace"
+SCRIPT_DIR="$TMP/template"
+TMPDIR_UPDATE="$TMP/tmp"
+mkdir -p "$WORKSPACE_DIR" "$SCRIPT_DIR" "$TMPDIR_UPDATE"
+
+run_sync() {
+  CLAUDE_CONFLICT_DETECTED=false
+  CLAUDE_CONFLICT_FILES=()
+  CLAUDE_SILENT_LOSS_FILES=()
+  CLAUDE_CONFLICTS=0
+  sync_workspace_claude_md >"$TMP/out.txt" 2>&1
+  # Both arrays are populated by sync_workspace_claude_md itself — read them
+  # here so a real regression (e.g. a conflict that stops getting recorded
+  # in CLAUDE_CONFLICT_FILES) shows up in the trace, not just in $out.txt.
+  [ "${#CLAUDE_CONFLICT_FILES[@]}" -gt 0 ] && echo "  (conflict files: ${CLAUDE_CONFLICT_FILES[*]})"
+  [ "${#CLAUDE_SILENT_LOSS_FILES[@]}" -gt 0 ] && echo "  (silent-loss files: ${CLAUDE_SILENT_LOSS_FILES[*]})"
+  return 0
+}
+
+echo "--- run 1: first install, no base/current yet ---"
+cat >"$SCRIPT_DIR/CLAUDE.md" <<'EOF'
+line1 platform
+line2 platform
+line3 platform
+EOF
+run_sync
+if [ -f "$WORKSPACE_DIR/CLAUDE.md" ] && [ -f "$WORKSPACE_DIR/.claude.md.base" ]; then
+  pass "first install seeds workspace CLAUDE.md and base"
+else
+  fail "expected workspace CLAUDE.md + base to be seeded on first install"
+fi
+
+echo "--- run 2: pilot and upstream both change line2 -> genuine conflict ---"
+cat >"$WORKSPACE_DIR/CLAUDE.md" <<'EOF'
+line1 platform
+line2 PILOT EDIT
+line3 platform
+EOF
+cat >"$SCRIPT_DIR/CLAUDE.md" <<'EOF'
+line1 platform
+line2 UPSTREAM EDIT
+line3 platform
+EOF
+run_sync
+if $CLAUDE_CONFLICT_DETECTED && [ "$CLAUDE_CONFLICTS" -eq 1 ] && grep -qF '<<<<<<<' "$WORKSPACE_DIR/CLAUDE.md"; then
+  pass "genuine conflict detected, markers written to workspace CLAUDE.md"
+else
+  fail "expected a detected conflict with markers in workspace file"
+fi
+BASE_AFTER_CONFLICT=$(cat "$WORKSPACE_DIR/.claude.md.base")
+
+echo "--- run 3 (issue #711 core case): repeat run WITHOUT resolving markers ---"
+run_sync
+if $CLAUDE_CONFLICT_DETECTED; then
+  pass "repeat run on an unresolved conflict still reports a conflict, not 'всё актуально'"
+else
+  fail "repeat run silently cleared the conflict — this is exactly issue #711"
+fi
+if grep -qF '<<<<<<<' "$WORKSPACE_DIR/CLAUDE.md"; then
+  pass "markers from run 2 are still intact after the unresolved repeat run"
+else
+  fail "markers vanished or were re-merged into a confusing state on the repeat run"
+fi
+if [ "$(cat "$WORKSPACE_DIR/.claude.md.base")" = "$BASE_AFTER_CONFLICT" ]; then
+  pass "base was NOT advanced while the conflict stayed unresolved"
+else
+  fail "base advanced despite an unresolved conflict — the exact regression #711 reports"
+fi
+
+echo "--- run 4: pilot manually resolves by accepting the upstream line ---"
+cat >"$WORKSPACE_DIR/CLAUDE.md" <<'EOF'
+line1 platform
+line2 UPSTREAM EDIT
+line3 platform
+EOF
+run_sync
+if ! $CLAUDE_CONFLICT_DETECTED && [ "$(cat "$WORKSPACE_DIR/CLAUDE.md")" = "$(cat "$SCRIPT_DIR/CLAUDE.md")" ]; then
+  pass "manual resolution converges cleanly once markers are gone"
+else
+  fail "resolution did not converge: conflict_detected=$CLAUDE_CONFLICT_DETECTED"
+fi
+
+echo "--- run 5: idempotent rerun with nothing changed ---"
+BEFORE_RUN5=$(cat "$WORKSPACE_DIR/CLAUDE.md")
+run_sync
+if [ "$NEEDS_WS_CLAUDE_SYNC" = "false" ] && [ "$(cat "$WORKSPACE_DIR/CLAUDE.md")" = "$BEFORE_RUN5" ]; then
+  pass "converged state is idempotent — no spurious re-sync on an unchanged tree"
+else
+  fail "expected NEEDS_WS_CLAUDE_SYNC=false and an unchanged file on a no-op rerun"
+fi
+
+echo "issue-711 CLAUDE.md base-advance guard: $pass_count checks passed"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2973,7 +2973,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "e89d3534943369502b20b364909c28640cbe2503c8c4fd8f9b3db92f54429653"
+      "sha256": "0c953d6146d07d38dd39bfd1f5e0cb3c5a80d6b23b5c6ee31ff528ba6c38a1d4"
     }
   ],
   "excluded_paths": [
@@ -3029,6 +3029,7 @@
     "scripts/tests/test_issue_657.sh",
     "scripts/tests/test_issue_660.sh",
     "scripts/tests/test_issue_665.sh",
+    "scripts/tests/test_issue_711_conflict_base.sh",
     "scripts/tests/test_issue_713_registry_status.sh",
     "scripts/tests/test_issue_python_resolver_contract.sh",
     "scripts/tests/test_manifest_coverage_local.py",

--- a/update.sh
+++ b/update.sh
@@ -2367,7 +2367,17 @@ sync_workspace_claude_md() {
         WS_BASE="$WORKSPACE_DIR/.claude.md.base"
         WS_CURRENT="$WORKSPACE_DIR/CLAUDE.md"
 
-        if [ -f "$WS_BASE" ] && [ -f "$WS_CURRENT" ] && command -v git >/dev/null 2>&1; then
+        # issue #711: a previous run left unresolved <<<<<<< markers in
+        # $WS_CURRENT (pilot hasn't touched the file yet). Running
+        # `git merge-file` again would 3-way-merge a file that already
+        # contains literal marker lines as if they were real content —
+        # confusing nested markers at best. Re-surface the same warning
+        # without attempting a new merge; base stays untouched either way.
+        if [ -f "$WS_CURRENT" ] && grep -q '^<<<<<<<' "$WS_CURRENT" 2>/dev/null; then
+            echo "  ~ $WS_CURRENT (неразрешённый конфликт с прошлого запуска — сначала разрешите маркеры вручную)"
+            CLAUDE_CONFLICT_DETECTED=true
+            CLAUDE_CONFLICT_FILES+=("$WS_CURRENT")
+        elif [ -f "$WS_BASE" ] && [ -f "$WS_CURRENT" ] && command -v git >/dev/null 2>&1; then
             WS_MERGE_TMP="$TMPDIR_UPDATE/ws-claude-merge.md"
             cp "$WS_CURRENT" "$WS_MERGE_TMP"
             if git merge-file -p "$WS_MERGE_TMP" "$WS_BASE" "$WS_NEW" > "$TMPDIR_UPDATE/ws-claude-merged.md" 2>/dev/null; then
@@ -2384,17 +2394,24 @@ sync_workspace_claude_md() {
             else
                 WS_CONFLICTS=$(grep -c '^<<<<<<<' "$TMPDIR_UPDATE/ws-claude-merged.md" 2>/dev/null || true); WS_CONFLICTS=${WS_CONFLICTS:-0}
                 cp "$TMPDIR_UPDATE/ws-claude-merged.md" "$WS_CURRENT"
-                cp "$WS_NEW" "$WS_BASE"
                 CLAUDE_CONFLICTS=$((CLAUDE_CONFLICTS + WS_CONFLICTS))
                 if [ "$WS_CONFLICTS" -gt 0 ]; then
                     # issue #226: don't abort here — a CLAUDE.md conflict is an isolated
                     # artifact, not a reason to skip the rest of the delivery (memory/hooks/
                     # skills propagation, repair-pass, commit). Warn now, fail at the end.
+                    # issue #711: do NOT advance $WS_BASE here (unlike the no-conflict
+                    # branch below) — advancing it made the next run's `diff -q
+                    # "$WORKSPACE_DIR/.claude.md.base" "$WS_NEW"` gate at the top of this
+                    # function succeed even though $WS_CURRENT still had unresolved
+                    # <<<<<<< markers, so update.sh reported "Всё актуально" on a corrupt
+                    # file. Base now advances only once the markers are gone (see the
+                    # pre-check above, which takes over on the next run).
                     echo "  ~ $WS_CURRENT ($WS_CONFLICTS конфликтов — разрешите вручную)"
                     echo "    Конфликты обозначены <<<<<<< / ======= / >>>>>>>"
                     CLAUDE_CONFLICT_DETECTED=true
                     CLAUDE_CONFLICT_FILES+=("$WS_CURRENT")
                 else
+                    cp "$WS_NEW" "$WS_BASE"
                     echo "  ✓ $WS_CURRENT обновлён (3-way merge)"
                 fi
             fi


### PR DESCRIPTION
## Что чинит

`sync_workspace_claude_md()` продвигала `$WS_BASE` на новую версию шаблона **безусловно** в ветке конфликта — даже когда 3-way merge оставил маркеры `<<<<<<< / ======= / >>>>>>>` нерешёнными в workspace-копии `CLAUDE.md`.

Следующий прогон сравнивает базу с шаблоном (`diff -q .claude.md.base $WS_NEW`), чтобы решить, нужна ли сверка вообще. Раз база уже была продвинута на прошлом прогоне, сравнение находило «нет расхождений», `NEEDS_WS_CLAUDE_SYNC` оставался `false`, `claude_conflict_gate` пропускал — и `update.sh` рапортовал **«✓ Всё актуально»**, пока маркеры конфликта так и лежали в рабочем файле пилота.

## Фикс (два места)

1. **Пре-проверка на входе:** если в `$WS_CURRENT` уже есть неразрешённые маркеры (предыдущий прогон, пилот ещё не тронул файл) — не запускать `git merge-file` повторно (это дало бы вложенные маркеры поверх уже существующих конфликтных строк), просто повторить то же предупреждение.
2. **В самой ветке конфликта** — убран безусловный `cp "$WS_NEW" "$WS_BASE"`. База продвигается только в ветке без конфликтов; следующий прогон на неразрешённом состоянии попадёт в чистую пре-проверку из п.1.

Направление подсказано самим автором issue — симметрия с уже принятым фиксом #555 (та же функция, соседняя ветка `if`, там база тоже не продвигается при обнаруженной проблеме).

## Риск и проверка (мини-гейт вместо отдельного АрхГейта, консенсус пир-сессии)

Полный жизненный цикл проверен живым прогоном `sync_workspace_claude_md()`:

1. первичная установка (нет base/current)
2. пилот и upstream меняют одну и ту же строку → конфликт, маркеры
3. **повтор БЕЗ разрешения маркеров** (это и есть баг #711) → конфликт остаётся видимым, база не продвинута
4. пилот вручную разрешает (принимает upstream-версию) → чистое слияние, база продвигается
5. идемпотентный повтор без изменений → `NEEDS_WS_CLAUDE_SYNC=false`, файл не трогается

Покрыто регрессионным тестом `scripts/tests/test_issue_711_conflict_base.sh` (7 проверок). Полный существующий набор `setup/test-update-issue-226.sh` (37 сценариев, включая end-to-end CLAUDE.md conflict) проходит без единой регрессии.

Closes #711

## Test plan

- [x] `scripts/tests/test_issue_711_conflict_base.sh` — 7 PASS
- [x] `bash setup/test-update-issue-226.sh` — 37 PASS, 0 FAIL (полный существующий набор, включая CLAUDE.md conflict e2e)
- [x] `shellcheck` чист на изменённом файле

---

Найдено и разобрано в пир-сессии Claude + Kimi + Codex (`2026-09-07-17-wp7-fmt-issues-triage`), WP-7 Ф116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)