### PR TITLE
fix(residency-gate): distinguish fresh install from vanished consent state (issue #521B)

### DIFF
--- a/.claude/skills/residency-gate/lib/state.py
+++ b/.claude/skills/residency-gate/lib/state.py
@@ -28,6 +28,7 @@ class ResidencyState:
     BACKUP_DIR_NAME = "migration-backups"
     LEGACY_BACKUP_NAME = "data-residency.yaml.legacy"
     LEGACY_QUARANTINE_NAME = ".data-residency.yaml.legacy.migrating"
+    INIT_MARKER_NAME = ".data-residency.initialized"
 
     def __init__(self, state_file: Optional[str] = None):
         """Initialize state manager.
@@ -76,6 +77,7 @@ class ResidencyState:
                 self._migrate_legacy_state()
             self._ensure_file_exists()
             self._ensure_private_file(self.state_file)
+            self._ensure_init_marker()
 
     @staticmethod
     def _absolute_path(value: str, label: str) -> Path:
@@ -672,9 +674,46 @@ class ResidencyState:
                 os.close(legacy_directory)
 
     def _ensure_file_exists(self) -> None:
-        """Create empty state file if it doesn't exist."""
-        if not self.state_file.exists() and not self.state_file.is_symlink():
-            self._save_state_unlocked({})
+        """Create empty state on first-ever use; fail closed if it vanished later.
+
+        A missing state file is ambiguous by itself: it looks identical whether
+        this location has never been used, or whether a real consent/denial
+        record existed here and was lost (disk corruption, accidental deletion).
+        Silently recreating an empty file would make that data loss look like a
+        fresh install with nothing asked yet (issue #521B). The init marker
+        breaks the ambiguity: its presence proves this location was previously
+        initialized, so a missing state file next to it is an integrity failure,
+        not a first run.
+        """
+        if self.state_file.exists() or self.state_file.is_symlink():
+            return
+        marker = self.state_file.parent / self.INIT_MARKER_NAME
+        if marker.exists() or marker.is_symlink():
+            raise ResidencyStateError(
+                "consent state file is missing but this location was already "
+                f"initialized: {self.state_file}. Refusing to silently treat "
+                "prior consent/denial decisions as never asked — restore it "
+                "from an external/OS-level backup if one exists, or remove "
+                f"the marker at {marker} only if you are certain no consent "
+                "state ever existed here."
+            )
+        self._save_state_unlocked({})
+
+    def _ensure_init_marker(self) -> None:
+        """Backfill or verify the tombstone marking this location as initialized.
+
+        Callers must invoke this only after ``_ensure_private_file(state_file)``
+        has proven the entry is a legitimate regular file (not a symlink,
+        directory, or extra hardlink) — planting the marker before that check
+        would falsely attest "already initialized" for an entry that
+        construction is about to reject, permanently locking out a fresh
+        install once the offending entry is removed.
+        """
+        marker = self.state_file.parent / self.INIT_MARKER_NAME
+        if marker.exists() or marker.is_symlink():
+            self._ensure_private_file(marker)
+            return
+        self._create_exclusive_private_file(marker, b"")
 
     def _load_state_unlocked(self) -> dict:
         """Load current state from yaml."""

--- a/scripts/tests/test_residency_gate_skill_adapter.py
+++ b/scripts/tests/test_residency_gate_skill_adapter.py
@@ -529,6 +529,31 @@ def test_default_state_home_is_local_private_and_outside_iwe(monkeypatch, tmp_pa
     assert stat.S_IMODE(state_home.stat().st_mode) == 0o700
     assert stat.S_IMODE(target.stat().st_mode) == 0o600
     assert stat.S_IMODE((state_home / ".data-residency.lock").stat().st_mode) == 0o600
+    marker = state_home / ResidencyState.INIT_MARKER_NAME
+    assert stat.S_IMODE(marker.stat().st_mode) == 0o600
+
+
+def test_state_file_removed_after_marker_present_fails_closed(monkeypatch, tmp_path):
+    """A state file that vanishes after this location was initialized must
+    fail loudly (issue #521B) — not be recreated empty and read back as
+    "user was never asked", which would mask real data loss as a fresh
+    install."""
+    home = tmp_path / "vanished-state-home"
+    state_home, _ = _configure_state_paths(monkeypatch, home)
+
+    first = ResidencyState()
+    first.grant_consent("vanished-test", "2.1_inbound_profile")
+    marker = state_home / ResidencyState.INIT_MARKER_NAME
+    assert marker.exists()
+    first.state_file.unlink()
+
+    with pytest.raises(
+        ResidencyStateError,
+        match="already initialized",
+    ):
+        ResidencyState()
+
+    assert not first.state_file.exists()
 
 
 def test_default_state_container_symlink_is_rejected(monkeypatch, tmp_path):
@@ -589,6 +614,11 @@ def test_existing_default_private_tree_permissions_are_repaired(
     assert stat.S_IMODE(state_home.stat().st_mode) == 0o700
     assert stat.S_IMODE(state.state_file.stat().st_mode) == 0o600
     assert stat.S_IMODE(state.lock_file.stat().st_mode) == 0o600
+    # Upgrade path: an install from before the init marker existed (issue
+    # #521B) must self-heal by backfilling the marker, not fail closed —
+    # only a state file that vanishes AFTER the marker exists is a defect.
+    marker = state_home / ResidencyState.INIT_MARKER_NAME
+    assert stat.S_IMODE(marker.stat().st_mode) == 0o600
 
 
 def test_state_home_override_wins_and_legacy_root_is_independent(
@@ -943,6 +973,30 @@ def test_hardlinked_state_is_rejected_without_touching_peer(monkeypatch, tmp_pat
     assert stat.S_IMODE(peer.stat().st_mode) == mode_before
 
 
+def test_rejected_state_file_does_not_plant_init_marker(monkeypatch, tmp_path):
+    """A construction attempt that fails validation (e.g. a symlinked state
+    file) must not leave the init marker behind — otherwise removing the
+    offending entry and retrying a genuine fresh install would falsely hit
+    the "already initialized" fail-closed path added for issue #521B."""
+    home = tmp_path / "rejected-then-fresh-home"
+    state_home, _ = _configure_state_paths(monkeypatch, home)
+    state_home.mkdir(parents=True)
+    target = state_home / ResidencyState.STATE_FILE_NAME
+    outside = tmp_path / "outside-state-target.yaml"
+    outside.write_bytes(_consent_document())
+    target.symlink_to(outside)
+
+    with pytest.raises(ResidencyStateError, match="must not be a symlink"):
+        ResidencyState()
+
+    marker = state_home / ResidencyState.INIT_MARKER_NAME
+    assert not marker.exists()
+
+    target.unlink()
+    state = ResidencyState()
+    assert state.get_consent("fresh-after-rejection", "2.1_inbound_profile")["status"] == "not_asked"
+
+
 def test_hardlinked_lock_is_rejected_before_fchmod(monkeypatch, tmp_path):
     home = tmp_path / "hardlinked-lock-home"
     state_home, _ = _configure_state_paths(monkeypatch, home)
@@ -1161,7 +1215,23 @@ def test_explicit_state_path_never_reads_or_retires_legacy(monkeypatch, tmp_path
 
     assert state.list_all_consents() == {}
     assert explicit.is_file()
+    # Explicit paths (embedding/tests) get the same fresh-vs-vanished marker
+    # as the default location — the "was this ever initialized" ambiguity
+    # applies to a long-lived embedder using a fixed path too (issue #521B).
+    assert (explicit.parent / ResidencyState.INIT_MARKER_NAME).is_file()
     assert legacy.read_bytes() == corrupt
+
+
+def test_explicit_state_path_removed_after_marker_present_fails_closed(
+    monkeypatch, tmp_path
+):
+    explicit = tmp_path / "embedded-state" / "data-residency.yaml"
+    first = ResidencyState(str(explicit))
+    first.grant_consent("explicit-vanished-test", "2.1_inbound_profile")
+    explicit.unlink()
+
+    with pytest.raises(ResidencyStateError, match="already initialized"):
+        ResidencyState(str(explicit))
 
 
 def test_policy_denied_outcome_has_adapter_parity(fake_home, temp_skill):

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -621,7 +621,7 @@
     },
     {
       "path": ".claude/skills/residency-gate/lib/state.py",
-      "sha256": "e873f1e865a7075fe4d27261d7e315c297ac363ee0b3971670c57a706759df8c"
+      "sha256": "5b9b385bf7306d840f2a3dcd1c960140b31f4785d4c2d5d961afacb2136b016c"
     },
     {
       "path": ".claude/skills/residency-gate/pre-grant.yaml",


### PR DESCRIPTION
## Summary

- issue #521B: a missing `data-residency.yaml` (residency-gate consent/denial state) was indistinguishable from a fresh install — the code silently recreated it empty and every downstream check read that as "user was never asked", masking real data loss (disk corruption, accidental deletion) as a clean first run.
- Adds a private init-marker file (`.data-residency.initialized`) planted only after the state file has passed the class's existing symlink/hardlink/regular-file validation (`_ensure_private_file`) — a rejected construction attempt (e.g. a symlink attack) never plants a false marker, which was a Critical finding from a cold-context review of the first version of this fix.
- If the marker is present but the state file is gone, construction now fails closed with a typed `ResidencyStateError` instead of silently treating prior consent/denial decisions as never asked. Pre-patch installs self-heal the marker on first use without raising (no forced re-consent for existing users).

Produced in a peer session with Codex (`MC-sessions/2026-09/10/2026-09-10-03-issue-521b-state-home/`), continuing the issue #521 triage split from 2026-08-24 that assigned #521B (state-home/privacy) to this line of work.

## Test plan

- [x] `python3 -m pytest scripts/tests/test_residency_gate_skill_adapter.py -q` — 57 passed (was 55 before this change; 2 new tests + assertions added to 2 existing tests)
- [x] Two rounds of cold-context code review (general-purpose sub-agent, context isolation) — first round found the marker-before-validation ordering bug (Critical), fixed and re-reviewed clean
- [x] `/verify code` — PASS, one low-severity wording fix applied (error message no longer implies a backup exists when none is guaranteed)
- [x] Manual end-to-end check through the real hook chain (`residency-gate-skill-adapter.sh` → `residency-gate-run.sh` → `residency-gate.py` → `state.py`) confirming the fail-closed error surfaces to the caller as `BLOCKED: ResidencyGate [runtime_error]`, exit 2 — not just inside the Python unit tests