### PR TITLE
fix: atomic WP-number reservation + --yes registers protective hooks (#743, #738)

### DIFF
--- a/scripts/create-wp.sh
+++ b/scripts/create-wp.sh
@@ -210,6 +210,11 @@ fi
 # EEXIST. Маркеры никогда не удаляются при архивации WP — номер не переиздаётся.
 WP_NUMBERS_DIR="$STATE_DIR/wp-numbers"
 mkdir -p "$WP_NUMBERS_DIR"
+# Fail fast on a real filesystem problem (permissions, read-only, disk full)
+# instead of burning all 50 retry attempts and reporting a misleading
+# "couldn't reserve after 50 tries" — that message is meant for a genuine
+# reservation race, not a broken filesystem (cold-review finding, PR #746).
+[[ -w "$WP_NUMBERS_DIR" ]] || { echo "❌ Нет прав на запись в $WP_NUMBERS_DIR — резервирование номера невозможно" >&2; exit 1; }
 
 registry_max() {
   python3 - "$REGISTRY" <<'PYEOF' 2>/dev/null
@@ -269,9 +274,18 @@ echo "📋 Следующий номер WP: $WP_NUM (зарезервирова
 WP_ID=$(printf '%03d' "$WP_NUM")
 
 # --- Проверка consent ---
+# Отказ здесь — штатный первый круг WP Gate (реальный пользователь ещё не
+# подтвердил создание), не гонка за номером: ничего для WP_NUM не создано,
+# поэтому маркер резервации снимаем перед выходом — иначе повторный запуск
+# после `touch` резервирует СЛЕДУЮЩИЙ номер, а не тот, что пользователь только
+# что подтвердил, и WP Gate никогда не проходит (живой тест поймал это до
+# релиза: touch consent-2 → второй запуск требует consent-3 → бесконечная
+# погоня). Отличие от "не удалось создать WP-N" ниже (rollback_wp_creation):
+# там уже могли быть частичные файловые следы, здесь — гарантированно нет.
 CONSENT_FILE="$STATE_DIR/wp-consent-${WP_NUM}"
 if [[ "$SKIP_CONSENT" -eq 0 ]]; then
   if [[ ! -f "$CONSENT_FILE" ]]; then
+    rmdir "$WP_NUMBERS_DIR/$WP_NUM" 2>/dev/null
     echo "🚫 WP Gate: нет согласия пользователя на создание WP-${WP_NUM}" >&2
     echo "   Создайте consent file и повторите:" >&2
     echo "   touch $CONSENT_FILE" >&2

--- a/scripts/create-wp.sh
+++ b/scripts/create-wp.sh
@@ -200,8 +200,19 @@ if [[ -n "$STATE" && -n "${STATE_AXES:-}" ]]; then
   fi
 fi
 
-# --- Найти следующий номер WP ---
-WP_NUM=$(python3 - "$REGISTRY" <<'PYEOF' 2>/dev/null
+# --- Найти и атомарно зарезервировать следующий номер WP ---
+# issue #743: max(REGISTRY)+1 без резервирования отдаёт один и тот же номер
+# двум параллельным агентам (Claude/Kimi/Codex — штатный режим платформы,
+# см. AGENTS.md § Git Staging), и повторно — любому сокращению активного
+# реестра (архивация, разделение). Тот же класс гонки уже закрыт для номеров
+# пир-сессий (session-dir-reserve.sh, WP-530): маркер-каталог + `mkdir` без
+# -p как единственный атомарный арбитр на POSIX-файловой системе, retry на
+# EEXIST. Маркеры никогда не удаляются при архивации WP — номер не переиздаётся.
+WP_NUMBERS_DIR="$STATE_DIR/wp-numbers"
+mkdir -p "$WP_NUMBERS_DIR"
+
+registry_max() {
+  python3 - "$REGISTRY" <<'PYEOF' 2>/dev/null
 import sys, re
 registry = sys.argv[1]
 max_num = 0
@@ -214,18 +225,43 @@ try:
                 n = int(m.group(1))
                 if n > max_num:
                     max_num = n
-except Exception as e:
-    print(0, file=sys.stderr)
-print(max_num + 1)
+except Exception:
+    pass
+print(max_num)
 PYEOF
-)
+}
 
-if [[ -z "$WP_NUM" || "$WP_NUM" -le 0 ]]; then
-  echo "❌ Не удалось определить следующий номер WP из REGISTRY" >&2
+highest_taken() {
+  local max
+  max=$(registry_max)
+  [[ "$max" =~ ^[0-9]+$ ]] || max=0
+  local d n
+  for d in "$WP_NUMBERS_DIR"/*/; do
+    [[ -d "$d" ]] || continue
+    n="$(basename "$d")"
+    [[ "$n" =~ ^[0-9]+$ ]] || continue
+    if [ "$n" -gt "$max" ]; then max=$n; fi
+  done
+  printf '%s\n' "$max"
+}
+
+WP_NUM=""
+for ((_attempt = 1; _attempt <= 50; _attempt++)); do
+  next=$(( $(highest_taken) + 1 ))
+  # Без -p: EEXIST — сигнал, что номер выиграла другая сессия, повторить со
+  # свежим highest_taken (могла также вырасти сама REGISTRY-часть максимума).
+  if mkdir "$WP_NUMBERS_DIR/$next" 2>/dev/null; then
+    WP_NUM="$next"
+    break
+  fi
+done
+
+if [[ -z "$WP_NUM" ]]; then
+  echo "❌ Не удалось зарезервировать номер WP за 50 попыток" >&2
   exit 1
 fi
 
-echo "📋 Следующий номер WP: $WP_NUM"
+echo "📋 Следующий номер WP: $WP_NUM (зарезервирован: $WP_NUMBERS_DIR/$WP_NUM)"
 
 # issue #338 п.4: без паддинга "WP-9" в листинге сортируется после "WP-10".
 # WP_ID — только для строк с префиксом "WP-" (пути, заголовки); frontmatter

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2149,7 +2149,7 @@
     },
     {
       "path": "scripts/create-wp.sh",
-      "sha256": "c855565180efcd81933c3fcb22fee0d7fbb0ed25060d69b9e2eeafeb5c70c8f5"
+      "sha256": "d4f808130d3c424d0de8f1701531bec6ac9914a98f6e41105d2add600b0cee95"
     },
     {
       "path": "scripts/day-close-lock.sh",
@@ -3025,7 +3025,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "a457e5f7d0ca31562294c63c872122bfbf38dbcb5c102fe08d2b755b4bde9ebf"
+      "sha256": "f35309c750047db28b6eea5d946ca534e803b16f52558b44cfd4ac3c83afef84"
     }
   ],
   "excluded_paths": [

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2149,7 +2149,7 @@
     },
     {
       "path": "scripts/create-wp.sh",
-      "sha256": "d4f808130d3c424d0de8f1701531bec6ac9914a98f6e41105d2add600b0cee95"
+      "sha256": "5c9761acd0426119a06899e80a3444b79995b604a1bc27d0ab29a6e02dabfd8c"
     },
     {
       "path": "scripts/day-close-lock.sh",

--- a/update.sh
+++ b/update.sh
@@ -50,9 +50,14 @@ API_BASE="https://api.github.com/repos/$REPO"
 CHECK_ONLY=false
 AUTO_YES=false
 FAST_CHECK=false
-# Stage B opt-ins (WP-7 F71): по умолчанию оба выключены — без флагов конвейер
-# только наблюдает (stage A) и ничего не пишет в пользовательские файлы.
+# Stage B opt-ins (WP-7 F71, поведение settings-merge скорректировано issue
+# #738): по умолчанию (без флагов, интерактивный запуск) оба выключены —
+# конвейер только наблюдает (stage A) и ничего не пишет в пользовательские
+# файлы. --yes включает settings-merge автоматически (см. ниже, после разбора
+# аргументов) — доказанно аддитивное слияние не рискованнее остального,
+# что --yes уже применяет без подтверждения.
 APPLY_SETTINGS_MERGE=false
+NO_SETTINGS_MERGE=false
 REFRESH_STALE=false
 
 # #533: governance compatibility entrypoints are upgraded as one ownership
@@ -98,6 +103,7 @@ for arg in "$@"; do
         --fast)             FAST_CHECK=true ;;
         --yes)              AUTO_YES=true ;;
         --apply-settings-merge) APPLY_SETTINGS_MERGE=true ;;
+        --no-settings-merge)    NO_SETTINGS_MERGE=true ;;
         --refresh-stale)    REFRESH_STALE=true ;;
         --version)          echo "exocortex-update v$VERSION"; exit 0 ;;
         --help|-h)
@@ -106,8 +112,9 @@ for arg in "$@"; do
             echo "Options:"
             echo "  --check     Показать доступные обновления без применения"
             echo "  --fast      С --check: сравнить только версию манифеста (без скачивания 300+ файлов, issue #230)"
-            echo "  --yes       Применить обновления без подтверждения"
-            echo "  --apply-settings-merge  Применить слияние settings.json (бэкап + пост-валидация; без флага — только предпросмотр)"
+            echo "  --yes       Применить обновления без подтверждения (включает settings.json merge, см. --no-settings-merge)"
+            echo "  --apply-settings-merge  Применить слияние settings.json отдельно от --yes (бэкап + пост-валидация; без флага и без --yes — только предпросмотр)"
+            echo "  --no-settings-merge     С --yes: НЕ применять слияние settings.json (оставить только предпросмотр, старое поведение --yes)"
             echo "  --refresh-stale         author_mode: обновить файлы «отстал от шаблона, правок нет» (бэкап; блок при «неизвестно» > 0)"
             echo "  --version   Версия скрипта"
             echo "  --help      Эта справка"
@@ -115,6 +122,24 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+# issue #738: --apply-settings-merge оставался opt-in даже под --yes, поэтому
+# автоматический `update.sh --yes` доставлял новые файлы хуков в .claude/hooks/,
+# но не регистрировал их в settings.json — блокирующие защитные хуки
+# (destructive-guard.sh, pull-on-touch.sh) молча оставались выключены.
+# Слияние доказанно только аддитивное (settings-merge-preview.py: union по
+# hooks/permissions, при конфликте побеждает значение пользователя, ничего
+# существующего не перезаписывается и не удаляется) — не более рискованно,
+# чем остальное, что --yes уже применяет без подтверждения. Явный
+# --apply-settings-merge остаётся отдельной ручкой для запуска слияния без
+# остального --yes-конвейера (например, повторный прогон после --check).
+# --no-settings-merge — явный opt-out для тех, кто сознательно держал
+# settings.json под ручным контролем и гонял --yes только ради остального
+# конвейера (Codex, ревью этого фикса, ход 3): сохраняет старое поведение
+# --yes точечно, без отказа от автоприменения остальных обновлений.
+if [ "$AUTO_YES" = "true" ] && [ "$NO_SETTINGS_MERGE" != "true" ]; then
+    APPLY_SETTINGS_MERGE=true
+fi
 
 # === Cross-platform sed -i ===
 if sed --version >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Peer session with Codex (WP-7, 2026-09-09): triage of 8 open template issues, two fixed here.

- **#743**: `create-wp.sh` derived the next WP number as `max(REGISTRY)+1` with no reservation — two parallel agents (the platform's normal mode) reading the same registry got the same number. Fixed with the same marker-directory + atomic `mkdir` pattern already used for peer-session numbers (`session-dir-reserve.sh`, WP-530). Numbers are never reissued (markers survive WP archival).
- **#738**: `update.sh --yes` delivered new hook files to `.claude/hooks/` but left their `settings.json` registration behind an opt-in `--apply-settings-merge` flag — so automated updates silently left new protective hooks unregistered, including `destructive-guard.sh` and `pull-on-touch.sh` (both blocking rules). The merge itself is additive-only (union merge, user value wins on conflict, nothing existing removed/overwritten) — verified live. `--yes` now applies it by default; `--no-settings-merge` added as an explicit opt-out.

Codex reviewed both (proposed consensus). One open question flagged on #738: does folding settings-merge into `--yes` surprise anyone who relied on it never touching `settings.json`? Flagged to the pilot — not a blocker for review, but worth a second look before merge.

Closes #743. Addresses #738 (root fix; loud-warning-only alternative was considered and rejected — see PR discussion).

## Test plan
- [x] `bash -n` clean on both scripts
- [x] `#743`: 8 parallel `create-wp.sh --no-consent-check` invocations against an isolated `WP-REGISTRY.md` fixture → 8 distinct numbers, zero collisions (re-verified after a portability tweak to the retry loop)
- [x] `#743`: flag-matrix assert test (no flags / `--yes` / `--apply-settings-merge` / `--check`) — `APPLY_SETTINGS_MERGE`/`AUTO_YES` end state matches spec for each combination, including the new `--no-settings-merge` opt-out
- [x] `#738`: live merge-apply test — stripped `destructive-guard.sh`/`pull-on-touch.sh` from a real `settings.json`, ran `settings-merge-apply.sh`, both hooks restored with zero conflicts and a backup
- [x] `generate-manifest.sh` re-run, `update-manifest.json` sha256 synced for both files

Refs: peer-session `2026-09-09-11-fmt-issues-triage-wp7` (Claude + Codex)

🤖 Generated with peer-session 2026-09-09-11-fmt-issues-triage-wp7 (Claude + Codex)