### PR TITLE
fix(translate): add name to frontmatter_translate_keys (issue #749)

### DIFF
--- a/translation-manifest.yaml
+++ b/translation-manifest.yaml
@@ -53,6 +53,7 @@ frontmatter_translate_keys:
   - title
   - description
   - summary
+  - name
 
 # FILE CATEGORIES
 # Д — Documentation: auto-translate via LLM pipeline + glossary

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -3013,7 +3013,7 @@
     },
     {
       "path": "translation-manifest.yaml",
-      "sha256": "c14d0fa83eaeb31d18be1fc0121d60faa4c0a61cb9ad475c00408776ab1c8bb0"
+      "sha256": "2a81f69899c474698f0ba0b55abae54499d8a44b3fd26bffdd1f1a7aff450786"
     },
     {
       "path": "translation/en-doc-style.md",


### PR DESCRIPTION
Половина находки #749 (сломанный Translate Sync, en-draft не обновляется с 24.08).

`translation-manifest.yaml` переводил только `title`/`description`/`summary` из frontmatter, `name` копировался как есть — кириллица в `docs/AGENT-FAULT-PROCESS.md` ловилась Cyrillic gate'ом на каждом прогоне. Добавил `name` в список тем же паттерном.

Вторая половина находки (внутренние ссылки вида «§2б» в теле `web-onboarding.md`) сложнее — не однострочный фикс, оставлена открытой в #749.

Refs: #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)