### PR TITLE
fix(session-guard): YAML-escape task field in semaphore write (WP-539)

### DIFF
--- a/scripts/session-guard.sh
+++ b/scripts/session-guard.sh
@@ -59,6 +59,41 @@ now_date() { date +"%Y-%m-%d"; }
 now_month() { date +"%Y-%m"; }
 fail() { echo "session-guard: $1" >&2; exit "${2:-1}"; }
 
+# yaml_task_line <value> -- render a "task: <value>" YAML line, quoting the
+# value only when PyYAML's own writer decides it needs quoting. session-guard
+# used to write this field with a bare `echo "task: $TASK"`: a value
+# containing a literal ": " (a real one arrived 2026-09-09, "РП170: R15-триаж
+# ...") produced a line no strict YAML parser can read back as a mapping,
+# leaving the semaphore ambiguous to any such reader -- see
+# bug-2026-09-09-git-wrapper-blocked-by-corrupt-semaphore.md. Delegates to
+# PyYAML rather than reimplementing the plain-scalar grammar in bash, and
+# falls back to the old bare form if PyYAML is unavailable -- a missing
+# dependency degrades to previous behaviour instead of failing `open`. Not
+# reused for other semaphore fields (e.g. `housekeeping:`/`slug:`, see the
+# comment at their write site) -- those are matched elsewhere by exact
+# raw-string equality and doubling as filename components, so quoting them
+# would trade this bug for a different one, not just extend the same fix.
+# width=10**7 disables PyYAML's default 80-column wrapping (cold review of
+# this same fix, 2026-09-10): ordinary prose long enough to exceed 80
+# columns -- not an edge case -- was folded onto a continuation line that
+# every raw `grep '^task: ' | cut` reader then silently truncated away,
+# reintroducing the same corruption class by length instead of by ": ".
+# Embedded newlines fold the scalar the same way regardless of width, so
+# they are collapsed to spaces first -- this field is documented as
+# single-line, not free-form multi-line text.
+yaml_task_line() {
+  python3 -c '
+import sys
+value = " ".join(sys.argv[1].splitlines())
+try:
+    import yaml
+except ImportError:
+    print("task: %s" % value)
+    raise SystemExit(0)
+sys.stdout.write(yaml.safe_dump({"task": value}, allow_unicode=True, default_flow_style=False, width=10**7).rstrip("\n"))
+' "$1"
+}
+
 # resolve_orz_sessions_dir -- forward-port from ~/IWE/scripts/session-guard.sh
 # (WP-526 Ф2, 29.08; this FMT copy stays on the reduced/freeze-canonical
 # variant per WP-546, so only this one function is ported, not the file).
@@ -366,6 +401,20 @@ if [ "$CMD" = "open" ]; then
       echo "---"
       echo "agent: $AGENT"
       echo "personality: $PERSONALITY"
+      # NOT run through yaml_task_line, unlike `task:` in the main open path
+      # below: $HOUSEKEEPING is also interpolated straight into a filename
+      # (HK_FILE, above) and matched elsewhere by exact raw-string equality
+      # (select_semaphore, close, note-file, orphan audit all grep
+      # '^slug: ' | cut and compare to the CLI argument verbatim) -- it is a
+      # path-safe slug token by convention, not free-form prose like `task`.
+      # Quoting only this line would not even close the YAML-parseability
+      # gap it shares with `slug:` below (same raw value, same document)
+      # without also quoting `slug:` -- and quoting `slug:` breaks every
+      # exact-match consumer. A colon here already produces an unparseable
+      # document for a strict reader regardless; the real fix is
+      # validating/restricting `--housekeeping` to a path-safe token, a
+      # separate, larger decision than this bug's scope (bug-2026-09-09-
+      # git-wrapper-blocked-by-corrupt-semaphore.md, "Резолюция", 2026-09-10).
       echo "housekeeping: $HOUSEKEEPING"
       # bug-2026-07-10 (Day Close): select_semaphore() only matches on `wp:`/`slug:`
       # lines. Without this, 2+ open housekeeping semaphores are permanently
@@ -487,7 +536,7 @@ if [ "$CMD" = "open" ]; then
     echo "agent: $AGENT"
     echo "personality: $PERSONALITY"
     echo "wp: $WP"
-    echo "task: ${TASK:-}"
+    echo "$(yaml_task_line "${TASK:-}")"
     echo "slug: ${SLUG:-$WP}"
     echo "opened_at: $(now_iso)"
     echo "created_at: $(now_iso)"

--- a/scripts/test-session-guard-yaml-task-escaping.sh
+++ b/scripts/test-session-guard-yaml-task-escaping.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Regression test for yaml_task_line() (WP-539, 2026-09-10) — session-guard
+# used to write the semaphore's `task:` field with a bare `echo "task: $TASK"`.
+# A real task string containing a literal ": " (2026-09-09, "РП170: R15-триаж
+# ...") produced a line no strict YAML parser can read back as a mapping --
+# see bug-2026-09-09-git-wrapper-blocked-by-corrupt-semaphore.md. This suite
+# proves the fix quotes only when needed and the semaphore round-trips
+# through a real YAML parser either way.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SG="$SCRIPT_DIR/session-guard.sh"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+export IWE_ROOT="$TMPDIR"
+# Fresh TMPDIR, not the real canonical checkout -- the write-freeze (WP-520)
+# keys off the real path, so it does not apply here (same rationale as
+# test-session-guard-pid-liveness.sh).
+export IWE_FROZEN_CANONICAL_PATH=""
+
+fail() { echo "FAIL: $1"; exit 1; }
+pass() { echo "PASS: $1"; }
+
+parse_task_from_semaphore() {
+  # Mirrors the real failure mode this test guards against: a strict YAML
+  # parser reading the whole frontmatter block, not a line-grep.
+  local sem="$1"
+  SEM_PATH_ENV="$sem" python3 -c '
+import os, re, sys
+import yaml
+text = open(os.environ["SEM_PATH_ENV"], encoding="utf-8").read()
+m = re.match(r"^---\n(.*?)\n---", text, re.S)
+if not m:
+    print("NO_FRONTMATTER", end="")
+    raise SystemExit(0)
+doc = yaml.safe_load(m.group(1))
+sys.stdout.write(doc.get("task", ""))
+'
+}
+
+# 1. A task value with a literal ": " must round-trip through a strict YAML
+# parser as the exact original string -- the actual bug this fix closes.
+COLON_TASK='Разбор знаний РП170: R15-триаж непроанализированных captures (peer с Codex)'
+IWE_AGENT=claude-code "$SG" open --wp WP-999 --task "$COLON_TASK" --slug colon-task-test --agent claude-code >/dev/null
+SEM=$(ls "$TMPDIR/.iwe-runtime/sessions/"*.open)
+PARSED=$(parse_task_from_semaphore "$SEM")
+[ "$PARSED" = "$COLON_TASK" ] || fail "task with ': ' did not round-trip through a strict YAML parser (got: $PARSED)"
+pass "task containing ': ' round-trips through a strict YAML parser"
+"$SG" close --agent claude-code >/dev/null 2>&1 || true
+rm -f "$SEM"
+
+# 2. A plain task (the overwhelmingly common case) stays byte-identical to
+# the pre-fix bare format -- no quoting overhead, no behaviour change for
+# every semaphore that never had this bug in the first place.
+PLAIN_TASK="обычная задача без спецсимволов"
+IWE_AGENT=claude-code "$SG" open --wp WP-999 --task "$PLAIN_TASK" --slug plain-task-test --agent claude-code >/dev/null
+SEM2=$(ls "$TMPDIR/.iwe-runtime/sessions/"*.open)
+[ "$(grep '^task: ' "$SEM2")" = "task: $PLAIN_TASK" ] || fail "plain task value was quoted/altered unnecessarily"
+pass "plain task value stays bare (byte-identical to pre-fix format)"
+"$SG" close --agent claude-code >/dev/null 2>&1 || true
+rm -f "$SEM2"
+
+# 3. A task value with an embedded double quote and a '#' must also
+# round-trip -- other plain-scalar-breaking characters, not just ':'.
+QUOTE_HASH_TASK='fix "quoting" bug #42'
+IWE_AGENT=claude-code "$SG" open --wp WP-999 --task "$QUOTE_HASH_TASK" --slug quote-hash-task-test --agent claude-code >/dev/null
+SEM3=$(ls "$TMPDIR/.iwe-runtime/sessions/"*.open)
+PARSED3=$(parse_task_from_semaphore "$SEM3")
+[ "$PARSED3" = "$QUOTE_HASH_TASK" ] || fail "task with embedded quote/# did not round-trip (got: $PARSED3)"
+pass "task containing a double quote and '#' round-trips through a strict YAML parser"
+"$SG" close --agent claude-code >/dev/null 2>&1 || true
+rm -f "$SEM3"
+
+# 4. A long, ordinary (multi-word, no special chars) task past PyYAML's
+# default 80-column wrap must still land as ONE physical line in the
+# semaphore -- cold review 2026-09-10 caught the initial fix folding such
+# values onto a continuation line, which every raw `grep '^task: ' | cut`
+# reader (kimi-session-watchdog.sh, session-guard's own `close` path)
+# then silently truncated, reintroducing the original bug by length
+# instead of by ':'. yaml.safe_load still reconstructs the value
+# correctly even when folded, which is why this needs its own assertion
+# distinct from the round-trip checks above.
+LONG_TASK="это довольно длинное текстовое описание задачи, которое легко превышает восемьдесят символов суммарной длины строки"
+IWE_AGENT=claude-code "$SG" open --wp WP-999 --task "$LONG_TASK" --slug long-task-test --agent claude-code >/dev/null
+SEM4=$(ls "$TMPDIR/.iwe-runtime/sessions/"*.open)
+[ "$(grep -c '^task: ' "$SEM4")" = "1" ] || fail "long task value was folded onto more than one 'task:' line"
+[ "$(grep '^task: ' "$SEM4")" = "task: $LONG_TASK" ] || fail "long task value was altered or wrapped (should stay bare, single-line)"
+pass "long plain-text task (>80 columns) stays on a single line"
+"$SG" close --agent claude-code >/dev/null 2>&1 || true
+rm -f "$SEM4"
+
+# 5. A task value with an embedded literal newline must be collapsed to a
+# single line, not folded into a YAML block/quoted-with-newline style --
+# width alone (test 4) does not prevent this, PyYAML still has to represent
+# the newline somehow. Semaphore free-text fields are documented as
+# single-line; this fix normalizes rather than accepting multi-line input.
+NEWLINE_TASK=$'line one\nline two'
+IWE_AGENT=claude-code "$SG" open --wp WP-999 --task "$NEWLINE_TASK" --slug newline-task-test --agent claude-code >/dev/null
+SEM5=$(ls "$TMPDIR/.iwe-runtime/sessions/"*.open)
+[ "$(grep -c '^task: ' "$SEM5")" = "1" ] || fail "task value with an embedded newline was folded onto more than one 'task:' line"
+[ "$(parse_task_from_semaphore "$SEM5")" = "line one line two" ] || fail "embedded newline was not collapsed to a space"
+pass "task value with an embedded newline collapses to a single line"
+
+echo "All yaml_task_line escaping tests passed"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2529,7 +2529,7 @@
     },
     {
       "path": "scripts/session-guard.sh",
-      "sha256": "7afdce09da6a3f1ddbe855c0cac659404c8d35231ceedcc1276e3c24afd32019"
+      "sha256": "e239fe9c50a5586330460aad1ce4c12950f5608f51cd96b0fb44aafd275b59fd"
     },
     {
       "path": "scripts/settings-promote.sh",
@@ -2590,6 +2590,10 @@
     {
       "path": "scripts/test-route-task.sh",
       "sha256": "05c714c8dfe530f1954bcd87fa4b312c15e235c341f8ffd3e12b6aeca00afe9c"
+    },
+    {
+      "path": "scripts/test-session-guard-yaml-task-escaping.sh",
+      "sha256": "36706ca648d1782376db6923c1a37cc74fab2d103089255875bb67c560c0008a"
     },
     {
       "path": "scripts/test_archive_cadence_sweep.py",


### PR DESCRIPTION
## Summary
- session-guard wrote the semaphore's `task:` field with a bare `echo`, so a value containing a literal ": " produced YAML no strict parser could read back as a mapping (bug-2026-09-09-git-wrapper-blocked-by-corrupt-semaphore.md).
- Renders the line through PyYAML instead (`yaml_task_line()`), quoting only when needed — plain text stays byte-identical.
- Disables PyYAML's default 80-column wrap (`width=10**7`) and collapses embedded newlines, so raw `grep '^task: ' | cut` readers never see a folded/truncated value — found by an independent cold review of the first version of this fix.
- `open --housekeeping <reason>` writes a sibling field the same way; deliberately NOT changed (documented inline) — that value is also used as a filename component and matched elsewhere by exact raw-string equality, so the same quoting fix would break those lookups without even fully closing the YAML-parseability gap.

## Test plan
- [x] New `scripts/test-session-guard-yaml-task-escaping.sh`: 5 cases (colon, quote+hash, plain text stays bare, long text stays single-line, embedded newline collapses) — all pass.
- [x] Existing housekeeping open/close smoke-tested manually, unaffected.
- [x] `update-manifest.json` updated (new file entry + refreshed `session-guard.sh` hash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)