### PR TITLE
fix(launchd): IWE_SCRIPTS missing from scheduled job env, stale .iwe-paths reads

### DIFF
--- a/.claude/runtime-overlay.yaml
+++ b/.claude/runtime-overlay.yaml
@@ -83,9 +83,15 @@ placeholders:
   - TIMEZONE_HOUR
   - TIMEZONE_DESC
   - GITHUB_USER
-  - GOVERNANCE_REPO
+  - GOVERNANCE_REPO   # launchd env var is named IWE_GOVERNANCE_REPO — same
+                      # value, deliberately different key name, not a separate
+                      # placeholder (peer-session 2026-09-08-32)
   - IWE_TEMPLATE      # путь к FMT (read-only upstream)
   - IWE_RUNTIME       # путь к $WORKSPACE_DIR/.iwe-runtime/ (writable substituted)
+  - IWE_SCRIPTS       # $IWE_TEMPLATE/scripts — shared scripts read-only from FMT
+                      # (peer-session 2026-09-08-32: missing here meant no
+                      # generated plist could ever carry it, so the launchd
+                      # jobs silently ran without it — issue found via Evgenii)
 
 # === Runtime layout (что появляется в $WORKSPACE_DIR/ после build-runtime.sh) ===
 #

--- a/roles/extractor/scripts/launchd/com.extractor.inbox-check.plist
+++ b/roles/extractor/scripts/launchd/com.extractor.inbox-check.plist
@@ -38,6 +38,8 @@
         <string>{{GOVERNANCE_REPO}}</string>
         <key>IWE_RUNTIME</key>
         <string>{{IWE_RUNTIME}}</string>
+        <key>IWE_SCRIPTS</key>
+        <string>{{IWE_SCRIPTS}}</string>
     </dict>
 
     <key>RunAtLoad</key>

--- a/roles/extractor/scripts/systemd/iwe-extractor-inbox-check.service
+++ b/roles/extractor/scripts/systemd/iwe-extractor-inbox-check.service
@@ -10,6 +10,8 @@ Environment=HOME={{HOME_DIR}}
 Environment=IWE_TEMPLATE={{IWE_TEMPLATE}}
 Environment=IWE_WORKSPACE={{WORKSPACE_DIR}}
 Environment=IWE_RUNTIME={{IWE_RUNTIME}}
+Environment=IWE_SCRIPTS={{IWE_SCRIPTS}}
+Environment=IWE_GOVERNANCE_REPO={{GOVERNANCE_REPO}}
 Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.local/bin
 StandardOutput=append:{{HOME_DIR}}/logs/extractor/systemd-inbox-check.log
 StandardError=append:{{HOME_DIR}}/logs/extractor/systemd-inbox-check-error.log

--- a/roles/strategist/scripts/launchd/com.strategist.morning.plist
+++ b/roles/strategist/scripts/launchd/com.strategist.morning.plist
@@ -41,6 +41,8 @@
         <string>{{WORKSPACE_DIR}}</string>
         <key>IWE_RUNTIME</key>
         <string>{{IWE_RUNTIME}}</string>
+        <key>IWE_SCRIPTS</key>
+        <string>{{IWE_SCRIPTS}}</string>
         <key>IWE_GOVERNANCE_REPO</key>
         <string>{{GOVERNANCE_REPO}}</string>
     </dict>

--- a/roles/strategist/scripts/launchd/com.strategist.weekreview.plist
+++ b/roles/strategist/scripts/launchd/com.strategist.weekreview.plist
@@ -43,6 +43,8 @@
         <string>{{WORKSPACE_DIR}}</string>
         <key>IWE_RUNTIME</key>
         <string>{{IWE_RUNTIME}}</string>
+        <key>IWE_SCRIPTS</key>
+        <string>{{IWE_SCRIPTS}}</string>
         <key>IWE_GOVERNANCE_REPO</key>
         <string>{{GOVERNANCE_REPO}}</string>
     </dict>

--- a/roles/strategist/scripts/strategist.sh
+++ b/roles/strategist/scripts/strategist.sh
@@ -59,9 +59,17 @@ REPO_DIR="$(dirname "$SCRIPT_DIR")"
 WORKSPACE="${IWE_WORKSPACE:-$HOME/IWE}/${IWE_GOVERNANCE_REPO:-DS-strategy}"
 
 # Guard: IWE_GOVERNANCE_REPO mismatch (Claude peer-review, 2026-05-26)
-EXPECTED_GOV=$(grep 'IWE_GOVERNANCE_REPO=' "$HOME/.iwe-paths" 2>/dev/null | sed 's/.*="//;s/"$//' || echo "DS-strategy")
+# WP-529 Ф94 (peer-session 2026-09-08-32, Evgenii's report): $HOME/.iwe-paths
+# is a legacy path install-iwe-paths.sh stopped writing (canonical file is
+# $WORKSPACE_DIR/.iwe-paths, see WORKSPACE above). Read the current path, and
+# read it without a pipe: `grep|sed || echo` masked grep's exit code behind
+# sed's (sed exits 0 on empty stdin), so the "|| echo DS-strategy" fallback
+# never fired and EXPECTED_GOV silently ended up empty instead.
+IWE_PATHS_FILE="${IWE_WORKSPACE:-$HOME/IWE}/.iwe-paths"
+EXPECTED_GOV=$(awk -F'"' '/^export IWE_GOVERNANCE_REPO=/{print $2; exit}' "$IWE_PATHS_FILE" 2>/dev/null)
+EXPECTED_GOV="${EXPECTED_GOV:-DS-strategy}"
 if [ "${IWE_GOVERNANCE_REPO:-}" ] && [ "$IWE_GOVERNANCE_REPO" != "$EXPECTED_GOV" ]; then
-    echo "WARN: IWE_GOVERNANCE_REPO=$IWE_GOVERNANCE_REPO, expected $EXPECTED_GOV (from ~/.iwe-paths)" >&2
+    echo "WARN: IWE_GOVERNANCE_REPO=$IWE_GOVERNANCE_REPO, expected $EXPECTED_GOV (from $IWE_PATHS_FILE)" >&2
 fi
 
 # WP-529 F6 (Evgenii post-update defect #1, 18.08): update.sh reinstalls

--- a/roles/strategist/scripts/strategist.sh
+++ b/roles/strategist/scripts/strategist.sh
@@ -66,7 +66,11 @@ WORKSPACE="${IWE_WORKSPACE:-$HOME/IWE}/${IWE_GOVERNANCE_REPO:-DS-strategy}"
 # sed's (sed exits 0 on empty stdin), so the "|| echo DS-strategy" fallback
 # never fired and EXPECTED_GOV silently ended up empty instead.
 IWE_PATHS_FILE="${IWE_WORKSPACE:-$HOME/IWE}/.iwe-paths"
-EXPECTED_GOV=$(awk -F'"' '/^export IWE_GOVERNANCE_REPO=/{print $2; exit}' "$IWE_PATHS_FILE" 2>/dev/null)
+# `|| true` guards against awk's own exit code (e.g. file not found) tripping
+# `set -e` on this assignment — not a pipe, so no exit-code-masking risk;
+# the value fallback below is the actual default, this only keeps the script
+# alive to reach it.
+EXPECTED_GOV=$(awk -F'"' '/^export IWE_GOVERNANCE_REPO=/{print $2; exit}' "$IWE_PATHS_FILE" 2>/dev/null || true)
 EXPECTED_GOV="${EXPECTED_GOV:-DS-strategy}"
 if [ "${IWE_GOVERNANCE_REPO:-}" ] && [ "$IWE_GOVERNANCE_REPO" != "$EXPECTED_GOV" ]; then
     echo "WARN: IWE_GOVERNANCE_REPO=$IWE_GOVERNANCE_REPO, expected $EXPECTED_GOV (from $IWE_PATHS_FILE)" >&2

--- a/roles/strategist/scripts/systemd/iwe-strategist-morning.service
+++ b/roles/strategist/scripts/systemd/iwe-strategist-morning.service
@@ -10,6 +10,7 @@ Environment=HOME={{HOME_DIR}}
 Environment=IWE_TEMPLATE={{IWE_TEMPLATE}}
 Environment=IWE_WORKSPACE={{WORKSPACE_DIR}}
 Environment=IWE_RUNTIME={{IWE_RUNTIME}}
+Environment=IWE_SCRIPTS={{IWE_SCRIPTS}}
 Environment=IWE_GOVERNANCE_REPO={{GOVERNANCE_REPO}}
 Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.local/bin
 StandardOutput=append:{{HOME_DIR}}/logs/strategist/systemd-morning.log

--- a/roles/strategist/scripts/systemd/iwe-strategist-weekreview.service
+++ b/roles/strategist/scripts/systemd/iwe-strategist-weekreview.service
@@ -10,6 +10,7 @@ Environment=HOME={{HOME_DIR}}
 Environment=IWE_TEMPLATE={{IWE_TEMPLATE}}
 Environment=IWE_WORKSPACE={{WORKSPACE_DIR}}
 Environment=IWE_RUNTIME={{IWE_RUNTIME}}
+Environment=IWE_SCRIPTS={{IWE_SCRIPTS}}
 Environment=IWE_GOVERNANCE_REPO={{GOVERNANCE_REPO}}
 Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.local/bin
 StandardOutput=append:{{HOME_DIR}}/logs/strategist/systemd-weekreview.log

--- a/roles/synchronizer/scripts/launchd/com.exocortex.scheduler.plist
+++ b/roles/synchronizer/scripts/launchd/com.exocortex.scheduler.plist
@@ -59,6 +59,10 @@
         <string>{{WORKSPACE_DIR}}</string>
         <key>IWE_RUNTIME</key>
         <string>{{IWE_RUNTIME}}</string>
+        <key>IWE_SCRIPTS</key>
+        <string>{{IWE_SCRIPTS}}</string>
+        <key>IWE_GOVERNANCE_REPO</key>
+        <string>{{GOVERNANCE_REPO}}</string>
     </dict>
 
     <key>RunAtLoad</key>

--- a/roles/synchronizer/scripts/systemd/iwe-exocortex-scheduler.service
+++ b/roles/synchronizer/scripts/systemd/iwe-exocortex-scheduler.service
@@ -10,6 +10,8 @@ Environment=HOME={{HOME_DIR}}
 Environment=IWE_TEMPLATE={{IWE_TEMPLATE}}
 Environment=IWE_WORKSPACE={{WORKSPACE_DIR}}
 Environment=IWE_RUNTIME={{IWE_RUNTIME}}
+Environment=IWE_SCRIPTS={{IWE_SCRIPTS}}
+Environment=IWE_GOVERNANCE_REPO={{GOVERNANCE_REPO}}
 Environment=PATH=/usr/local/bin:/usr/bin:/bin:%h/.local/bin
 StandardOutput=append:{{HOME_DIR}}/logs/synchronizer/systemd-scheduler.log
 StandardError=append:{{HOME_DIR}}/logs/synchronizer/systemd-scheduler-error.log

--- a/scripts/tests/test_launchd_identity_runtime.sh
+++ b/scripts/tests/test_launchd_identity_runtime.sh
@@ -23,6 +23,7 @@ USER_NAME="runtime-test-user"
 GOVERNANCE_REPO="DS-strategy"
 IWE_TEMPLATE="$ROOT"
 IWE_RUNTIME="$WORKSPACE/.iwe-runtime"
+IWE_SCRIPTS="$ROOT/scripts"
 EOF
 
 bash "$ROOT/setup/build-runtime.sh" --quiet --workspace "$WORKSPACE" --env-file "$ENV_FILE"
@@ -55,7 +56,18 @@ for rel in "${PLISTS[@]}"; do
     [ -f "$plist" ] || { echo "FAIL: missing rendered plist $rel" >&2; exit 1; }
     assert_plist_identity "$plist" USER runtime-test-user
     assert_plist_identity "$plist" LOGNAME runtime-test-user
-    if [ "$rel" = "roles/extractor/scripts/launchd/com.extractor.inbox-check.plist" ]; then
+    # WP-529 Ф94 (peer-session 2026-09-08-32): every scheduled agent job reads
+    # IWE_SCRIPTS (day-open-pipeline.sh lookup, extractor, ~10 other scripts).
+    # It was never in a shipped plist, so this asserts the key itself is
+    # present — the class of defect the substitution engine's own
+    # unfilled-placeholder scan does NOT catch (a key that's simply absent
+    # renders no placeholder to flag).
+    assert_plist_identity "$plist" IWE_SCRIPTS "$ROOT/scripts"
+    if [ "$rel" = "roles/extractor/scripts/launchd/com.extractor.inbox-check.plist" ] || \
+       [ "$rel" = "roles/synchronizer/scripts/launchd/com.exocortex.scheduler.plist" ]; then
+        # WP-529 Ф94: scheduler.plist ended at IWE_RUNTIME and never passed
+        # IWE_GOVERNANCE_REPO, though it execs strategist.sh as a child
+        # process that reads it (strategist.sh:59).
         assert_plist_identity "$plist" IWE_GOVERNANCE_REPO DS-strategy
     fi
     if command -v plutil >/dev/null 2>&1 && ! plutil -lint "$plist" >/dev/null; then

--- a/scripts/tests/test_launchd_identity_runtime.sh
+++ b/scripts/tests/test_launchd_identity_runtime.sh
@@ -80,6 +80,34 @@ for rel in "${PLISTS[@]}"; do
     fi
 done
 
+# WP-529 Ф94: the Linux equivalent of these 4 launchd jobs is a matching
+# systemd unit per role (build-runtime.sh substitutes both regardless of
+# host OS — it's plain text substitution). Same defect class, same fix,
+# needed its own assertion: nothing here was covering .service files at all.
+SERVICES=(
+    roles/strategist/scripts/systemd/iwe-strategist-morning.service
+    roles/strategist/scripts/systemd/iwe-strategist-weekreview.service
+    roles/synchronizer/scripts/systemd/iwe-exocortex-scheduler.service
+    roles/extractor/scripts/systemd/iwe-extractor-inbox-check.service
+)
+assert_service_env() {
+    local unit="$1" key="$2" value="$3"
+    grep -Fxq "Environment=$key=$value" "$unit" || {
+        echo "FAIL: $unit does not render Environment=$key=$value" >&2
+        exit 1
+    }
+}
+for rel in "${SERVICES[@]}"; do
+    unit="$WORKSPACE/.iwe-runtime/$rel"
+    [ -f "$unit" ] || { echo "FAIL: missing rendered systemd unit $rel" >&2; exit 1; }
+    assert_service_env "$unit" IWE_SCRIPTS "$ROOT/scripts"
+    assert_service_env "$unit" IWE_GOVERNANCE_REPO DS-strategy
+    if grep -q '{{[A-Z_]*}}' "$unit"; then
+        echo "FAIL: $rel retains an unfilled placeholder" >&2
+        exit 1
+    fi
+done
+
 MISSING_ENV="$TMP/missing-user.env"
 grep -v '^USER_NAME=' "$ENV_FILE" > "$MISSING_ENV"
 FALLBACK_USER=$(id -un)

--- a/setup.sh
+++ b/setup.sh
@@ -478,6 +478,7 @@ USER_NAME="$USER_NAME"
 GOVERNANCE_REPO="$GOVERNANCE_REPO"
 IWE_TEMPLATE="$IWE_TEMPLATE_PATH"
 IWE_RUNTIME="$IWE_RUNTIME_PATH"
+IWE_SCRIPTS="$IWE_TEMPLATE_PATH/scripts"
 
 # === Platform LLM Proxy (optional own API key for unlimited usage) ===
 PLATFORM_LLM_PROXY_URL=https://llm.aisystant.com/v1

--- a/setup/install-iwe-paths.sh
+++ b/setup/install-iwe-paths.sh
@@ -75,6 +75,17 @@ IWEENV_EOF
 
 $QUIET || echo "  ✓ $IWE_ENV_FILE written (workspace=$WORKSPACE_DIR)"
 
+# WP-529 Ф94 (peer-session 2026-09-08-32): $HOME/.iwe-paths was the ORIGINAL
+# canonical file (Round 5, pre-WP-219) before the source-of-truth moved to
+# $WORKSPACE_DIR/.iwe-paths above. Installs from that era can still have a
+# real (non-symlink) file there that nothing regenerates or reads anymore —
+# flag it so custom edits to it don't silently stop mattering unnoticed.
+LEGACY_IWE_PATHS="$HOME/.iwe-paths"
+if [ -f "$LEGACY_IWE_PATHS" ] && [ ! -L "$LEGACY_IWE_PATHS" ] && [ "$LEGACY_IWE_PATHS" != "$IWE_ENV_FILE" ]; then
+    $QUIET || echo "  ⚠ Найден устаревший $LEGACY_IWE_PATHS (до WP-219) — больше не читается ни одним скриптом."
+    $QUIET || echo "    Актуальный файл: $IWE_ENV_FILE. Проверьте $LEGACY_IWE_PATHS на предмет ручных правок и удалите его вручную."
+fi
+
 # Replace both the legacy $HOME/.iwe-paths one-liner and any older managed
 # block. Marker presence alone is not proof that it sources this workspace.
 if [ -f "$ZSHENV_FILE" ]; then

--- a/setup/smoke-test-fresh-install.sh
+++ b/setup/smoke-test-fresh-install.sh
@@ -572,6 +572,21 @@ else
         else
             pass "e2e full mode: все plist'ы без placeholders"
         fi
+        # WP-529 Ф94 (peer-session 2026-09-08-32): an empty substitution
+        # (missing key in .exocortex.env, env_get returns "") leaves no
+        # literal {{PLACEHOLDER}} behind, so the check above alone would not
+        # have caught setup.sh's heredoc missing IWE_SCRIPTS — assert the
+        # rendered value directly, on the real setup.sh output.
+        E2E_MORNING_PLIST=$(find "$E2E_LAUNCHDIR" -name 'com.strategist.morning.plist' 2>/dev/null | head -1)
+        if [ -n "$E2E_MORNING_PLIST" ]; then
+            if grep -A1 '<key>IWE_SCRIPTS</key>' "$E2E_MORNING_PLIST" | grep -q '<string>.\+</string>'; then
+                pass "e2e full mode: IWE_SCRIPTS renders non-empty in com.strategist.morning.plist"
+            else
+                fail "e2e full mode: IWE_SCRIPTS is missing or empty in com.strategist.morning.plist"
+            fi
+        else
+            warn "e2e full mode: com.strategist.morning.plist not found under $E2E_LAUNCHDIR"
+        fi
     else
         warn "e2e full mode: LaunchAgents dir не создан (возможно, ни одна auto-role не установлена)"
     fi

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1857,7 +1857,7 @@
     },
     {
       "path": "roles/strategist/scripts/strategist.sh",
-      "sha256": "2d6fe1af59731727f141e8fca8f6189c9ab813a60650b2aea671ab109393e930"
+      "sha256": "16e0e520f9f8537237dec68f9e5861c4fb7783b0d79e3063e2aac48c174250a9"
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-morning.service",

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -293,7 +293,7 @@
     },
     {
       "path": ".claude/runtime-overlay.yaml",
-      "sha256": "8a7a0cfcd3606ab80d76fbf3aaf8dec71c2079c01070130ad50913e9e1e30b36"
+      "sha256": "836a2413a5e3c3ff7122f633c7ec58dc56de4df72360d8b1ddca322eb2bb5272"
     },
     {
       "path": ".claude/scripts/check-index-health.py",
@@ -1689,11 +1689,11 @@
     },
     {
       "path": "roles/extractor/scripts/launchd/com.extractor.inbox-check.plist",
-      "sha256": "0f698455a221d847c195a22d3207c1ae348c338c86f2f6e1ba7cba8b7b37a45e"
+      "sha256": "4c89964e2b8b1a70bfd6489aaff13d1a23a12e02875f639f40af5f016eaa9f85"
     },
     {
       "path": "roles/extractor/scripts/systemd/iwe-extractor-inbox-check.service",
-      "sha256": "f99b4c0accd17a2498587226fbb775f6e535ed968e6d5722854e5300bcadce49"
+      "sha256": "ef72b2366f91afda3d66c71e35b49a8deb23b8279a62333306fd1114e1bf767a"
     },
     {
       "path": "roles/extractor/scripts/systemd/iwe-extractor-inbox-check.timer",
@@ -1849,19 +1849,19 @@
     },
     {
       "path": "roles/strategist/scripts/launchd/com.strategist.morning.plist",
-      "sha256": "a79e22b95bd917fa194695500ee8ed28f32df180bb56bd62313b776b67970677"
+      "sha256": "0324eb6af0de9d4ed63e7c9144aabf1668f38d5d49145260d6777afdb196ca03"
     },
     {
       "path": "roles/strategist/scripts/launchd/com.strategist.weekreview.plist",
-      "sha256": "0cb4af08c5f63d01bfcbc07736453383ccb9be35b2e804e0f660eb10424ae637"
+      "sha256": "b96cd7bf763ff8e37be359d528bbb33507b93f4e286e034147027711fe7ffb37"
     },
     {
       "path": "roles/strategist/scripts/strategist.sh",
-      "sha256": "ea4f00b8a5c80b93bdccd81e29eb489b33a9d3943460c9a8996f61cb5f2be866"
+      "sha256": "2d6fe1af59731727f141e8fca8f6189c9ab813a60650b2aea671ab109393e930"
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-morning.service",
-      "sha256": "977321695ba576f19214ccf219f98e6101cd94eae5c0de54fe374ad3738c2577"
+      "sha256": "b49a03afcdbdfadf8cb6b97ddefa22f5183f41c05cb2c43ad6c169d0a7f4fad2"
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-morning.timer",
@@ -1869,7 +1869,7 @@
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-weekreview.service",
-      "sha256": "f300d3ea098e2bb653e1d3b8ba7c544811a7deaa65ecb51d81d9d55cbf270b49"
+      "sha256": "0274a04d10a40c849af5f226513fb63948dce4253e77398af0008859280994f5"
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-weekreview.timer",
@@ -1913,7 +1913,7 @@
     },
     {
       "path": "roles/synchronizer/scripts/launchd/com.exocortex.scheduler.plist",
-      "sha256": "0f555d8af7de37467ac34955e2d58c3f2deb0141b69e2e956e54a15bfdd54293"
+      "sha256": "b76fdb7251e00560f230514011e27bd59c237e1af838db9d35707ebc170c7ba4"
     },
     {
       "path": "roles/synchronizer/scripts/notify.sh",
@@ -1929,7 +1929,7 @@
     },
     {
       "path": "roles/synchronizer/scripts/systemd/iwe-exocortex-scheduler.service",
-      "sha256": "d80079cce7ea8f26d4d3b8d6490487a526e809f99b9538dc7badae0e2dba8eba"
+      "sha256": "be33f1ac25bb038c90fc1486bc2c0a57a9a36202b0d115a599cf09439bbdc702"
     },
     {
       "path": "roles/synchronizer/scripts/systemd/iwe-exocortex-scheduler.timer",
@@ -2753,7 +2753,7 @@
     },
     {
       "path": "scripts/tests/test_launchd_identity_runtime.sh",
-      "sha256": "a4c14370c1817b6010fb31d35916cd72e028349427f1c14e72a10bfd3144593e"
+      "sha256": "433e3a77becb80cc5f9b296a387180777a0cc722d2d9a9611bf30eab7b139509"
     },
     {
       "path": "scripts/tests/test_role_runner_update_marker_guard.sh",
@@ -2985,7 +2985,7 @@
     },
     {
       "path": "setup.sh",
-      "sha256": "31a75c3d8f7acc21a711ea4c40a037ec9ac3e81a868b8da4f56c95324bc0c0ba"
+      "sha256": "6c5de026806d7d7e11aa4c28c78dae620fc904ce97ca2faeffb53e5f934cf220"
     },
     {
       "path": "setup/build-runtime.sh",
@@ -2993,7 +2993,7 @@
     },
     {
       "path": "setup/install-iwe-paths.sh",
-      "sha256": "8f4839935293ecfcbf8c981619d2d24832291a646f943a37ee34cf077a92bb67"
+      "sha256": "672677e388baf0e6d4839fd857dbebb85b053fea7b5f660eaf1be472709532c9"
     },
     {
       "path": "setup/optional/setup-cloud-scheduler.sh",
@@ -3025,7 +3025,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "660b3ee006bdbd7095562232153d50c700f79b7d8a2a157b9c209faab4ece9b0"
+      "sha256": "657fe5f8ab4af7c127d556249d651021a229b346f745d10238dfa602822c9985"
     }
   ],
   "excluded_paths": [

--- a/update.sh
+++ b/update.sh
@@ -3648,6 +3648,16 @@ if [ -f "$ENV_FILE" ]; then
             ENV_IWE_TEMPLATE="$SCRIPT_DIR"
         fi
 
+        # === Auto-add IWE_SCRIPTS (peer-session 2026-09-08-32, Evgenii's Day
+        # Open report) === Was never in placeholders: before this fix, so no
+        # generated plist could ever carry it — the launchd jobs silently ran
+        # without it (strategist.sh:357-366 fell back to the free-form prompt).
+        if ! grep -q '^IWE_SCRIPTS=' "$ENV_FILE" 2>/dev/null; then
+            echo "IWE_SCRIPTS=$SCRIPT_DIR/scripts" >> "$ENV_FILE"
+            echo "  ✓ Добавлено IWE_SCRIPTS=$SCRIPT_DIR/scripts в .exocortex.env (WP-529 Ф94)"
+            ENV_IWE_SCRIPTS="$SCRIPT_DIR/scripts"
+        fi
+
         # === WP-273 Этап 2: IWE_RUNTIME для Generated runtime architecture (F) ===
         if ! grep -q '^IWE_RUNTIME=' "$ENV_FILE" 2>/dev/null; then
             DETECT_WS_RT="${ENV_WORKSPACE_DIR:-$WORKSPACE_DIR}"
@@ -4022,11 +4032,21 @@ done
 if $ROLES_CHANGED && command -v launchctl >/dev/null 2>&1; then
     echo ""
     echo "Роли обновлены. Переустановка..."
-    # Source ~/.iwe-paths (если есть) — гарантирует IWE_RUNTIME/IWE_TEMPLATE в env для install.sh
-    [ -f "$HOME/.iwe-paths" ] && . "$HOME/.iwe-paths"
+    # WP-529 Ф94 (peer-session 2026-09-08-32): $HOME/.iwe-paths is a legacy
+    # path install-iwe-paths.sh stopped writing — sourcing it here silently
+    # no-op'd (`[ -f ... ] && .` is not an error if the file is absent), so
+    # role installers ran without IWE_RUNTIME/IWE_TEMPLATE/IWE_SCRIPTS in
+    # their environment. update.sh already knows all of these; pass them
+    # explicitly instead of relying on a file that may not exist.
+    ROLE_REINSTALL_GOV="${EFFECTIVE_GOVERNANCE_REPO:-$(effective_governance_repo)}"
     for role_dir in "$SCRIPT_DIR"/roles/*/; do
         [ -f "$role_dir/install.sh" ] && [ -f "$role_dir/role.yaml" ] || continue
         if grep -q 'auto:.*true' "$role_dir/role.yaml" 2>/dev/null; then
+            IWE_WORKSPACE="$WORKSPACE_DIR" \
+            IWE_TEMPLATE="$SCRIPT_DIR" \
+            IWE_SCRIPTS="$SCRIPT_DIR/scripts" \
+            IWE_RUNTIME="$WORKSPACE_DIR/.iwe-runtime" \
+            IWE_GOVERNANCE_REPO="$ROLE_REINSTALL_GOV" \
             bash "$role_dir/install.sh" 2>/dev/null && \
                 echo "  ✓ $(basename "$role_dir") переустановлен" || \
                 echo "  ○ $(basename "$role_dir"): переустановите вручную"


### PR DESCRIPTION
## Summary
- Руслан сообщил, что утренний конвейер Day Open тихо откатывается на свободный промпт, а диагностика показывала «IWE_GOVERNANCE_REPO=DS-strategy, ожидалось пусто».
- Дефект А: `IWE_SCRIPTS` никогда не был зарегистрирован как подставляемая переменная — ни один плист не мог его нести. Похожий случай уже был (issue #598, 37 дней/88 запусков), тогда закрыли только половину причины.
- Дефект Б: `strategist.sh`/`update.sh` читали устаревший `$HOME/.iwe-paths` вместо актуального `$WORKSPACE_DIR/.iwe-paths`; чтение через `grep | sed || echo` маскировало код возврата, из-за чего запасное значение никогда не подставлялось.
- Спроектировано и реализовано в пир-сессии с kimi и codex (`2026-09-08-32-day-open-pipeline-env`); два раунда независимого холодного ревью и сам CI нашли и закрыли три дополнительных проблемы (регрессия в `setup.sh`, недостающий фикс на Linux-стороне, регрессия `set -e` в самой правке).

## Test plan
- [x] `bash scripts/tests/test_launchd_identity_runtime.sh` — зелёный, проверяет рендер `IWE_SCRIPTS`/`IWE_GOVERNANCE_REPO` на всех 4 launchd-плистах и 4 systemd-юнитах через реальный `build-runtime.sh`
- [x] Живой end-to-end прогон `setup.sh` (full mode, изолированный `$HOME`/`WORKSPACE_DIR`, `SETUP_CI=1`) — подтверждён непустой `IWE_SCRIPTS` в сгенерированных плистах
- [x] Юнит-проверка awk-замены `EXPECTED_GOV` на реальный/отсутствующий/пустой `.iwe-paths`
- [x] Функциональная проверка WARN в `install-iwe-paths.sh` на трёх сценариях (нет файла / реальный legacy-файл / симлинк)
- [x] Полный CI зелёный (12/12) перед мержем

🤖 Generated with [Claude Code](https://claude.com/claude-code)