### PR TITLE
fix(mandatory-gate): find-python3.sh resolver never matched any real install path

### DIFF
--- a/.claude/hooks/protocol-artifact-validate.sh
+++ b/.claude/hooks/protocol-artifact-validate.sh
@@ -34,6 +34,24 @@ GOV_REPO="${IWE_GOVERNANCE_REPO:-${IWE_GOVERNANCE_REPO:-DS-strategy}}"
 WORKSPACE="${IWE_WORKSPACE:-${IWE_ROOT:-$HOME/IWE}}"
 GOV_PATH="$WORKSPACE/$GOV_REPO"
 
+# find-python3.sh resolver (issue #764): $WORKSPACE/scripts/lib/find-python3.sh
+# never existed on any install. The manifest delivers find-python3.sh as this
+# hook's own sibling (.claude/lib/find-python3.sh), so resolve relative to
+# this hook's own location first; $IWE_SCRIPTS is an explicit override.
+resolve_find_python3() {
+    local candidate
+    if [ -n "${IWE_SCRIPTS:-}" ] && [ -f "$IWE_SCRIPTS/lib/find-python3.sh" ]; then
+        printf '%s\n' "$IWE_SCRIPTS/lib/find-python3.sh"
+        return 0
+    fi
+    candidate="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd || true)/lib/find-python3.sh"
+    if [ -f "$candidate" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+    fi
+    return 1
+}
+
 # R4.5 fix (WP-273): trigger ТОЛЬКО по staged files, НЕ по тексту команды.
 # Старая логика грепала TOOL_INPUT на «DayPlan|day-close» — false positive
 # на любой коммит файла `day-close/SKILL.md` или сообщения с «day-close».
@@ -127,13 +145,34 @@ if [ -f "$DAY_RHYTHM_CONFIG" ]; then
   # other sites in this migration (peer-session 2026-08-19-29, codex turn 1).
   # No bare-python3 fallback: the resolver's own first candidate is already
   # bare `python3` from PATH.
-  _RESOLVED_PYTHON3=$("$WORKSPACE/scripts/lib/find-python3.sh" 2>/dev/null) || _RESOLVED_PYTHON3=""
-  if [ -n "$_RESOLVED_PYTHON3" ] && "$_RESOLVED_PYTHON3" -c "
-import yaml, sys
-d = yaml.safe_load(open(sys.argv[1])) or {}
+  _RESOLVER=$(resolve_find_python3) || _RESOLVER=""
+  _RESOLVED_PYTHON3=""
+  [ -n "$_RESOLVER" ] && _RESOLVED_PYTHON3=$("$_RESOLVER" 2>/dev/null) || true
+  if [ -z "$_RESOLVED_PYTHON3" ]; then
+    # issue #765: резолвер python3 не менее надёжен, чем сам YAML — та же
+    # fail-closed граница, что применяется ниже к битому/нечитаемому конфигу.
+    ERRORS+=("day-rhythm-config.yaml есть, но python3 не резолвится (find-python3.sh не найден или не вернул интерпретатор) — mandatory-проверка невозможна, fail-closed")
+  else
+    # Коды: 0 = mandatory сконфигурирован; 1 = валидный конфиг без mandatory;
+    # 2+ = битый/нечитаемый YAML — fail-closed (тот же контракт, что sibling
+    # validate-staged-artifacts.sh).
+    _MANDATORY_RC=0
+    "$_RESOLVED_PYTHON3" -c "
+import sys
+try:
+    import yaml
+    d = yaml.safe_load(open(sys.argv[1]))
+except Exception:
+    sys.exit(2)
+if not isinstance(d, dict):
+    sys.exit(2)
 sys.exit(0 if d.get('mandatory_daily_wps') else 1)
-" "$DAY_RHYTHM_CONFIG" 2>/dev/null; then
-    MANDATORY_WPS_CONFIGURED=true
+" "$DAY_RHYTHM_CONFIG" 2>/dev/null || _MANDATORY_RC=$?
+    case "$_MANDATORY_RC" in
+      0) MANDATORY_WPS_CONFIGURED=true ;;
+      1) : ;; # валидный конфиг без mandatory — проверка не требуется
+      *) ERRORS+=("day-rhythm-config.yaml существует, но не читается (нет PyYAML / битый или пустой YAML / корень не map / интерпретатор упал rc=$_MANDATORY_RC) — mandatory-проверка невозможна, fail-closed") ;;
+    esac
   fi
 fi
 if [ "$MANDATORY_WPS_CONFIGURED" = "true" ] && ! grep -qi "mandatory" "$DAYPLAN"; then

--- a/.claude/hooks/tests/test-protocol-artifact-validate-mandatory-fail-closed.sh
+++ b/.claude/hooks/tests/test-protocol-artifact-validate-mandatory-fail-closed.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# test-protocol-artifact-validate-mandatory-fail-closed.sh — issue #764/#765.
+#
+# protocol-artifact-validate.sh resolved find-python3.sh via
+# $WORKSPACE/scripts/lib/find-python3.sh — a path that never exists on any
+# install (scripts/lib/ lives inside the template or as .claude/lib/, never
+# copied to the workspace root). Resolver never found → python3 never runs →
+# MANDATORY_WPS_CONFIGURED stays false, same as "mandatory not configured" —
+# a broken environment was silently treated as a legitimate absence of the
+# mandatory check.
+#
+# The hook is copied into an isolated fixture directory so that the sibling
+# ../lib/find-python3.sh can genuinely be absent (in the real repo it always
+# exists, which would mask the bug). Checks the hook now blocks the commit
+# with a named reason, instead of silently approving it.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REAL_RESOLVER="$HOOK_DIR/../lib/find-python3.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); echo "PASS: $1"; }
+bad() { FAIL=$((FAIL+1)); echo "FAIL: $1"; }
+
+# --- Fixture: isolated workspace + governance-репо ---
+# day-rhythm-config.yaml lives at $WORKSPACE/memory/ (workspace root, a
+# symlink to auto-memory on a real install) — NOT inside the governance-repo.
+WS="$TMP/ws"
+mkdir -p "$WS/DS-strategy/current" "$WS/memory"
+git -C "$WS/DS-strategy" init -q
+git -C "$WS/DS-strategy" config user.email test@test
+git -C "$WS/DS-strategy" config user.name test
+
+valid_dayplan() { # <path>
+  cat > "$1" <<'EOF'
+# DayPlan 2026-09-10
+## План на сегодня
+| Время | РП |
+|-------|----|
+| 10:00 | WP-7 |
+## Календарь
+| Время | Событие |
+|-------|---------|
+| 09:00 | тест |
+## IWE за ночь
+нет находок
+## Разбор заметок
+нет заметок
+## Итоги вчера
+готово
+~1.0x мультипликатор
+~2ч РП / ~1ч физ
+EOF
+}
+
+printf 'mandatory_daily_wps: ["WP-7"]\n' > "$WS/memory/day-rhythm-config.yaml"
+valid_dayplan "$WS/DS-strategy/current/DayPlan 2026-09-10.md"
+git -C "$WS/DS-strategy" add "current/DayPlan 2026-09-10.md"
+
+printf '%s' '{"session_id":"t","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"cd \"'"$WS"'/DS-strategy\" && git add -A && git commit -m x"}}' \
+  > "$TMP/envelope.json"
+
+run_hook() { # <fixture-dir-with-hook-copy>
+  # IWE_SCRIPTS explicitly cleared: the ambient dev shell has it exported to
+  # the real template checkout (whose scripts/lib/find-python3.sh genuinely
+  # exists) — inheriting it here would mask exactly the "resolver absent"
+  # scenario this test exists to cover.
+  env -u IWE_SCRIPTS IWE_WORKSPACE="$WS" IWE_ROOT="$WS" IWE_GOVERNANCE_REPO="DS-strategy" \
+    bash "$1/protocol-artifact-validate.sh" < "$TMP/envelope.json"
+}
+
+# --- 1. Резолвер отсутствует целиком: копия хука без соседнего ../lib/ ---
+NO_RESOLVER_DIR="$TMP/no-resolver/.claude/hooks"
+mkdir -p "$NO_RESOLVER_DIR"
+cp "$HOOK_DIR/protocol-artifact-validate.sh" "$NO_RESOLVER_DIR/"
+
+OUT=$(run_hook "$NO_RESOLVER_DIR")
+if echo "$OUT" | grep -q '"decision": *"block"'; then
+  ok "резолвер отсутствует → хук блокирует коммит (fail-closed, не тихий пропуск)"
+else
+  bad "резолвер отсутствует → хук блокирует коммит (fail-closed, не тихий пропуск) (получено: $OUT)"
+fi
+echo "$OUT" | grep -qF 'python3 не резолвится' \
+  && ok "причина блокировки названа явно" \
+  || bad "причина блокировки названа явно (получено: $OUT)"
+
+# --- 2. Тот же конфиг, резолвер присутствует рядом (self-relative ../lib/) ---
+WITH_RESOLVER_DIR="$TMP/with-resolver/.claude/hooks"
+mkdir -p "$WITH_RESOLVER_DIR" "$TMP/with-resolver/.claude/lib"
+cp "$HOOK_DIR/protocol-artifact-validate.sh" "$WITH_RESOLVER_DIR/"
+cp "$REAL_RESOLVER" "$TMP/with-resolver/.claude/lib/find-python3.sh"
+
+OUT2=$(run_hook "$WITH_RESOLVER_DIR")
+if echo "$OUT2" | grep -q '"decision": *"block"' && echo "$OUT2" | grep -qi "mandatory"; then
+  ok "резолвер присутствует, mandatory сконфигурирован, DayPlan без упоминания mandatory → блок с содержательной причиной"
+else
+  bad "резолвер присутствует, mandatory сконфигурирован, DayPlan без упоминания mandatory → блок с содержательной причиной (получено: $OUT2)"
+fi
+
+git -C "$WS/DS-strategy" reset -q
+
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_issue_544_staged_precommit.sh
+++ b/scripts/tests/test_issue_544_staged_precommit.sh
@@ -154,8 +154,14 @@ git -C "$GOV" reset -q
 rm -f "$GOV/current/WeekPlan W99.md"
 
 # --- 7. Mandatory fail-closed: конфиг существует, но не читается ---
-mkdir -p "$WS/scripts/lib" "$WS/memory"
-cp "$ROOT/scripts/lib/find-python3.sh" "$WS/scripts/lib/"
+# find-python3.sh резолвится рядом со скриптом-потребителем (issue #764:
+# $WORKSPACE/scripts/lib/ никогда не существует ни на одной установке).
+# Кейс 7 упражняет резолвер через IWE_SCRIPTS (задан на строке 39, указывает
+# сюда же); кейсы 9-12 (после unset на строке 174+) упражняют тот же путь
+# через self-relative fallback — оба совпадают в этой фикстуре с одним и тем
+# же каталогом, поэтому обе ветки resolve_find_python3() покрыты.
+mkdir -p "$WS/FMT-exocortex-template/scripts/lib" "$WS/memory"
+cp "$ROOT/scripts/lib/find-python3.sh" "$WS/FMT-exocortex-template/scripts/lib/"
 printf 'mandatory_daily_wps: [сломано\n  без закрывающей скобки\n' > "$WS/memory/day-rhythm-config.yaml"
 valid_dayplan "$GOV/current/DayPlan 2026-08-31.md"
 if (cd "$GOV" && git add "current/DayPlan 2026-08-31.md" && git commit -qm "broken-config") >"$TMP/c7.err" 2>&1; then
@@ -217,17 +223,38 @@ printf 'mandatory_daily_wps: []
 FAKEPY="$WS/fake-python3"
 printf '#!/bin/sh\nexit 126\n' > "$FAKEPY"; chmod +x "$FAKEPY"
 # Подменяем резолвер: он должен вернуть путь к падающему интерпретатору.
-mv "$WS/scripts/lib/find-python3.sh" "$WS/scripts/lib/find-python3.sh.away"
-printf '#!/bin/sh\necho "%s"\n' "$FAKEPY" > "$WS/scripts/lib/find-python3.sh"; chmod +x "$WS/scripts/lib/find-python3.sh"
+mv "$WS/FMT-exocortex-template/scripts/lib/find-python3.sh" "$WS/FMT-exocortex-template/scripts/lib/find-python3.sh.away"
+printf '#!/bin/sh\necho "%s"\n' "$FAKEPY" > "$WS/FMT-exocortex-template/scripts/lib/find-python3.sh"; chmod +x "$WS/FMT-exocortex-template/scripts/lib/find-python3.sh"
 valid_dayplan "$GOV/current/DayPlan 2026-09-02.md"
 if (cd "$GOV" && git add "current/DayPlan 2026-09-02.md" && git commit -qm "weird-rc") >"$TMP/c11.err" 2>&1; then
     bad "нестандартный rc интерпретатора (126) блокирует коммит (fail-closed)"
 else
     ok "нестандартный rc интерпретатора (126) блокирует коммит (fail-closed)"
 fi
-mv "$WS/scripts/lib/find-python3.sh.away" "$WS/scripts/lib/find-python3.sh"
+mv "$WS/FMT-exocortex-template/scripts/lib/find-python3.sh.away" "$WS/FMT-exocortex-template/scripts/lib/find-python3.sh"
 git -C "$GOV" reset -q
 rm -f "$GOV/current/DayPlan 2026-09-02.md" "$WS/memory/day-rhythm-config.yaml" "$FAKEPY"
+
+# --- 12. Резолвер find-python3.sh отсутствует целиком — fail-closed, не WARN
+# (issue #764/#765: старый код искал резолвер по $WORKSPACE/scripts/lib/,
+# такого пути нет ни на одной установке — python3 никогда не резолвился, и
+# конфиг существующий, но не читаемый только из-за этого, тихо пропускался
+# как «mandatory не сконфигурирован»). ---
+mkdir -p "$WS/memory"
+printf 'mandatory_daily_wps: []\n' > "$WS/memory/day-rhythm-config.yaml"
+mv "$WS/FMT-exocortex-template/scripts/lib/find-python3.sh" "$WS/FMT-exocortex-template/scripts/lib/find-python3.sh.away"
+valid_dayplan "$GOV/current/DayPlan 2026-09-03.md"
+if (cd "$GOV" && git add "current/DayPlan 2026-09-03.md" && git commit -qm "no-resolver") >"$TMP/c12.err" 2>&1; then
+    bad "резолвер find-python3.sh отсутствует → блокирует коммит (fail-closed, не тихий пропуск)"
+else
+    ok "резолвер find-python3.sh отсутствует → блокирует коммит (fail-closed, не тихий пропуск)"
+fi
+grep -qF 'python3 не резолвится' "$TMP/c12.err" \
+    && ok "fail-closed без резолвера называет причину" \
+    || bad "fail-closed без резолвера называет причину"
+mv "$WS/FMT-exocortex-template/scripts/lib/find-python3.sh.away" "$WS/FMT-exocortex-template/scripts/lib/find-python3.sh"
+git -C "$GOV" reset -q
+rm -f "$GOV/current/DayPlan 2026-09-03.md" "$WS/memory/day-rhythm-config.yaml"
 
 if [ "$fail" -gt 0 ]; then
     echo "FAIL: $fail проверок упало"

--- a/scripts/validate-staged-artifacts.sh
+++ b/scripts/validate-staged-artifacts.sh
@@ -25,6 +25,24 @@ GOV_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
 ERRORS=()
 
+# find-python3.sh resolver (issue #764): $WORKSPACE/scripts/lib/find-python3.sh
+# never existed on any install — scripts/lib/ lives inside the template, not
+# in the workspace root. Resolve via $IWE_SCRIPTS first (setup.sh's own var),
+# then self-relative to this script's own governance-repo scripts/lib/.
+resolve_find_python3() {
+    local candidate
+    if [ -n "${IWE_SCRIPTS:-}" ] && [ -f "$IWE_SCRIPTS/lib/find-python3.sh" ]; then
+        printf '%s\n' "$IWE_SCRIPTS/lib/find-python3.sh"
+        return 0
+    fi
+    candidate="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || true)/lib/find-python3.sh"
+    if [ -f "$candidate" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+    fi
+    return 1
+}
+
 err() { ERRORS+=("$1"); }
 
 # staged_to_tmp <path> — staged blob во временный файл; печатает путь.
@@ -76,17 +94,19 @@ validate_dayplan() { # <staged-path> <tmpfile>
     fi
 
     # Mandatory check — только если сконфигурирован. Конфиг существует, но
-    # не читается (битый YAML) — fail-closed: обязательная граница не вправе
-    # молча пропустить проверку из-за инфраструктурной ошибки. Python без
-    # резолвера/интерпретатора — пропуск с WARN (оценить конфиг нечем).
+    # не читается (битый YAML) ИЛИ python3 не резолвится — оба одинаково
+    # fail-closed (issue #765): обязательная граница не вправе молча
+    # пропустить проверку из-за инфраструктурной ошибки, резолвер python3
+    # не более надёжен, чем сам YAML.
     local config="$WORKSPACE/memory/day-rhythm-config.yaml"
-    local py=""
-    if [ -f "$WORKSPACE/scripts/lib/find-python3.sh" ]; then
-        py=$("$WORKSPACE/scripts/lib/find-python3.sh" 2>/dev/null) || py=""
+    local py="" py_resolver=""
+    py_resolver=$(resolve_find_python3) || py_resolver=""
+    if [ -n "$py_resolver" ]; then
+        py=$("$py_resolver" 2>/dev/null) || py=""
     fi
     if [ -f "$config" ]; then
         if [ -z "$py" ]; then
-            echo "WARN: day-rhythm-config.yaml есть, но python3 не найден — mandatory-проверка DayPlan пропущена" >&2
+            err "DayPlan $rel: day-rhythm-config.yaml есть, но python3 не резолвится (find-python3.sh не найден или не вернул интерпретатор) — mandatory-проверка невозможна, fail-closed"
         else
             # Коды: 0 = mandatory сконфигурирован; 1 = валидный конфиг (map)
             # без mandatory; 2 = любая ошибка (нет PyYAML, битый YAML, корень

--- a/setup/test-update-edge-cases.sh
+++ b/setup/test-update-edge-cases.sh
@@ -663,18 +663,40 @@ T11_CHECKS_BLOCK=$(awk '
 /^# --- Ф3 Check 5:/{found=0}
 found' "$HOOK_FILE")
 
+# Check 4 calls resolve_find_python3() (issue #764/#765 fix), defined earlier
+# in the hook outside the Check-3..5 slice above — extract it too, by function
+# boundary, and source it first so the sliced block can call it.
+T11_RESOLVER_BLOCK=$(awk '
+/^resolve_find_python3\(\) \{$/{found=1}
+found{print}
+found && /^}$/{exit}
+' "$HOOK_FILE")
+
 if [ -z "$T11_CHECKS_BLOCK" ]; then
     fail "T11: could not extract Check 3/4 block from protocol-artifact-validate.sh — marker comments moved?"
+elif [ -z "$T11_RESOLVER_BLOCK" ]; then
+    fail "T11: could not extract resolve_find_python3() from protocol-artifact-validate.sh — function moved/renamed?"
 else
+    T11_RESOLVER_FILE="$TEST_WS/t11-resolver.sh"
+    printf '%s\n' "$T11_RESOLVER_BLOCK" > "$T11_RESOLVER_FILE"
+    source "$T11_RESOLVER_FILE"
+
     T11_CHECKS_FILE="$TEST_WS/t11-checks.sh"
     printf '%s\n' "$T11_CHECKS_BLOCK" > "$T11_CHECKS_FILE"
+
+    # resolve_find_python3() is sourced from a temp file above, so its own
+    # self-relative fallback (dirname of its *defining* file) points into
+    # $TEST_WS, not the real template — IWE_SCRIPTS is what makes it resolve
+    # to a real find-python3.sh in these fixtures (issue #764: the fixture
+    # used to place find-python3.sh at $WORKSPACE/scripts/lib/, the exact
+    # path the fixed resolver no longer looks at).
+    export IWE_SCRIPTS="$TEMPLATE_DIR/scripts"
 
     # Case A: default installation (mandatory_daily_wps commented out in the
     # template default), DayPlan uses the real pilot phrasing from issue #328.
     T11_DIR="$TEST_WS/t11-dayplan"
-    mkdir -p "$T11_DIR/memory" "$T11_DIR/current" "$T11_DIR/scripts/lib"
+    mkdir -p "$T11_DIR/memory" "$T11_DIR/current"
     cp "$TEMPLATE_DIR/memory/day-rhythm-config.yaml" "$T11_DIR/memory/day-rhythm-config.yaml"
-    cp "$TEMPLATE_DIR/scripts/lib/find-python3.sh" "$T11_DIR/scripts/lib/find-python3.sh"
     cat > "$T11_DIR/current/DayPlan.md" <<'HEREDOC'
 ## Бюджет
 ~1.25 ч РП всего / 0 ч физической работы. Мультипликатор не считаю.
@@ -695,8 +717,7 @@ HEREDOC
     # section — must still fail. Proves Case A isn't passing because the
     # checks were silently disabled, not because the config was honored.
     T11_DIR_B="$TEST_WS/t11-dayplan-b"
-    mkdir -p "$T11_DIR_B/memory" "$T11_DIR_B/current" "$T11_DIR_B/scripts/lib"
-    cp "$TEMPLATE_DIR/scripts/lib/find-python3.sh" "$T11_DIR_B/scripts/lib/find-python3.sh"
+    mkdir -p "$T11_DIR_B/memory" "$T11_DIR_B/current"
     cat > "$T11_DIR_B/memory/day-rhythm-config.yaml" <<'HEREDOC'
 mandatory_daily_wps:
   - wp: 7

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -109,7 +109,7 @@
     },
     {
       "path": ".claude/hooks/protocol-artifact-validate.sh",
-      "sha256": "64f250446dacc1967e722313f52a063bbb9feb02c79cf5f21d00b3b12fb67f15"
+      "sha256": "009b9363f3950ab97407ae3aa1b14e780fd1f8474ac9ea8529341d72a374439e"
     },
     {
       "path": ".claude/hooks/protocol-completion-reminder.sh",
@@ -186,6 +186,10 @@
     {
       "path": ".claude/hooks/tests/test-destructive-mcp-guard-malformed-json.sh",
       "sha256": "604c42d167de4ac40ea2d48b1f97c1dca000357b16000b7567477406876abe82"
+    },
+    {
+      "path": ".claude/hooks/tests/test-protocol-artifact-validate-mandatory-fail-closed.sh",
+      "sha256": "6298b52f77be40dca698050a95fee94cca66cf4a9e64f119acde03b18d76f765"
     },
     {
       "path": ".claude/hooks/tests/test-secret-leak-block-unparsed-input.sh",
@@ -2821,7 +2825,7 @@
     },
     {
       "path": "scripts/validate-staged-artifacts.sh",
-      "sha256": "be628b27788432af3497f918c5e7a2157d0f98914ae02a2e2a6d82c7f78204da"
+      "sha256": "949b65b9ccb048e22073db6efe720b733dda9897399594c205761a1b4a527df3"
     },
     {
       "path": "scripts/verify-context-budget.sh",


### PR DESCRIPTION
## Summary
- Both mandatory-DayPlan validators (`scripts/validate-staged-artifacts.sh` and `.claude/hooks/protocol-artifact-validate.sh`) resolved `find-python3.sh` via `$WORKSPACE/scripts/lib/find-python3.sh` — a path that never exists on any real install (the helper lives inside the template's own `scripts/lib/` or as `.claude/lib/find-python3.sh`). Resolver never found → python3 never ran → an infrastructure failure was silently treated as "mandatory not configured", the opposite of the fail-closed contract already applied to broken/unreadable YAML in the same code path.
- Fix: resolve via `$IWE_SCRIPTS` first, then self-relative to each script's own location; treat "resolver/interpreter unresolvable" as fail-closed, matching the existing broken-YAML behavior.
- Updated existing test fixtures that (accidentally) encoded the same wrong path convention, and added two new regression tests asserting the fail-closed behavior directly.

Fixes #764, #765

## Context
Продолжение триажа WP-7 (peer-session 2026-09-10-09-fmt-issues-triage, Kimi+Codex). Root cause confirmed independently by both peers before implementation; cold-context code review after the fix found no Critical/High findings (one Medium comment-clarity nit, addressed).

## Test plan
- [x] scripts/tests/test_issue_544_staged_precommit.sh — full suite green (18 assertions, 2 new)
- [x] .claude/hooks/tests/test-protocol-artifact-validate-mandatory-fail-closed.sh — new file, 3/3 assertions green
- [x] scripts/validate-fmt-scripts.sh — 0 violations
- [x] update-manifest.json regenerated (generate-manifest.sh) to cover the new test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)