### PR TITLE
fix(peer-adapter-filter): .agentigore trailing-slash directory patterns never matched

### DIFF
--- a/generate-manifest.sh
+++ b/generate-manifest.sh
@@ -189,6 +189,9 @@ AGENT_FAULT_EXPLICIT_INCLUDE=(
 # real release would have shipped a template without its own test gate and
 # nobody would have noticed until a user hit the bug the gate exists to catch.
 SCRIPT_CONTRACT_EXPLICIT_INCLUDE=(
+    # Changes to this array require a `Delivery-Route: github-explicit-include`
+    # commit trailer (docs/critical-files-map.yaml) — enforced by
+    # scripts/check-delivery-route-label.sh in CI.
     # 2026-08-23 (v0.38.7 матрица, находка 4): check-python-resolver-contract.sh
     # доставляется, а его обязательный baseline сидел в excluded — на установке
     # строго из манифеста сторож падал rc=2. Ratchet-снимок — часть поставки.

--- a/generate-manifest.sh
+++ b/generate-manifest.sh
@@ -193,6 +193,7 @@ SCRIPT_CONTRACT_EXPLICIT_INCLUDE=(
     # доставляется, а его обязательный baseline сидел в excluded — на установке
     # строго из манифеста сторож падал rc=2. Ratchet-снимок — часть поставки.
     "scripts/tests/fixtures/python-resolver-baseline.txt"
+    "scripts/tests/test_issue_728_agentigore_dirslash.sh"
     "scripts/tests/test_issue_718_sync_canary.sh"
     "scripts/tests/test_issue_720_decision_log_sot.sh"
     "scripts/tests/test_create_wp_registry_coherence.sh"

--- a/scripts/peer-adapter-filter.py
+++ b/scripts/peer-adapter-filter.py
@@ -94,6 +94,16 @@ def main() -> int:
                 if rel_path == prefix or rel_path.startswith(prefix + os.sep):
                     return True
                 continue
+            # X/ (trailing slash, no other special markers) — gitignore-style
+            # directory name, matched anywhere in the path (issue #728: a
+            # plain fnmatch never matches "__pycache__/" against a file path,
+            # since no file path ends in "/" — this pattern class never
+            # matched anything before this branch existed).
+            if p.endswith("/"):
+                target = p[:-1]
+                if any(fnmatch.fnmatch(part, target) for part in parts[:-1]):
+                    return True
+                continue
             # Plain glob — match relative path or basename
             if fnmatch.fnmatch(rel_path, p):
                 return True

--- a/scripts/tests/test_issue_728_agentigore_dirslash.sh
+++ b/scripts/tests/test_issue_728_agentigore_dirslash.sh
@@ -12,6 +12,7 @@
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+PY3=$("$ROOT/scripts/lib/find-python3.sh")
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
@@ -31,7 +32,7 @@ printf '__pycache__/\n' > "$AGENTIGORE"
 
 RC=0
 SRC_DIR="$SRC" DST_DIR="$DST" AGENTIGORE_FILE="$AGENTIGORE" \
-  python3 "$ROOT/scripts/peer-adapter-filter.py" >"$TMP/out.log" 2>"$TMP/err.log" || RC=$?
+  "$PY3" "$ROOT/scripts/peer-adapter-filter.py" >"$TMP/out.log" 2>"$TMP/err.log" || RC=$?
 
 if [ "$RC" -eq 0 ]; then
   ok "фильтр отработал без ошибки"

--- a/scripts/tests/test_issue_728_agentigore_dirslash.sh
+++ b/scripts/tests/test_issue_728_agentigore_dirslash.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# test_issue_728_agentigore_dirslash.sh — regression for issue #728.
+#
+# .agentigore trailing-slash directory patterns (e.g. `__pycache__/`) never
+# matched anything: is_ignored() in peer-adapter-filter.py only fell through
+# to a plain fnmatch(rel_path, pattern) / fnmatch(basename, pattern), and no
+# real file's relative path or basename ever ends in "/". A build artifact
+# like `guide-kit/structurer/__pycache__/foo.pyc` was copied into the peer
+# projection uncut, even though `__pycache__/` was explicitly listed to
+# exclude it (found live in a peer-session, issue #296's own fix regressed
+# silently because it never worked to begin with).
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+ok()  { echo "PASS: $1"; }
+bad() { echo "FAIL: $1"; fail=$((fail + 1)); }
+
+SRC="$TMP/src"
+DST="$TMP/dst"
+mkdir -p "$SRC/guide-kit/structurer/__pycache__" "$SRC/keep"
+echo "binary-ish" > "$SRC/guide-kit/structurer/__pycache__/foo.pyc"
+echo "source" > "$SRC/guide-kit/structurer/foo.py"
+echo "keep me" > "$SRC/keep/file.txt"
+
+AGENTIGORE="$TMP/agentigore"
+printf '__pycache__/\n' > "$AGENTIGORE"
+
+RC=0
+SRC_DIR="$SRC" DST_DIR="$DST" AGENTIGORE_FILE="$AGENTIGORE" \
+  python3 "$ROOT/scripts/peer-adapter-filter.py" >"$TMP/out.log" 2>"$TMP/err.log" || RC=$?
+
+if [ "$RC" -eq 0 ]; then
+  ok "фильтр отработал без ошибки"
+else
+  bad "фильтр отработал без ошибки (rc=$RC, stderr: $(cat "$TMP/err.log"))"
+fi
+
+if [ ! -e "$DST/guide-kit/structurer/__pycache__/foo.pyc" ]; then
+  ok "__pycache__/ директория исключена из проекции (issue #728)"
+else
+  bad "__pycache__/ директория исключена из проекции (issue #728)"
+fi
+
+if [ -f "$DST/guide-kit/structurer/foo.py" ]; then
+  ok "соседний исходник не задет исключением"
+else
+  bad "соседний исходник не задет исключением"
+fi
+
+if [ -f "$DST/keep/file.txt" ]; then
+  ok "не связанный с паттерном файл скопирован как есть"
+else
+  bad "не связанный с паттерном файл скопирован как есть"
+fi
+
+if [ "$fail" -gt 0 ]; then
+    echo "FAIL: $fail проверок упало"
+    exit 1
+fi
+echo "PASS: .agentigore trailing-slash directory patterns exclude matching dirs (issue #728)"

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1141,7 +1141,7 @@
     },
     {
       "path": "generate-manifest.sh",
-      "sha256": "a943b65dd1ac5c2a1406f80f3ec4c7ca49588ba6c032be64053fe486860f48f9"
+      "sha256": "52e1b8b8ae51fc6cdc92d1e9af6a6626f2fd6b2c1f741613c5e56fcf01c1c6d2"
     },
     {
       "path": "guide-kit/.gitignore",
@@ -2477,7 +2477,7 @@
     },
     {
       "path": "scripts/peer-adapter-filter.py",
-      "sha256": "ebbfdae528c71bfb8d41f45bc7851bccc4cb06b57090ffd4ff14aa7eb507da2a"
+      "sha256": "e9019119b7242fcc165cc8e16dad281505639853db824abf2f48227817b0ae75"
     },
     {
       "path": "scripts/peer-session-finalize.sh",
@@ -2746,6 +2746,10 @@
     {
       "path": "scripts/tests/test_issue_720_decision_log_sot.sh",
       "sha256": "b38448f83b4ee3a7cefe3cf40eea41e56153f50134fd91f78c28bc2643318686"
+    },
+    {
+      "path": "scripts/tests/test_issue_728_agentigore_dirslash.sh",
+      "sha256": "8fd41c1964b7668c7cd07a93921314f4398876417c097c8dbc029275fb8f79a0"
     },
     {
       "path": "scripts/tests/test_issue_calendar_api_error_named.sh",

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1141,7 +1141,7 @@
     },
     {
       "path": "generate-manifest.sh",
-      "sha256": "52e1b8b8ae51fc6cdc92d1e9af6a6626f2fd6b2c1f741613c5e56fcf01c1c6d2"
+      "sha256": "21d30b236b7fa4bfd3ad931ace08219782037966a142bb61a3fd8a632f8778d6"
     },
     {
       "path": "guide-kit/.gitignore",
@@ -2749,7 +2749,7 @@
     },
     {
       "path": "scripts/tests/test_issue_728_agentigore_dirslash.sh",
-      "sha256": "8fd41c1964b7668c7cd07a93921314f4398876417c097c8dbc029275fb8f79a0"
+      "sha256": "3a109db4e82516d917bcb5835b45d4f589d01d9f40c15db69ac53b535b22b0ba"
     },
     {
       "path": "scripts/tests/test_issue_calendar_api_error_named.sh",


### PR DESCRIPTION
## Summary
- `.agentigore` supports gitignore-style trailing-slash directory patterns (e.g. `__pycache__/`), meant to exclude a directory anywhere in the projection copied for peer agents (peer-session DP.SC.154). `is_ignored()` had no branch for a bare trailing-slash pattern — it fell through to the plain-glob fallback, which can never match since no real file's path or basename ends in "/". The pattern class matched nothing, ever.
- Fix: a bare trailing-slash pattern is now matched as a directory name anywhere in the path, using the same technique the existing `**/X/**` branch already applies.

Fixes #728

## Context
Продолжение триажа WP-7 (peer-session `2026-09-10-09-fmt-issues-triage`, Kimi+Codex) — separate fix from #764/#765 (PR #769), unrelated root cause, kept on its own branch/PR.

## Test plan
- [x] Reproduced the leak against the pre-fix code directly (without touching git state) — confirmed `__pycache__/foo.pyc` leaked into the projection
- [x] New regression test `scripts/tests/test_issue_728_agentigore_dirslash.sh` — green against the fix
- [x] `scripts/validate-fmt-scripts.sh` — 0 violations
- [x] `update-manifest.json` regenerated + new test added to `SCRIPT_CONTRACT_EXPLICIT_INCLUDE` so it actually ships (otherwise `scripts/tests/` is excluded by default — same gap issue #707 describes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)