### PR TITLE
fix(tests): убрать личное имя репозитория из фикстуры extractor-feeders

### DIFF
--- a/scripts/tests/test-update-extractor-feeders.sh
+++ b/scripts/tests/test-update-extractor-feeders.sh
@@ -27,7 +27,7 @@ declare -F backfill_extractor_feeders >/dev/null
 
 SCRIPT_DIR="$TMP/template"
 WORKSPACE_DIR="$TMP/workspace"
-EFFECTIVE_GOVERNANCE_REPO="DS-my-strategy"
+EFFECTIVE_GOVERNANCE_REPO="DS-strategy"
 mkdir -p "$SCRIPT_DIR/scripts" "$WORKSPACE_DIR" "$TMP/bin"
 
 FEEDERS="$SCRIPT_DIR/scripts/setup-extractor-feeders.sh"
@@ -49,7 +49,7 @@ PATH="$TMP/bin:$PATH"
 # init.templateDir, fleeting-notes seeding) -- that is what --schedule-only buys.
 write_feeders 0
 OUT=$(backfill_extractor_feeders)
-EXPECTED="--schedule-only|DS-my-strategy|$WORKSPACE_DIR/.iwe-runtime"
+EXPECTED="--schedule-only|DS-strategy|$WORKSPACE_DIR/.iwe-runtime"
 if [ "$(cat "$TMP/feeders-call")" != "$EXPECTED" ]; then
     echo "feeders invoked with wrong mode or environment: $(cat "$TMP/feeders-call")" >&2
     exit 1


### PR DESCRIPTION
## Что

Тест `test-update-extractor-feeders.sh` хардкодил личное имя governance-репо пилота (`DS-my-strategy`) как значение тестовой фикстуры — реальный репозиторий не используется, значение произвольное. `validate-template.sh` [1/5] Author-specific content отклонял это как утечку авторского контента.

## Фикс

Заменено на `DS-strategy` — уже документированный дефолт этого шаблона (`CLAUDE.md`: «governance-репо называется DS-strategy по умолчанию»). Логика теста не тронута.

## Контекст

Найдено по ходу WP-538 Ф7 (DS-my-strategy) — этот блокер не давал закоммитить не связанную правку (перевод английского заголовка в уведомлениях) в другом репозитории (DS-ai-systems), т.к. общий pre-commit хук там гоняет `validate-template.sh` при любых изменениях в `synchronizer/scripts/`.

## Test plan

- [x] `bash scripts/tests/test-update-extractor-feeders.sh` — PASS
- [x] `bash setup/scripts/validate-template.sh <этот-репо>` (из DS-ai-systems) — ALL CHECKS PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)