### PR TITLE
fix(hooks,translate-sync): portable timeout, registry path, subsection letters

### DIFF
--- a/.claude/hooks/destructive-guard.sh
+++ b/.claude/hooks/destructive-guard.sh
@@ -9,6 +9,23 @@ block() {
   exit 2
 }
 
+# Portable timeout (same helper as rule-engine.sh:_safe_timeout — kept local,
+# not sourced, since this hook has no other dependency on rule-engine.sh).
+# Plain `timeout` is a GNU coreutils binary, not part of base macOS: on a
+# clean Mac install (no Homebrew coreutils) it is simply absent, `command not
+# found` exits 127, and the `if !` below treats that identically to a real jq
+# failure — every Bash call gets fail-closed blocked (issue #754).
+_safe_timeout() {
+  local t="$1"; shift
+  if command -v gtimeout &>/dev/null; then
+    gtimeout "$t" "$@"
+  elif command -v timeout &>/dev/null; then
+    timeout "$t" "$@"
+  else
+    perl -e "alarm $t; exec @ARGV" -- "$@"
+  fi
+}
+
 # Read stdin once: a pipe/redirected fd is fully drained by the first jq call,
 # so a second `jq` reading raw stdin always sees EOF and returns empty — this
 # silently zeroed out $CWD on every invocation (found WP-547, 03.09, while
@@ -30,7 +47,7 @@ HOOK_INPUT=$(cat 2>/dev/null || true)
 # above, but nothing bounded how long it could run on a pathological payload
 # either — a hang here would hang the hook, and by the same fail-closed logic
 # as the rest of this block, a hung/killed jq (exit 124) blocks too.
-if ! printf '%s' "$HOOK_INPUT" | timeout 5 jq -e \
+if ! printf '%s' "$HOOK_INPUT" | _safe_timeout 5 jq -e \
   'type == "object" and (.tool_input | type) == "object" and (.tool_input.command | type) == "string" and (.tool_input.command | length) > 0' \
   >/dev/null 2>&1; then
   block "не удалось разобрать вход хука, либо tool_input.command отсутствует/пустой/неверного типа — блокирую как неопределённо опасный запрос."

--- a/.claude/hooks/sql-pii-guard.sh
+++ b/.claude/hooks/sql-pii-guard.sh
@@ -130,6 +130,20 @@ esac
 
 [ -x "$ENGINE" ] || guard_failure "rule engine is missing or not executable"
 
+# rule-engine.sh defaults RULE_REGISTRY to $HOME/IWE/.claude/rules-registry.yaml
+# (its own hardcoded assumption about the workspace path), not to a path
+# relative to itself. On any install where the workspace isn't literally
+# named "IWE" directly under $HOME, that default silently misses the
+# registry this template ships at .claude/rules-registry.yaml (relative to
+# HOOK_DIR) — load_rules_for_event() then returns an empty rule list instead
+# of erroring, and every SQL write fails closed with a misleading "AR.112/
+# AR.113 were not both applied" (issue #753). Point the engine at the
+# template's own shipped copy explicitly, the same path self_test() already
+# uses below, unless the caller already overrode RULE_REGISTRY.
+RULE_REGISTRY="${RULE_REGISTRY:-$HOOK_DIR/../rules-registry.yaml}"
+[ -r "$RULE_REGISTRY" ] || guard_failure "rules registry not found at $RULE_REGISTRY — AR.112/AR.113 cannot be evaluated"
+export RULE_REGISTRY
+
 CTX=$(python3 - "$FILE_PATH" <<'PYEOF'
 import json
 import sys

--- a/.github/workflows/translate-sync.yml
+++ b/.github/workflows/translate-sync.yml
@@ -226,6 +226,46 @@ jobs:
                   print(f"stripped Cyrillic anchors: {path}")
           PYEOF
 
+      - name: Normalize Cyrillic subsection letters (§2б → §2b)
+        # Pack/DP references use a trailing Cyrillic letter as a subsection
+        # label (`DP.ARCH.002 §2б`, meaning "part b of section 2") in plain
+        # prose, not inside a link — the anchor-stripper above only touches
+        # markdown link syntax, so this pattern reaches en-draft untouched
+        # and trips the hard Cyrillic gate below (issue #752/#749; root
+        # cause tracked in WP-7). Translit only the single trailing letter
+        # right after "§<digits>", not general prose — a blanket scrub would
+        # risk mangling text the LLM translator was supposed to handle.
+        if: always() && steps.en_draft.outcome == 'success'
+        run: |
+          python3 - <<'PYEOF'
+          import pathlib
+          import re
+
+          # Full alphabet, not just the letters seen in issue #752 — a
+          # partial table closes today's report but not the class (cold
+          # review flagged this: the codebase already has a "§3р" elsewhere,
+          # letter outside the first 10).
+          TRANSLIT = {
+              "а": "a", "б": "b", "в": "v", "г": "g", "д": "d", "е": "e",
+              "ё": "e", "ж": "zh", "з": "z", "и": "i", "й": "y", "к": "k",
+              "л": "l", "м": "m", "н": "n", "о": "o", "п": "p", "р": "r",
+              "с": "s", "т": "t", "у": "u", "ф": "f", "х": "h", "ц": "c",
+              "ч": "ch", "ш": "sh", "щ": "sch", "ъ": "", "ы": "y", "ь": "",
+              "э": "e", "ю": "yu", "я": "ya",
+          }
+          subsection = re.compile(r"(§\d+)([" + "".join(TRANSLIT) + r"])\b")
+
+          def fix(match):
+              return match.group(1) + TRANSLIT[match.group(2)]
+
+          for path in pathlib.Path("../en-draft").rglob("*.md"):
+              content = path.read_text(encoding="utf-8")
+              cleaned = subsection.sub(fix, content)
+              if cleaned != content:
+                  path.write_text(cleaned, encoding="utf-8")
+                  print(f"normalized subsection letters: {path}")
+          PYEOF
+
       - name: Write EN-side community files to en-draft
         # Feedback lives on iwesys/IWE itself (pilot decision 2026-07-10):
         # Issues and Discussions are enabled on the EN repo, no references

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -61,7 +61,7 @@
     },
     {
       "path": ".claude/hooks/destructive-guard.sh",
-      "sha256": "a6d9468071cdd50436125384eb1820d7444a5b33a07688548c34dc193ea45877"
+      "sha256": "df9d2075aaba4ce83c9aeab9f7e5efb1474c4681801e9a47be0e246b51c633b6"
     },
     {
       "path": ".claude/hooks/destructive-mcp-guard.sh",
@@ -169,7 +169,7 @@
     },
     {
       "path": ".claude/hooks/sql-pii-guard.sh",
-      "sha256": "f081e4d19a64ccf2de50c979e2df48dfe6c3f7534700bce48174fc955c14a19e"
+      "sha256": "4c567c88d1590531060cd09e19897ef31c91d2c26be3258410d03fc0b95b294d"
     },
     {
       "path": ".claude/hooks/tests/test-destructive-guard-executed-command-scope.sh",


### PR DESCRIPTION
## Summary
Three independent fixes closing four issues, found and implemented in a Kimi+Codex peer session (`2026-09-10-03-fmt-issues-triage`), triaged against internal work-item cards РП-7/544/529.

- **destructive-guard.sh** (closes #754): `timeout 5 jq` has no fallback when plain `timeout` is absent — a clean macOS has no coreutils `timeout` by default, so every Bash call failed closed with "command not found". Reuses the portable `_safe_timeout()` helper already present in `rule-engine.sh` (`gtimeout` → `timeout` → `perl alarm`).
- **sql-pii-guard.sh** (closes #753): `rule-engine.sh` defaults `RULE_REGISTRY` to `$HOME/IWE/.claude/rules-registry.yaml`, not a path relative to itself. On any install where the workspace isn't literally `~/IWE`, the registry this template ships at `.claude/rules-registry.yaml` was never found — `load_rules_for_event()` silently returned `[]`, and AR.112/AR.113 failed closed on every SQL write. Now points the engine at the template's own shipped registry explicitly (the same path `self_test()` already used), with a loud failure if it's genuinely missing.
- **translate-sync.yml** (closes #752, closes #749): Translate Sync has failed since 2026-08-24 on residual Cyrillic caught by the hard gate. Two distinct root causes were found for this — the frontmatter half (`docs/AGENT-FAULT-PROCESS.md` using `name:` instead of `title:`) was already fixed by #750 (merged 2026-09-09) but explicitly left the other half open. This PR closes that remaining half: subsection labels like `DP.ARCH.002 §2б` are plain prose, not link syntax, so the existing anchor-stripper step never touched them — a new step transliterates the trailing letter (full Cyrillic alphabet, not just the one case reported, per cold review). Rebased on top of #750 — `translation-manifest.yaml` is no longer part of this diff.

## Test plan
- [x] Full existing `destructive-guard.sh` test suite green before and after (16+17+42 PASS, 0 FAIL)
- [x] `sql-pii-guard.sh --self-test` green before and after (9/9 PASS, including the `no_rules` and `pii_schema_manual_review` cases)
- [x] Manual simulation: `destructive-guard.sh` invoked with a `PATH` containing no `timeout`/`gtimeout` binary — valid commands still pass, dangerous commands still block
- [x] Manual regex check: `§2б` → `§2b`, `§3р` → `§3r`, `§2 время` unaffected (word boundary correctly excludes mid-word matches)
- [x] YAML syntax validated
- [x] Cold-context code review (separate subagent) — no Critical/High findings; one Medium (transliteration table coverage) addressed before this PR
- [x] Rebased onto main after #750 merged; conflict in `translation-manifest.yaml` resolved by dropping the now-duplicate `name` key addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)