### PR TITLE
fix: TIMEZONE_HOUR — установщик спрашивал UTC, launchd/systemd читают как местное время

### DIFF
--- a/roles/strategist/README.md
+++ b/roles/strategist/README.md
@@ -60,7 +60,7 @@ FMT-exocortex-template/              DS-strategy/ (отдельный репо)
 
 ## Расписание (launchd, macOS)
 
-| Время (UTC) | День | Сценарий | Plist |
+| Время (местное время машины) | День | Сценарий | Plist |
 |-------------|------|----------|-------|
 | {{TIMEZONE_HOUR}}:00 | Понедельник | `session-prep` (headless) | `com.strategist.morning` |
 | {{TIMEZONE_HOUR}}:00 | Вт-Вс | `day-plan` | `com.strategist.morning` |

--- a/roles/strategist/scripts/systemd/iwe-strategist-morning.timer
+++ b/roles/strategist/scripts/systemd/iwe-strategist-morning.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=IWE Strategist — morning run в {{TIMEZONE_HOUR}}:00 UTC
+Description=IWE Strategist — morning run в {{TIMEZONE_HOUR}}:00 (местное время)
 
 [Timer]
 OnCalendar=*-*-* {{TIMEZONE_HOUR}}:00:00

--- a/roles/synchronizer/scripts/launchd/com.exocortex.scheduler.plist
+++ b/roles/synchronizer/scripts/launchd/com.exocortex.scheduler.plist
@@ -11,10 +11,10 @@
         <string>dispatch</string>
     </array>
 
-    <!-- Пробуждение в ключевые часы:
+    <!-- Пробуждение в ключевые часы (местное время машины, launchd так и планирует):
          0:00  — week-review (Пн) + code-scan
          3:00  — extractor inbox-check
-         4:00  — strategist morning
+         {{TIMEZONE_HOUR}}:00  — strategist morning
          6:00  — extractor + daily-report
          9:00  — extractor
          12:00 — extractor

--- a/setup.sh
+++ b/setup.sh
@@ -277,7 +277,7 @@ if [ -n "${SETUP_CI:-}" ]; then
     WORKSPACE_DIR="${WORKSPACE_DIR/#\~/$HOME}"
     CLAUDE_PATH="${CLAUDE_PATH:-claude}"
     TIMEZONE_HOUR="${TIMEZONE_HOUR:-4}"
-    TIMEZONE_DESC="${TIMEZONE_DESC:-4:00 UTC}"
+    TIMEZONE_DESC="${TIMEZONE_DESC:-4:00 (местное время)}"
     echo "  [CI] GITHUB_USER=$GITHUB_USER WORKSPACE_DIR=$WORKSPACE_DIR"
 else
     read -p "GitHub username (или Enter для пропуска): " GITHUB_USER
@@ -292,16 +292,16 @@ else
         # Core: используем defaults, не спрашиваем Claude-специфичные параметры
         CLAUDE_PATH="${AI_CLI:-claude}"
         TIMEZONE_HOUR="4"
-        TIMEZONE_DESC="4:00 UTC"
+        TIMEZONE_DESC="4:00 (местное время)"
     else
         read -p "Claude CLI path [$(command -v claude || echo '/opt/homebrew/bin/claude')]: " CLAUDE_PATH
         CLAUDE_PATH="${CLAUDE_PATH:-$(command -v claude || echo '/opt/homebrew/bin/claude')}"
 
-        read -p "Strategist launch hour (UTC, 0-23) [4]: " TIMEZONE_HOUR
+        read -p "Strategist launch hour, местное время машины (0-23) [4]: " TIMEZONE_HOUR
         TIMEZONE_HOUR="${TIMEZONE_HOUR:-4}"
 
-        read -p "Timezone description (e.g. '7:00 MSK') [${TIMEZONE_HOUR}:00 UTC]: " TIMEZONE_DESC
-        TIMEZONE_DESC="${TIMEZONE_DESC:-${TIMEZONE_HOUR}:00 UTC}"
+        read -p "Timezone description (e.g. '7:00 MSK') [${TIMEZONE_HOUR}:00 (местное время)]: " TIMEZONE_DESC
+        TIMEZONE_DESC="${TIMEZONE_DESC:-${TIMEZONE_HOUR}:00 (местное время)}"
     fi
 fi
 
@@ -417,7 +417,7 @@ if $CORE_ONLY; then
     echo "  Mode:           core (offline)"
 else
     echo "  Claude path:    $CLAUDE_PATH"
-    echo "  Schedule hour:  $TIMEZONE_HOUR (UTC)"
+    echo "  Schedule hour:  $TIMEZONE_HOUR (местное время)"
     echo "  Time desc:      $TIMEZONE_DESC"
 fi
 echo "  Home dir:       $HOME_DIR"
@@ -1222,7 +1222,7 @@ else
         echo "  3. Ask Claude: «Проведём первую стратегическую сессию»"
         echo ""
         echo "Strategist will run automatically:"
-        echo "  - Morning ($TIMEZONE_DESC): strategy (Mon) / day-plan (Tue-Sun)"
+        echo "  - Morning at $TIMEZONE_DESC: strategy (Mon) / day-plan (Tue-Sun)"
         echo "  - Sunday night: week review"
     fi
     echo ""

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1713,7 +1713,7 @@
     },
     {
       "path": "roles/strategist/README.md",
-      "sha256": "e7a13b44f9d0a2bd4af4c19094b201cf5cb804653bb7c01b7ea988e468887329"
+      "sha256": "eb6b976372513838c3f7dfc8a7d92565b253f61f3392acd89cc27ea04e46c283"
     },
     {
       "path": "roles/strategist/install.sh",
@@ -1865,7 +1865,7 @@
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-morning.timer",
-      "sha256": "b724ec2c2d77638613664a1febfde418f55f6ddc89b091fd170d5f7af9e438fc"
+      "sha256": "262ad3aadd2e292209118373c2b24f5d571f33968f2870c1df66a5ccc92c4073"
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-weekreview.service",
@@ -1913,7 +1913,7 @@
     },
     {
       "path": "roles/synchronizer/scripts/launchd/com.exocortex.scheduler.plist",
-      "sha256": "b76fdb7251e00560f230514011e27bd59c237e1af838db9d35707ebc170c7ba4"
+      "sha256": "7173995a3718b160d229dd5767631ecff23917ef170113c029a80c8c7d94986b"
     },
     {
       "path": "roles/synchronizer/scripts/notify.sh",
@@ -2985,7 +2985,7 @@
     },
     {
       "path": "setup.sh",
-      "sha256": "6c5de026806d7d7e11aa4c28c78dae620fc904ce97ca2faeffb53e5f934cf220"
+      "sha256": "134dde54a5afdd58964d31c18a8d6fbc3970447f5224e922d6270e10ac76f1a8"
     },
     {
       "path": "setup/build-runtime.sh",
@@ -3025,7 +3025,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "657fe5f8ab4af7c127d556249d651021a229b346f745d10238dfa602822c9985"
+      "sha256": "a457e5f7d0ca31562294c63c872122bfbf38dbcb5c102fe08d2b755b4bde9ebf"
     }
   ],
   "excluded_paths": [

--- a/update.sh
+++ b/update.sh
@@ -3732,7 +3732,7 @@ WORKSPACE_DIR="$DETECTED_WORKSPACE"
 CLAUDE_PATH="$(command -v claude 2>/dev/null || echo 'claude')"
 CLAUDE_PROJECT_SLUG="$(echo "$DETECTED_WORKSPACE" | tr '/' '-')"
 TIMEZONE_HOUR="4"
-TIMEZONE_DESC="4:00 UTC"
+TIMEZONE_DESC="4:00 (местное время)"
 HOME_DIR="$HOME"
 
 # === Knowledge Gateway (T3+) — fill in if using personal Pack index ===


### PR DESCRIPTION
## Проблема

`setup.sh` спрашивал «Strategist launch hour (UTC, 0-23)», но launchd `StartCalendarInterval.Hour` и systemd `OnCalendar` (без суффикса ` UTC`) оба трактуют это значение как местное время машины — README и комментарии в плистах называли те же часы «UTC». Для любого пояса восточнее UTC это давало систематический сдвиг запуска Стратега/Синхронизатора.

Найдено коллегой пилота на живой установке: `TIMEZONE_HOUR=4` при желаемых 7:00 MSK запускал задание в 4:00 местного, а не в 7:00.

## Фикс

Только текстовый — поведение планировщика (сами значения Hour/OnCalendar) не менялось, launchd/systemd и так работают в местном времени:
- `setup.sh`: вопрос установщика + summary-echo + дефолты `TIMEZONE_DESC`
- `update.sh`: legacy default `TIMEZONE_DESC` (сценарий восстановления `.env`)
- `roles/strategist/README.md`: заголовок таблицы расписания
- `roles/strategist/scripts/systemd/iwe-strategist-morning.timer`: Description
- `roles/synchronizer/scripts/launchd/com.exocortex.scheduler.plist`: заголовок комментария над `StartCalendarInterval` получил явную пометку «местное время машины»; хардкод «4:00 — strategist morning» заменён на `{{TIMEZONE_HOUR}}:00` (была рассинхронизация с реальной переменной)

## Процесс

Пир-сессия с Codex (`2026-09-09-02-wp7-f128-timezone-hour`, консенсус за 2 хода) + холодное ревью субагентом (High: грамматика заголовка README; Medium: двойные скобки в summary-строке `setup.sh` — оба исправлены).

## Test plan

- [x] `bash -n setup.sh` / `bash -n update.sh` — чисто
- [x] `setup/smoke-test-fresh-install.sh` — 23/27, без регрессий (4 непройденных теста — известные и не связанные с этой правкой: `env -i` PATH на NixOS и глобальный git-wrapper гейт на посторонний тестовый git-репозиторий в /tmp)
- [x] `xml.dom.minidom.parse()` на изменённый `.plist` — валиден

Refs: WP-7 Ф128 (DS-my-strategy@b1de2a338)

🤖 Generated with [Claude Code](https://claude.com/claude-code)