### PR TITLE
fix(day-open): explicit invariant + WARN guard against Block DOF placeholder leak

### DIFF
--- a/scripts/day-open-llm-fill.py
+++ b/scripts/day-open-llm-fill.py
@@ -569,6 +569,7 @@ def build_today_plan_prompt(header: str, section_content: str, weekplan: str,
         "6. Не меняй структуру markdown (таблицы, списки, жирный текст).",
         "7. Верни ТОЛЬКО содержимое секции — БЕЗ заголовка секции.",
         "8. Audit-trail для carry-over: после строки '**Carry-over из Day Close вчера:**' воспроизведи ВЕСЬ список из WeekReport ('Не выполнено (carry-over ...)') или вчерашнего DayPlan ('Завтра начать с'). Если какой-то пункт carry-over НЕ попал в таблицу плана — оставь его в самой строке carry-over с пометкой `(отложено: <причина>)` в круглых скобках сразу после пункта. Возможные причины: 'нет WP-ID — ad-hoc задача, не проходит JSON-fact pipeline' / 'условный carry-over \"если бюджет\", дневной бюджет заполнен другими РП' / 'WP в JSON, но статус — done/blocked'. НЕ выкидывай пункт молча — у пилота должен оставаться след. ВАЖНО: пункты с пометкой '(отложено: ...)' живут ТОЛЬКО в строке carry-over (текстовом следе), их часы НЕ входят в Бюджет дня (инвариант 5 остаётся в силе: бюджет = сумма часов JSON-фактов + mandatory_daily_wps).",
+        "9. В переданной секции таблица содержит одну строку-ОБРАЗЕЦ формата: '| 🔴 | С | NNN | **<!-- PENDING -->** | X | pending |'. Это НЕ данные и не РП из JSON — это только показ формата колонок. Эта строка целиком (включая литералы NNN, X, pending) НЕ должна попасть в твой ответ ни в каком виде. Замени её (и добавь остальные) РОВНО N строками, где N = число РП в JSON-фактах (инвариант 2) — по одной строке на каждый РП, реальные номер/название/часы/статус из JSON, без единого NNN/X/<!-- PENDING --> в финальной таблице.",
         "",
         "=== JSON-ФАКТЫ: Активные РП (источник — frontmatter WP-*.md) ===",
         facts_json,
@@ -658,6 +659,25 @@ def fill_chunk(chunk: dict, weekplan: str, active_wps: str, calendar: str,
 
     if not response.strip():
         raise RuntimeError(f"Empty response for section {header}")
+    if is_today_plan:
+        # WP-561 Ф11 (found live 2026-09-09): the example format row (day-open-
+        # scaffold.sh, "| ... | NNN | ... | X | pending |") is only half-marked
+        # as a placeholder -- one cell wrapped in <!-- PENDING -->, the rest
+        # plain literals -- so the LLM sometimes keeps it verbatim alongside
+        # the real per-WP rows instead of dropping it. day-open-checks-runner.sh
+        # already blocks the commit on this (Block DOF check), but that check
+        # only reports "1/22 failed", not why -- print the offending line(s)
+        # here, at the point they were produced, so the answer is in whatever
+        # log captures this script's stderr, without needing to reproduce the run.
+        leftover = [ln for ln in response.splitlines()
+                    if ln.strip().startswith("|")
+                    and re.search(r"\|\s*NNN\s*\||<!-- PENDING -->|\|\s*X\s*\|", ln)]
+        if leftover:
+            print("[WARN] today_plan response still contains the scaffold's "
+                  "example row (NNN/X/PENDING) -- Block DOF check will block "
+                  "the commit. Offending line(s):", file=sys.stderr)
+            for ln in leftover:
+                print(f"[WARN]   {ln}", file=sys.stderr)
     return response
 
 

--- a/seed/strategy/scripts/day-open-llm-fill.py
+++ b/seed/strategy/scripts/day-open-llm-fill.py
@@ -570,6 +570,7 @@ def build_today_plan_prompt(header: str, section_content: str, weekplan: str,
         "6. Не меняй структуру markdown (таблицы, списки, жирный текст).",
         "7. Верни ТОЛЬКО содержимое секции — БЕЗ заголовка секции.",
         "8. Audit-trail для carry-over: после строки '**Carry-over из Day Close вчера:**' воспроизведи ВЕСЬ список из WeekReport ('Не выполнено (carry-over ...)') или вчерашнего DayPlan ('Завтра начать с'). Если какой-то пункт carry-over НЕ попал в таблицу плана — оставь его в самой строке carry-over с пометкой `(отложено: <причина>)` в круглых скобках сразу после пункта. Возможные причины: 'нет WP-ID — ad-hoc задача, не проходит JSON-fact pipeline' / 'условный carry-over \"если бюджет\", дневной бюджет заполнен другими РП' / 'WP в JSON, но статус — done/blocked'. НЕ выкидывай пункт молча — у пилота должен оставаться след. ВАЖНО: пункты с пометкой '(отложено: ...)' живут ТОЛЬКО в строке carry-over (текстовом следе), их часы НЕ входят в Бюджет дня (инвариант 5 остаётся в силе: бюджет = сумма часов JSON-фактов + mandatory_daily_wps).",
+        "9. В переданной секции таблица содержит одну строку-ОБРАЗЕЦ формата: '| 🔴 | С | NNN | **<!-- PENDING -->** | X | pending |'. Это НЕ данные и не РП из JSON — это только показ формата колонок. Эта строка целиком (включая литералы NNN, X, pending) НЕ должна попасть в твой ответ ни в каком виде. Замени её (и добавь остальные) РОВНО N строками, где N = число РП в JSON-фактах (инвариант 2) — по одной строке на каждый РП, реальные номер/название/часы/статус из JSON, без единого NNN/X/<!-- PENDING --> в финальной таблице.",
         "",
         "=== JSON-ФАКТЫ: Активные РП (источник — frontmatter WP-*.md) ===",
         facts_json,
@@ -659,6 +660,25 @@ def fill_chunk(chunk: dict, weekplan: str, active_wps: str, calendar: str,
 
     if not response.strip():
         raise RuntimeError(f"Empty response for section {header}")
+    if is_today_plan:
+        # WP-561 Ф11 (found live 2026-09-09): the example format row (day-open-
+        # scaffold.sh, "| ... | NNN | ... | X | pending |") is only half-marked
+        # as a placeholder -- one cell wrapped in <!-- PENDING -->, the rest
+        # plain literals -- so the LLM sometimes keeps it verbatim alongside
+        # the real per-WP rows instead of dropping it. day-open-checks-runner.sh
+        # already blocks the commit on this (Block DOF check), but that check
+        # only reports "1/22 failed", not why -- print the offending line(s)
+        # here, at the point they were produced, so the answer is in whatever
+        # log captures this script's stderr, without needing to reproduce the run.
+        leftover = [ln for ln in response.splitlines()
+                    if ln.strip().startswith("|")
+                    and re.search(r"\|\s*NNN\s*\||<!-- PENDING -->|\|\s*X\s*\|", ln)]
+        if leftover:
+            print("[WARN] today_plan response still contains the scaffold's "
+                  "example row (NNN/X/PENDING) -- Block DOF check will block "
+                  "the commit. Offending line(s):", file=sys.stderr)
+            for ln in leftover:
+                print(f"[WARN]   {ln}", file=sys.stderr)
     return response
 
 

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2189,7 +2189,7 @@
     },
     {
       "path": "scripts/day-open-llm-fill.py",
-      "sha256": "c1c4592e652db242ec2698b157d70e2e649e9ae38b2543b850198d913e048da9"
+      "sha256": "bf9aa003ff7f34987f68c58285c10c627e2dde92accd1a1ae8244e8d0e7acb92"
     },
     {
       "path": "scripts/day-open-multiplier-backfill-patch.py",
@@ -2893,7 +2893,7 @@
     },
     {
       "path": "seed/strategy/scripts/day-open-llm-fill.py",
-      "sha256": "21fdc689599ba88fff4215cf590e5baaa0efa1d0f552e7c7e9be311bab7e41cf"
+      "sha256": "21ed75881d7c07c1beb5967112a67f5cc5cdf53674f774fb737abd64fb029f24"
     },
     {
       "path": "seed/strategy/scripts/day-open-multiplier-backfill-patch.py",


### PR DESCRIPTION
## Summary
- The `today_plan` prompt (day-open-llm-fill.py) told the model to "replace every marker", but the scaffold's example format row (`| 🔴 | С | NNN | **<!-- PENDING -->** | X | pending |`) marks only one of its six literals as a placeholder — the model sometimes kept the rest verbatim in its response, tripping the existing Block DOF check without leaving a diagnosable trace.
- Adds an explicit invariant naming the example row, plus a mechanical WARN check (same signature the checks-runner uses) that logs the offending line to stderr right after the model's response.
- Ported from a live incident on a downstream personal installation (2026-09-09): diagnosed, fixed, and verified there via a probe run and a real production run (both green after the fix).

## Not included (intentionally)
- The companion log-durability fix from the downstream incident targets `scripts/processes/handlers/day-open-run.sh`, a subsystem not present in this template yet.
- A matching fix to this template's own `day-open-scaffold.sh` (marking the same example row's placeholders explicitly) — not independently verified against this template's copy.
- Both are noted as an open phase in the downstream WP-7 for follow-up.

## Test plan
- [x] `python3 -m py_compile` on both copies (scripts/, seed/strategy/scripts/)
- [x] Both copies diff identical except the `SNAPSHOT` header line
- [x] Standalone import + WARN-regex behavior check against the FMT tree layout (real leak line detected, real data line ignored)
- [x] Verified end-to-end on the downstream repo where this originated (day-open-llm-fill.py, byte-identical prompt/detector logic)
- [ ] No dedicated smoke test exists for this file in this template (also true upstream before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)