### PR TITLE
fix: setup.sh/update.sh never created $WORKSPACE_DIR/extensions/, breaking canonical Day Open

### DIFF
--- a/scripts/tests/test_issue_extensions_dir_missing.sh
+++ b/scripts/tests/test_issue_extensions_dir_missing.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# WP-7 Ф133 (live user report, Ruslan, 2026-09-09): the canonical Day Open
+# pipeline never completed on a fresh install — it always fell back to the
+# free-form prompt. Root cause: setup.sh reads $WORKSPACE_DIR/extensions/
+# (e.g. extensions/mcp-user.json) but never creates it, while
+# day-open-hooks-runner.sh's step 0 treats a missing extensions/ as a hard
+# abort by design (scripts/lib/day-open-hooks.sh: "every install ships
+# extensions/, so this means a broken install, not 'no hooks'").
+#
+# This must exercise the REAL bug, not a synthetic stand-in: it runs an
+# actual full-mode setup.sh (SETUP_CI=1, same invocation as
+# setup/smoke-test-fresh-install.sh's E2E10) into a disposable workspace,
+# then calls day-open-hooks-runner.sh directly against that workspace's
+# extensions/ — no LLM, no network, no day-of-week branching (unlike
+# strategist.sh, rejected as a regression target in peer-session
+# 2026-09-09-10-wp7-f133-day-open-ext: too many unrelated side effects).
+# setup/test-day-open-delivery-closure.sh's own hooks-runner test (5i)
+# manually mkdir's extensions/ before running — it validates the runner's
+# contract in isolation but can never catch this install-time gap. This
+# test is red before the setup.sh/update.sh fix and green after.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+WORKSPACE="$TMP/workspace"
+FAKE_HOME="$TMP/home"
+mkdir -p "$WORKSPACE" "$FAKE_HOME"
+
+# setup.sh's own exit code is not asserted here: past the point that creates
+# extensions/ (step [4c]/[4d], well before [6/6] governance-repo git init),
+# later steps can fail for reasons unrelated to this bug (e.g. a git wrapper
+# hook rejecting the disposable repo's own init in some sandboxed dev
+# environments) without that being evidence either way about extensions/.
+# The assertion below is the actual regression target; setup.sh's output is
+# kept only as debug context if that assertion fails.
+SETUP_RC=0
+SETUP_OUT=$(HOME="$FAKE_HOME" SETUP_CI=1 GITHUB_USER=issue-test WORKSPACE_DIR="$WORKSPACE" \
+    GOVERNANCE_REPO="DS-strategy" \
+    GIT_AUTHOR_NAME="issue-test" GIT_AUTHOR_EMAIL="issue-test@test.local" \
+    GIT_COMMITTER_NAME="issue-test" GIT_COMMITTER_EMAIL="issue-test@test.local" \
+    bash "$ROOT/setup.sh" 2>&1) || SETUP_RC=$?
+
+RUNNER="$ROOT/scripts/day-open-hooks-runner.sh"
+[ -f "$RUNNER" ] || { echo "FAIL: $RUNNER not found" >&2; exit 1; }
+
+RUNNER_RC=0
+RUNNER_OUT=$(IWE_ROOT="$WORKSPACE" HOME="$FAKE_HOME" bash "$RUNNER" before 2>&1) || RUNNER_RC=$?
+
+if [ "$RUNNER_RC" -ne 0 ]; then
+    echo "FAIL: day-open-hooks-runner.sh before exited $RUNNER_RC against a workspace" \
+        "produced by a real setup.sh run — extensions/ dir contract violated" >&2
+    echo "--- runner output ---" >&2
+    echo "$RUNNER_OUT" >&2
+    echo "--- setup.sh WORKSPACE_DIR (setup.sh exit=$SETUP_RC) ---" >&2
+    ls -la "$WORKSPACE" >&2
+    echo "--- setup.sh output (debug context, last 20 lines) ---" >&2
+    echo "$SETUP_OUT" | tail -20 >&2
+    exit 1
+fi
+
+echo "PASS: day-open-hooks-runner.sh before succeeds against a real setup.sh workspace"

--- a/setup.sh
+++ b/setup.sh
@@ -725,6 +725,18 @@ MCP_TEMPLATE="$TEMPLATE_DIR/.mcp.json"
 MCP_DEST="$WORKSPACE_DIR/.mcp.json"
 MCP_USER_EXT="$WORKSPACE_DIR/extensions/mcp-user.json"
 
+# WP-7 Ф133 (live user report, Ruslan, 2026-09-09): extensions/ was already
+# read here (MCP_USER_EXT above) and by day-open-hooks-runner.sh's step 0,
+# but setup.sh never created it — day-open-hooks.sh's fail-closed contract
+# ("every install ships extensions/") aborted the canonical Day Open
+# pipeline on every fresh install. Empty is sufficient: find_day_open_hook_files
+# only requires the directory to exist, not to be non-empty.
+if $DRY_RUN; then
+    echo "  [DRY RUN] Would create $WORKSPACE_DIR/extensions"
+else
+    mkdir -p "$WORKSPACE_DIR/extensions"
+fi
+
 if $DRY_RUN; then
     _IWE_TIER=$(check_user_tier)
     echo "  [DRY RUN] Would generate $MCP_DEST (tier=$_IWE_TIER)"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -397,7 +397,7 @@
     },
     {
       "path": ".claude/skills/day-close/day-close-details.md",
-      "sha256": "3e83f5a48f1455dfebabbeb35211e4e74169baf532ff8bfbd71eca07010557ea"
+      "sha256": "c1b2e300632f6000b1e6138e2274d758d22d2d7be4240a7e125b05868607cbe7"
     },
     {
       "path": ".claude/skills/day-close/day-close/SKILL.md",
@@ -1497,7 +1497,7 @@
     },
     {
       "path": "memory/memory-lifecycle-spec.md",
-      "sha256": "dff4f2312e292b310595688bb2a23a0da2c16250201d54bfebf082472e0f2544"
+      "sha256": "68dfa01867f40cce0bf66e7276bbc7c1af96d4657c1659feb5004399d640f60b"
     },
     {
       "path": "memory/navigation.md",
@@ -1717,7 +1717,7 @@
     },
     {
       "path": "roles/strategist/install.sh",
-      "sha256": "ad8def2736fcbcba78a8f4313f9eac9f0d65387011c2e37b7a3d908351953842"
+      "sha256": "d95a06571d86f5721030f959938d0cb910e22fc0f7cbe19b033f39b7c6ae2b60"
     },
     {
       "path": "roles/strategist/prompts/add-wp.md",
@@ -1857,7 +1857,7 @@
     },
     {
       "path": "roles/strategist/scripts/strategist.sh",
-      "sha256": "8cc51f04a94e34eeb1a8d5ad232b1b68dacfb02a4fa113d8299e8b9a85149f7f"
+      "sha256": "16e0e520f9f8537237dec68f9e5861c4fb7783b0d79e3063e2aac48c174250a9"
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-morning.service",
@@ -2149,7 +2149,7 @@
     },
     {
       "path": "scripts/create-wp.sh",
-      "sha256": "5c9761acd0426119a06899e80a3444b79995b604a1bc27d0ab29a6e02dabfd8c"
+      "sha256": "c855565180efcd81933c3fcb22fee0d7fbb0ed25060d69b9e2eeafeb5c70c8f5"
     },
     {
       "path": "scripts/day-close-lock.sh",
@@ -2189,7 +2189,7 @@
     },
     {
       "path": "scripts/day-open-llm-fill.py",
-      "sha256": "bf9aa003ff7f34987f68c58285c10c627e2dde92accd1a1ae8244e8d0e7acb92"
+      "sha256": "c1c4592e652db242ec2698b157d70e2e649e9ae38b2543b850198d913e048da9"
     },
     {
       "path": "scripts/day-open-multiplier-backfill-patch.py",
@@ -2445,7 +2445,7 @@
     },
     {
       "path": "scripts/memory-health.sh",
-      "sha256": "df51e1796bfc6638891f23d4fa561f002e6f74997b0018b6b25c771e0328bbd7"
+      "sha256": "cf0844f0fff0392081714d2766c0367937ef505992a5e8a56fd55c1c1e6748de"
     },
     {
       "path": "scripts/memory-migrate.sh",
@@ -2453,7 +2453,7 @@
     },
     {
       "path": "scripts/memory-validate.sh",
-      "sha256": "f8308e3c2a05de11f2c97ab9824ca5d0a70e2a1e3e5296a36d102d950f9cb501"
+      "sha256": "b64ca8dc78fa4a4f02a669728cca3b8b2a0c3356d96f52312afcb54c7eb7dd49"
     },
     {
       "path": "scripts/migrate-initial-marker.sh",
@@ -2893,7 +2893,7 @@
     },
     {
       "path": "seed/strategy/scripts/day-open-llm-fill.py",
-      "sha256": "21ed75881d7c07c1beb5967112a67f5cc5cdf53674f774fb737abd64fb029f24"
+      "sha256": "21fdc689599ba88fff4215cf590e5baaa0efa1d0f552e7c7e9be311bab7e41cf"
     },
     {
       "path": "seed/strategy/scripts/day-open-multiplier-backfill-patch.py",
@@ -2985,7 +2985,7 @@
     },
     {
       "path": "setup.sh",
-      "sha256": "134dde54a5afdd58964d31c18a8d6fbc3970447f5224e922d6270e10ac76f1a8"
+      "sha256": "ba3a950fc36569f8df183dc838a3d05999f77be71d31a6fce9c629e9a391e0af"
     },
     {
       "path": "setup/build-runtime.sh",
@@ -3025,7 +3025,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "f35309c750047db28b6eea5d946ca534e803b16f52558b44cfd4ac3c83afef84"
+      "sha256": "46413af72209a09abd03c62943f2d7355542cd0814ac14d76d80d1d0dfac6078"
     }
   ],
   "excluded_paths": [
@@ -3083,7 +3083,7 @@
     "scripts/tests/test_issue_665.sh",
     "scripts/tests/test_issue_711_conflict_base.sh",
     "scripts/tests/test_issue_713_registry_status.sh",
-    "scripts/tests/test_issue_729_strategy_day.sh",
+    "scripts/tests/test_issue_extensions_dir_missing.sh",
     "scripts/tests/test_issue_python_resolver_contract.sh",
     "scripts/tests/test_manifest_coverage_local.py",
     "scripts/tests/test_mount_readonly_packs.sh",

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -397,7 +397,7 @@
     },
     {
       "path": ".claude/skills/day-close/day-close-details.md",
-      "sha256": "c1b2e300632f6000b1e6138e2274d758d22d2d7be4240a7e125b05868607cbe7"
+      "sha256": "3e83f5a48f1455dfebabbeb35211e4e74169baf532ff8bfbd71eca07010557ea"
     },
     {
       "path": ".claude/skills/day-close/day-close/SKILL.md",
@@ -1497,7 +1497,7 @@
     },
     {
       "path": "memory/memory-lifecycle-spec.md",
-      "sha256": "68dfa01867f40cce0bf66e7276bbc7c1af96d4657c1659feb5004399d640f60b"
+      "sha256": "dff4f2312e292b310595688bb2a23a0da2c16250201d54bfebf082472e0f2544"
     },
     {
       "path": "memory/navigation.md",
@@ -1717,7 +1717,7 @@
     },
     {
       "path": "roles/strategist/install.sh",
-      "sha256": "d95a06571d86f5721030f959938d0cb910e22fc0f7cbe19b033f39b7c6ae2b60"
+      "sha256": "ad8def2736fcbcba78a8f4313f9eac9f0d65387011c2e37b7a3d908351953842"
     },
     {
       "path": "roles/strategist/prompts/add-wp.md",
@@ -1857,7 +1857,7 @@
     },
     {
       "path": "roles/strategist/scripts/strategist.sh",
-      "sha256": "16e0e520f9f8537237dec68f9e5861c4fb7783b0d79e3063e2aac48c174250a9"
+      "sha256": "8cc51f04a94e34eeb1a8d5ad232b1b68dacfb02a4fa113d8299e8b9a85149f7f"
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-morning.service",
@@ -2149,7 +2149,7 @@
     },
     {
       "path": "scripts/create-wp.sh",
-      "sha256": "c855565180efcd81933c3fcb22fee0d7fbb0ed25060d69b9e2eeafeb5c70c8f5"
+      "sha256": "5c9761acd0426119a06899e80a3444b79995b604a1bc27d0ab29a6e02dabfd8c"
     },
     {
       "path": "scripts/day-close-lock.sh",
@@ -2189,7 +2189,7 @@
     },
     {
       "path": "scripts/day-open-llm-fill.py",
-      "sha256": "c1c4592e652db242ec2698b157d70e2e649e9ae38b2543b850198d913e048da9"
+      "sha256": "bf9aa003ff7f34987f68c58285c10c627e2dde92accd1a1ae8244e8d0e7acb92"
     },
     {
       "path": "scripts/day-open-multiplier-backfill-patch.py",
@@ -2445,7 +2445,7 @@
     },
     {
       "path": "scripts/memory-health.sh",
-      "sha256": "cf0844f0fff0392081714d2766c0367937ef505992a5e8a56fd55c1c1e6748de"
+      "sha256": "df51e1796bfc6638891f23d4fa561f002e6f74997b0018b6b25c771e0328bbd7"
     },
     {
       "path": "scripts/memory-migrate.sh",
@@ -2453,7 +2453,7 @@
     },
     {
       "path": "scripts/memory-validate.sh",
-      "sha256": "b64ca8dc78fa4a4f02a669728cca3b8b2a0c3356d96f52312afcb54c7eb7dd49"
+      "sha256": "f8308e3c2a05de11f2c97ab9824ca5d0a70e2a1e3e5296a36d102d950f9cb501"
     },
     {
       "path": "scripts/migrate-initial-marker.sh",
@@ -2893,7 +2893,7 @@
     },
     {
       "path": "seed/strategy/scripts/day-open-llm-fill.py",
-      "sha256": "21fdc689599ba88fff4215cf590e5baaa0efa1d0f552e7c7e9be311bab7e41cf"
+      "sha256": "21ed75881d7c07c1beb5967112a67f5cc5cdf53674f774fb737abd64fb029f24"
     },
     {
       "path": "seed/strategy/scripts/day-open-multiplier-backfill-patch.py",
@@ -3025,7 +3025,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "46413af72209a09abd03c62943f2d7355542cd0814ac14d76d80d1d0dfac6078"
+      "sha256": "1442776d1e24f854ae0595cfb0dbff4b150253f7c7b19d53d61f0823fff3f48e"
     }
   ],
   "excluded_paths": [
@@ -3083,6 +3083,7 @@
     "scripts/tests/test_issue_665.sh",
     "scripts/tests/test_issue_711_conflict_base.sh",
     "scripts/tests/test_issue_713_registry_status.sh",
+    "scripts/tests/test_issue_729_strategy_day.sh",
     "scripts/tests/test_issue_extensions_dir_missing.sh",
     "scripts/tests/test_issue_python_resolver_contract.sh",
     "scripts/tests/test_manifest_coverage_local.py",

--- a/update.sh
+++ b/update.sh
@@ -3958,6 +3958,18 @@ fi
 
 # (Step 6b removed — repo rename no longer supported, no link migration needed)
 
+# === Step 6b2: Self-heal missing extensions/ (WP-7 Ф133) ===
+# setup.sh never created $WORKSPACE_DIR/extensions/ before this fix (only
+# read from it — MCP_USER below, day-open-hooks-runner.sh step 0), so every
+# install that ran setup.sh before this fix landed and will never re-run
+# setup.sh is stuck without it. day-open-hooks.sh's fail-closed contract
+# ("every install ships extensions/") then aborts the canonical Day Open
+# pipeline on every single run — confirmed live (Ruslan, 2026-09-09).
+# Idempotent no-op once the directory exists, same as any other self-heal.
+if ! $CHECK_ONLY; then
+    mkdir -p "$WORKSPACE_DIR/extensions"
+fi
+
 MCP_TEMPLATE="$SCRIPT_DIR/.mcp.json"
 MCP_WORKSPACE="$WORKSPACE_DIR/.mcp.json"
 MCP_USER="$WORKSPACE_DIR/extensions/mcp-user.json"


### PR DESCRIPTION
## Проблема

Живой пользователь (Руслан) сообщил, что канонический конвейер Day Open ни разу не отработал целиком на его установке — оба раза съехал в запасной («свободный») режим планирования дня.

Корень: `setup.sh` уже ЧИТАЛ из `$WORKSPACE_DIR/extensions/` (например `extensions/mcp-user.json`), но никогда её не создавал — ни при первой установке, ни в `update.sh`. `day-open-hooks-runner.sh` (первый шаг канонического конвейера, «0. Extension graph: before») трактует отсутствие `extensions/` как жёсткий отказ по дизайну (`scripts/lib/day-open-hooks.sh`: «every install ships extensions/, so this means a broken install, not "no hooks"»). Контракт директории уже предполагался — установщик просто не выполнял свою часть.

Симптом маскировался молча: `strategist.sh` (сценарий `morning`) при падении конвейера логирует `WARN` и уходит в запасной промпт, но не возвращает планировщику ненулевой код — задание "успешно" завершается каждое утро, даже когда канонический конвейер не отработал.

## Фикс

- `setup.sh` — создаёт `$WORKSPACE_DIR/extensions/` на свежей установке (`mkdir -p`, DRY_RUN-safe).
- `update.sh` — тот же `mkdir -p` идемпотентно на каждом прогоне (self-heal для уже установленных пользователей — `setup.sh` у них второй раз не запустится).
- Пустая директория достаточна — сама проверка в `day-open-hooks.sh` требует только существования, не непустоты. Fail-closed контракт там не трогали.

## Новый регресс-тест

`scripts/tests/test_issue_extensions_dir_missing.sh` — гоняет настоящий `setup.sh` (полный режим, `SETUP_CI=1`, одноразовая директория) → вызывает `day-open-hooks-runner.sh before` напрямую против результата → проверяет успех. Не зависит от `strategist.sh` (день недели, обращения к ИИ, telegram) — узкий детерминированный regression, красный до фикса и зелёный после (проверено дважды: автором и независимым холодным ревью). Существующий тест 5i в `test-day-open-delivery-closure.sh` не мог поймать этот баг — он вручную создаёт `extensions/` перед проверкой.

## Процесс

Пир-сессия с Codex (`2026-09-09-10-wp7-f133-day-open-ext`, консенсус за 3 хода) — отклонили `strategist.sh morning` и `day-open-pipeline.sh --probe` как цели для регресс-теста (день недели, побочки, `--probe` всё равно реально дёргает LLM). Холодное ревью субагентом — без критических/высоких/средних находок.

## Test plan

- [x] `bash -n setup.sh` / `bash -n update.sh` — чисто
- [x] Новый тест: красный до фикса (падает именно на отсутствии `extensions/`), зелёный после
- [x] `setup/smoke-test-fresh-install.sh` — без новых регрессий (те же 4 известных непройденных теста, что и раньше, не связаны с этой правкой)
- [x] `setup/test-day-open-delivery-closure.sh` — 106 pass (fail-closed контракт 5i не сломан), 2 непройденных теста — предсуществующие и не связаны (Python cwd/import в несвязанных скриптах)
- [x] `scripts/tests/test_launchd_identity_runtime.sh` — pass

Refs: WP-7 Ф133

🤖 Generated with [Claude Code](https://claude.com/claude-code)