### PR TITLE
fix(update): host-global side effects on a foreign copy, catalog migration, silent hash failure

### DIFF
--- a/scripts/generate-executor-catalog.py
+++ b/scripts/generate-executor-catalog.py
@@ -194,9 +194,20 @@ def _read_existing_catalog(output_path: Path) -> dict:
 
     missing = [key for key in PRESERVED_TOP_LEVEL_KEYS if key not in existing]
     if missing:
+        # issue #767: the previous message named the missing section but gave
+        # no next step, so update.sh printed it and stopped without telling
+        # the operator what to actually do. This can legitimately happen on
+        # an install upgrading across the release that introduced "reflexes"
+        # (not necessarily corruption) -- name the concrete fix, matching the
+        # existing repair contract this file already ships (see
+        # --repair-add-reflexes below), which the existing test suite already
+        # asserts must still REJECT a bare missing key rather than silently
+        # backfill it (silent backfill would mask real data loss the same
+        # way as a genuinely truncated file).
         raise ValueError(
             f"existing catalog is missing runtime-owned sections {missing}: {output_path}; "
-            "refusing to overwrite it"
+            "refusing to overwrite it. Fix: "
+            f"python3 {sys.argv[0]} --repair-add-reflexes {output_path}"
         )
     for key in PRESERVED_TOP_LEVEL_KEYS:
         if not isinstance(existing[key], list):
@@ -270,7 +281,46 @@ def _parse_args() -> argparse.Namespace:
         default=workspace / governance_repo / "scripts" / "executor-catalog.yaml",
         help="Catalog output path",
     )
+    parser.add_argument(
+        "--repair-add-reflexes",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "One-shot migration for a catalog written before PRESERVED_TOP_LEVEL_KEYS "
+            "grew the 'reflexes' entry (issue #767): add an empty reflexes: [] to PATH "
+            "in place and exit, without touching any other section. Refuses (nonzero "
+            "exit) if PATH is not valid YAML, is not a mapping, or already has "
+            "'reflexes' -- this is a targeted repair for exactly the missing-key case, "
+            "not a general-purpose catalog fixer."
+        ),
+    )
     return parser.parse_args()
+
+
+def repair_add_reflexes(path: Path) -> None:
+    """Add an empty `reflexes: []` to an existing catalog missing only that key."""
+    try:
+        existing = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise ValueError(f"{path} is not readable/valid YAML: {exc}") from exc
+    if not isinstance(existing, dict):
+        raise ValueError(f"{path} is not a YAML mapping — refusing to guess a repair")
+    if "reflexes" in existing:
+        raise ValueError(f"{path} already has a 'reflexes' section — nothing to repair")
+    existing["reflexes"] = []
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        yaml.safe_dump(existing, temporary, allow_unicode=True, sort_keys=False)
+        temporary_path = Path(temporary.name)
+    temporary_path.chmod(0o644)
+    temporary_path.replace(path)
 
 
 def _without_generation_time(catalog: dict) -> dict:
@@ -320,6 +370,16 @@ def _write_catalog_if_changed(catalog: dict, output_path: Path) -> bool:
 
 def main():
     args = _parse_args()
+
+    if args.repair_add_reflexes is not None:
+        try:
+            repair_add_reflexes(args.repair_add_reflexes.expanduser())
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(f"OK: added empty reflexes: [] to {args.repair_add_reflexes}")
+        return
+
     skills_dir = args.skills_dir.expanduser()
     output_path = args.output.expanduser()
 

--- a/scripts/setup-extractor-feeders.sh
+++ b/scripts/setup-extractor-feeders.sh
@@ -18,10 +18,17 @@
 
 set -euo pipefail
 
-IWE_RUNTIME="${IWE_RUNTIME:-$HOME/IWE/.iwe-runtime}"
+# issue #768: this script hardcoded $HOME/IWE everywhere below, ignoring
+# IWE_WORKSPACE entirely -- update.sh's caller comment used to say "the
+# feeders script never reads it" as if that were a fact of nature, when it
+# was really just this script never having been written to read it. A
+# workspace copy running update.sh got its real launchd job silently
+# re-pointed at $HOME/IWE regardless of where it actually lived.
+IWE_WORKSPACE="${IWE_WORKSPACE:-$HOME/IWE}"
+IWE_RUNTIME="${IWE_RUNTIME:-$IWE_WORKSPACE/.iwe-runtime}"
 GOVERNANCE_REPO="${IWE_GOVERNANCE_REPO:-DS-strategy}"
 EXTRACTOR_SH="$IWE_RUNTIME/roles/extractor/scripts/extractor.sh"
-FLEETING="$HOME/IWE/$GOVERNANCE_REPO/inbox/fleeting-notes.md"
+FLEETING="$IWE_WORKSPACE/$GOVERNANCE_REPO/inbox/fleeting-notes.md"
 
 MODE="${1:-install}"
 
@@ -172,7 +179,7 @@ if [ "$PLATFORM" = "Darwin" ]; then
         <key>USER</key><string>${USER:-$(whoami)}</string>
         <key>LOGNAME</key><string>${USER:-$(whoami)}</string>
         <key>IWE_TEMPLATE</key><string>$IWE_TEMPLATE_DIR</string>
-        <key>IWE_WORKSPACE</key><string>$HOME/IWE</string>
+        <key>IWE_WORKSPACE</key><string>$IWE_WORKSPACE</string>
         <key>IWE_GOVERNANCE_REPO</key><string>$GOVERNANCE_REPO</string>
         <key>IWE_RUNTIME</key><string>$IWE_RUNTIME</string>
     </dict>

--- a/scripts/tests/test-update-extractor-feeders.sh
+++ b/scripts/tests/test-update-extractor-feeders.sh
@@ -25,6 +25,14 @@ eval "$(awk '
 ' "$ROOT/update.sh")"
 declare -F backfill_extractor_feeders >/dev/null
 
+# issue #768: backfill_extractor_feeders() now checks $HOST_GLOBAL_OWNER_CONFLICT
+# (set near the top of update.sh, outside the extracted function body) before
+# doing anything -- default to the no-conflict case here, same as every real
+# invocation on a machine that IS the recorded owner of its own host-global
+# resources. Case 6 below flips this on to check the opposite path.
+HOST_GLOBAL_OWNER_CONFLICT=false
+HOST_GLOBAL_OWNER_CONFLICT_REASON=""
+
 SCRIPT_DIR="$TMP/template"
 WORKSPACE_DIR="$TMP/workspace"
 EFFECTIVE_GOVERNANCE_REPO="DS-strategy"
@@ -130,4 +138,22 @@ if ! grep -Fq 'повторите вручную' <(printf '%s' "$OUT"); then
     exit 1
 fi
 
-echo 'PASS: update.sh backfills the Extractor feeders (install, opt-out, no-CLI, missing script, failure)'
+# 6. issue #768: a foreign/unowned host does not get its launchd schedule
+# touched at all, regardless of everything else being in place.
+write_feeders 0
+rm -f "$TMP/feeders-call"
+HOST_GLOBAL_OWNER_CONFLICT=true
+HOST_GLOBAL_OWNER_CONFLICT_REASON="~/.zshenv points to /some/other/workspace"
+OUT=$(backfill_extractor_feeders)
+HOST_GLOBAL_OWNER_CONFLICT=false
+HOST_GLOBAL_OWNER_CONFLICT_REASON=""
+if [ -e "$TMP/feeders-call" ]; then
+    echo 'host-global owner conflict did not stop the feeders script from running' >&2
+    exit 1
+fi
+if ! grep -Fq 'points to /some/other/workspace' <(printf '%s' "$OUT"); then
+    echo 'host-global owner conflict skip did not explain why' >&2
+    exit 1
+fi
+
+echo 'PASS: update.sh backfills the Extractor feeders (install, opt-out, no-CLI, missing script, failure, foreign workspace)'

--- a/scripts/tests/test_issue_463_setup_reuses_resolved_python3.sh
+++ b/scripts/tests/test_issue_463_setup_reuses_resolved_python3.sh
@@ -390,6 +390,37 @@ assert_invalid_catalog_rejected "nonmapping" $'- item\n'
 assert_invalid_catalog_rejected "missing-reflexes" $'schema_version: "1.0"\n'
 assert_invalid_catalog_rejected "nonlist-reflexes" $'reflexes: {}\n'
 
+# issue #767: a bare-missing-reflexes catalog is correctly rejected above, but
+# the error used to name the problem with no next step. --repair-add-reflexes
+# is the one-shot migration path it now points to -- verify it actually
+# converges the rejected case into an accepted one.
+REPAIR_TARGET="$TEST_ROOT/repair-missing-reflexes.yaml"
+printf 'schema_version: "1.0"\nsome_other_field: kept\n' > "$REPAIR_TARGET"
+REPAIR_OUT=$("$RESOLVED" "$ROOT/scripts/generate-executor-catalog.py" \
+    --repair-add-reflexes "$REPAIR_TARGET" 2>&1)
+REPAIR_STATUS=$?
+if [ "$REPAIR_STATUS" -eq 0 ] && grep -qF 'some_other_field: kept' "$REPAIR_TARGET" \
+    && grep -qF 'reflexes: []' "$REPAIR_TARGET"; then
+    pass "--repair-add-reflexes adds an empty reflexes section, keeps the rest"
+else
+    fail "--repair-add-reflexes did not converge (status=$REPAIR_STATUS): $REPAIR_OUT"
+fi
+REPAIR_RERUN_OUT=$(IWE_ROOT="$CUSTOM_WORKSPACE" IWE_GOVERNANCE_REPO=custom-governance \
+    "$RESOLVED" "$ROOT/scripts/generate-executor-catalog.py" \
+    --skills-dir "$CUSTOM_SKILLS" --output "$REPAIR_TARGET" 2>&1)
+if [ $? -eq 0 ]; then
+    pass "generator no longer rejects a catalog repaired by --repair-add-reflexes"
+else
+    fail "generator still rejects the repaired catalog: $REPAIR_RERUN_OUT"
+fi
+REPAIR_TWICE_OUT=$("$RESOLVED" "$ROOT/scripts/generate-executor-catalog.py" \
+    --repair-add-reflexes "$REPAIR_TARGET" 2>&1)
+if [ $? -ne 0 ]; then
+    pass "--repair-add-reflexes refuses a catalog that already has reflexes"
+else
+    fail "--repair-add-reflexes ran again on an already-repaired catalog: $REPAIR_TWICE_OUT"
+fi
+
 VALIDATE_OUTPUT="$TEST_ROOT/validate-input-only.yaml"
 printf 'reflexes: [\n' > "$VALIDATE_OUTPUT"
 cp "$VALIDATE_OUTPUT" "$VALIDATE_OUTPUT.before"

--- a/seed/strategy/scripts/generate-executor-catalog.py
+++ b/seed/strategy/scripts/generate-executor-catalog.py
@@ -194,9 +194,20 @@ def _read_existing_catalog(output_path: Path) -> dict:
 
     missing = [key for key in PRESERVED_TOP_LEVEL_KEYS if key not in existing]
     if missing:
+        # issue #767: the previous message named the missing section but gave
+        # no next step, so update.sh printed it and stopped without telling
+        # the operator what to actually do. This can legitimately happen on
+        # an install upgrading across the release that introduced "reflexes"
+        # (not necessarily corruption) -- name the concrete fix, matching the
+        # existing repair contract this file already ships (see
+        # --repair-add-reflexes below), which the existing test suite already
+        # asserts must still REJECT a bare missing key rather than silently
+        # backfill it (silent backfill would mask real data loss the same
+        # way as a genuinely truncated file).
         raise ValueError(
             f"existing catalog is missing runtime-owned sections {missing}: {output_path}; "
-            "refusing to overwrite it"
+            "refusing to overwrite it. Fix: "
+            f"python3 {sys.argv[0]} --repair-add-reflexes {output_path}"
         )
     for key in PRESERVED_TOP_LEVEL_KEYS:
         if not isinstance(existing[key], list):
@@ -270,7 +281,46 @@ def _parse_args() -> argparse.Namespace:
         default=workspace / governance_repo / "scripts" / "executor-catalog.yaml",
         help="Catalog output path",
     )
+    parser.add_argument(
+        "--repair-add-reflexes",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "One-shot migration for a catalog written before PRESERVED_TOP_LEVEL_KEYS "
+            "grew the 'reflexes' entry (issue #767): add an empty reflexes: [] to PATH "
+            "in place and exit, without touching any other section. Refuses (nonzero "
+            "exit) if PATH is not valid YAML, is not a mapping, or already has "
+            "'reflexes' -- this is a targeted repair for exactly the missing-key case, "
+            "not a general-purpose catalog fixer."
+        ),
+    )
     return parser.parse_args()
+
+
+def repair_add_reflexes(path: Path) -> None:
+    """Add an empty `reflexes: []` to an existing catalog missing only that key."""
+    try:
+        existing = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise ValueError(f"{path} is not readable/valid YAML: {exc}") from exc
+    if not isinstance(existing, dict):
+        raise ValueError(f"{path} is not a YAML mapping — refusing to guess a repair")
+    if "reflexes" in existing:
+        raise ValueError(f"{path} already has a 'reflexes' section — nothing to repair")
+    existing["reflexes"] = []
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        yaml.safe_dump(existing, temporary, allow_unicode=True, sort_keys=False)
+        temporary_path = Path(temporary.name)
+    temporary_path.chmod(0o644)
+    temporary_path.replace(path)
 
 
 def _without_generation_time(catalog: dict) -> dict:
@@ -320,6 +370,16 @@ def _write_catalog_if_changed(catalog: dict, output_path: Path) -> bool:
 
 def main():
     args = _parse_args()
+
+    if args.repair_add_reflexes is not None:
+        try:
+            repair_add_reflexes(args.repair_add_reflexes.expanduser())
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(f"OK: added empty reflexes: [] to {args.repair_add_reflexes}")
+        return
+
     skills_dir = args.skills_dir.expanduser()
     output_path = args.output.expanduser()
 

--- a/setup/install-iwe-paths.sh
+++ b/setup/install-iwe-paths.sh
@@ -11,7 +11,8 @@
 # при миграции ~/.iwe-paths не апгрейдился (Round 5 Евгения, 27 апр).
 #
 # Usage:
-#   bash install-iwe-paths.sh --workspace PATH --governance REPO_NAME [--dry-run] [--quiet]
+#   bash install-iwe-paths.sh --workspace PATH --governance REPO_NAME
+#       [--skip-zshenv] [--dry-run] [--quiet]
 #
 # Exit codes:
 #   0 — успех
@@ -23,12 +24,14 @@ WORKSPACE_DIR=""
 GOVERNANCE_REPO=""
 DRY_RUN=false
 QUIET=false
+SKIP_ZSHENV=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --workspace)  WORKSPACE_DIR="$2"; shift 2 ;;
         --governance) GOVERNANCE_REPO="$2"; shift 2 ;;
         --dry-run)    DRY_RUN=true; shift ;;
+        --skip-zshenv) SKIP_ZSHENV=true; shift ;;
         --quiet|-q)   QUIET=true; shift ;;
         --help|-h)
             grep '^#' "$0" | head -20
@@ -55,7 +58,11 @@ IWE_ENV_MARKER="# IWE environment (WP-219, DP.FM.009): lookup-слой для п
 
 if $DRY_RUN; then
     $QUIET || echo "  [DRY RUN] Would write $IWE_ENV_FILE (workspace=$WORKSPACE_DIR, governance=$GOVERNANCE_REPO)"
-    $QUIET || echo "  [DRY RUN] Would ensure $ZSHENV_FILE sources \$WORKSPACE_DIR/.iwe-paths"
+    if $SKIP_ZSHENV; then
+        $QUIET || echo "  [DRY RUN] Would leave $ZSHENV_FILE unchanged (--skip-zshenv)"
+    else
+        $QUIET || echo "  [DRY RUN] Would ensure $ZSHENV_FILE sources \$WORKSPACE_DIR/.iwe-paths"
+    fi
     exit 0
 fi
 
@@ -86,29 +93,37 @@ if [ -f "$LEGACY_IWE_PATHS" ] && [ ! -L "$LEGACY_IWE_PATHS" ] && [ "$LEGACY_IWE_
     $QUIET || echo "    Актуальный файл: $IWE_ENV_FILE. Проверьте $LEGACY_IWE_PATHS на предмет ручных правок и удалите его вручную."
 fi
 
-# Replace both the legacy $HOME/.iwe-paths one-liner and any older managed
-# block. Marker presence alone is not proof that it sources this workspace.
-if [ -f "$ZSHENV_FILE" ]; then
-    ZSHENV_TMP=$(mktemp)
-    awk '
-      /^# IWE environment \(WP-219, DP.FM.009\):/{skip=1; next}
-      skip && /^unset _IWE_ROOT$/{skip=0; next}
-      /\[ -f "\$HOME\/\.iwe-paths" \] && source "\$HOME\/\.iwe-paths"/{next}
-      !skip{print}
-    ' "$ZSHENV_FILE" > "$ZSHENV_TMP"
-    mv "$ZSHENV_TMP" "$ZSHENV_FILE"
-fi
-if ! grep -qF "_IWE_ROOT=\"$WORKSPACE_DIR\"" "$ZSHENV_FILE" 2>/dev/null; then
-    cat >> "$ZSHENV_FILE" <<ZSHENV_EOF
+# issue #768: a foreign/unowned $ZSHENV_FILE (already pointing at a
+# different, already-configured workspace, per the caller's ownership check)
+# must not be touched — that real, per-user shell rc file is not scoped to
+# $WORKSPACE_DIR the way $IWE_ENV_FILE above is.
+if $SKIP_ZSHENV; then
+    $QUIET || echo "  ○ $ZSHENV_FILE unchanged (--skip-zshenv)"
+else
+    # Replace both the legacy $HOME/.iwe-paths one-liner and any older managed
+    # block. Marker presence alone is not proof that it sources this workspace.
+    if [ -f "$ZSHENV_FILE" ]; then
+        ZSHENV_TMP=$(mktemp)
+        awk '
+          /^# IWE environment \(WP-219, DP.FM.009\):/{skip=1; next}
+          skip && /^unset _IWE_ROOT$/{skip=0; next}
+          /\[ -f "\$HOME\/\.iwe-paths" \] && source "\$HOME\/\.iwe-paths"/{next}
+          !skip{print}
+        ' "$ZSHENV_FILE" > "$ZSHENV_TMP"
+        mv "$ZSHENV_TMP" "$ZSHENV_FILE"
+    fi
+    if ! grep -qF "_IWE_ROOT=\"$WORKSPACE_DIR\"" "$ZSHENV_FILE" 2>/dev/null; then
+        cat >> "$ZSHENV_FILE" <<ZSHENV_EOF
 
 # IWE environment (WP-219, DP.FM.009): lookup-слой для путей к скриптам
 _IWE_ROOT="$WORKSPACE_DIR"
 [ -f "\$_IWE_ROOT/.iwe-paths" ] && source "\$_IWE_ROOT/.iwe-paths"
 unset _IWE_ROOT
 ZSHENV_EOF
-    $QUIET || echo "  ✓ $ZSHENV_FILE → sources \$WORKSPACE_DIR/.iwe-paths"
-else
-    $QUIET || echo "  ○ $ZSHENV_FILE already sources $WORKSPACE_DIR/.iwe-paths"
+        $QUIET || echo "  ✓ $ZSHENV_FILE → sources \$WORKSPACE_DIR/.iwe-paths"
+    else
+        $QUIET || echo "  ○ $ZSHENV_FILE already sources $WORKSPACE_DIR/.iwe-paths"
+    fi
 fi
 
 # Auto-enable pre-commit hooks for IWE repos that have .githooks/

--- a/setup/test-update-edge-cases.sh
+++ b/setup/test-update-edge-cases.sh
@@ -2802,6 +2802,60 @@ else
     fail "T38g: setup corrupted a special-character replacement or its merge base"
 fi
 
+# ============================================================================
+# T39: hash_file() fails loudly with neither shasum nor sha256sum (issue #755)
+# ============================================================================
+echo "--- T39: hash_file() on a system with no hasher at all (issue #755) ---"
+
+# Extracts the real preflight check + hash_file() from update.sh (same
+# awk-by-function-name technique as T24's rule helpers) -- not a re-typed
+# copy, so this breaks the moment the two diverge.
+T39_PREFLIGHT=$(awk '
+/^if ! command -v shasum/{copy=1}
+copy{print}
+copy && /^fi$/{exit}
+' "$TEMPLATE_DIR/update.sh")
+T39_HASH_FILE=$(awk '/^hash_file\(\)/{copy=1} copy{print} copy && /^}/{exit}' "$TEMPLATE_DIR/update.sh")
+
+if [ -z "$T39_PREFLIGHT" ] || [ -z "$T39_HASH_FILE" ]; then
+    fail "T39: could not extract the hasher preflight or hash_file() from update.sh — code moved?"
+else
+    T39_DIR="$TEST_WS/t39-no-hasher"
+    T39_BIN="$T39_DIR/bin"
+    mkdir -p "$T39_BIN"
+    # A PATH containing only what bash itself needs to run this snippet --
+    # no shasum, no sha256sum, no perl (real /bin already lacks GNU coreutils
+    # sha256sum on macOS; symlinking just the handful of builtins this test
+    # needs keeps the fixture from silently finding a real hasher elsewhere).
+    for tool in bash cut env command printf; do
+        p=$(command -v "$tool" 2>/dev/null) || continue
+        ln -sf "$p" "$T39_BIN/$(basename "$p")"
+    done
+    T39_TARGET="$T39_DIR/some-file.txt"
+    echo "content" > "$T39_TARGET"
+
+    T39_SNIPPET="$T39_DIR/snippet.sh"
+    {
+        echo 'EXIT_RUNTIME=3'
+        printf '%s\n' "$T39_PREFLIGHT"
+        printf '%s\n' "$T39_HASH_FILE"
+        echo 'hash_file "$1"'
+    } > "$T39_SNIPPET"
+
+    T39_STATUS=0
+    T39_OUT=$(env -i PATH="$T39_BIN" HOME="$HOME" bash "$T39_SNIPPET" "$T39_TARGET" 2>&1) || T39_STATUS=$?
+
+    if [ "$T39_STATUS" -eq 3 ] && [ -z "$T39_OUT" ]; then
+        # exit 3 with nothing on stdout is wrong in the OTHER direction: it
+        # would mean the preflight fired but printed nothing to explain why.
+        fail "T39: preflight exited EXIT_RUNTIME but printed no diagnostic"
+    elif [ "$T39_STATUS" -eq 3 ] && printf '%s' "$T39_OUT" | grep -qi "shasum\|sha256sum"; then
+        pass "T39: no hasher on PATH -> loud EXIT_RUNTIME(3) naming the missing tools, not a silent empty hash"
+    else
+        fail "T39: expected EXIT_RUNTIME(3) with a shasum/sha256sum diagnostic, got status=$T39_STATUS: $T39_OUT"
+    fi
+fi
+
 # ============================================================
 # Summary
 # ============================================================

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2257,7 +2257,7 @@
     },
     {
       "path": "scripts/generate-executor-catalog.py",
-      "sha256": "775b126e54d95531c9abc2f8ac97534ec92cdba312764356431bb149ed2c7145"
+      "sha256": "a4fd8e441601d9634be147a2e6f4bc120db74f0ecba13081a3be0f94afcf381d"
     },
     {
       "path": "scripts/generate-hot-files-list.sh",
@@ -2537,7 +2537,7 @@
     },
     {
       "path": "scripts/setup-extractor-feeders.sh",
-      "sha256": "170efdf27b5a7874a87bdaae0c7d70e2de5c6843d4663725a60f884b5059d109"
+      "sha256": "c32fcd060cb5741764fb8783c69604e1b6f51d16464e762e7d7c9eba97464cca"
     },
     {
       "path": "scripts/setup-vscode-auto-mode.sh",
@@ -2709,7 +2709,7 @@
     },
     {
       "path": "scripts/tests/test_issue_463_setup_reuses_resolved_python3.sh",
-      "sha256": "2f57fc6e6ace9c4bac9c13a7e1e2865b7c26f50f0bf8bc0778a276a266a7ee20"
+      "sha256": "06530443e8a91ad556babff38f43d83e62075cc9c8796a84f470389f40f87604"
     },
     {
       "path": "scripts/tests/test_issue_469_settings_merge_hook_identity.py",
@@ -2925,7 +2925,7 @@
     },
     {
       "path": "seed/strategy/scripts/generate-executor-catalog.py",
-      "sha256": "775b126e54d95531c9abc2f8ac97534ec92cdba312764356431bb149ed2c7145"
+      "sha256": "a4fd8e441601d9634be147a2e6f4bc120db74f0ecba13081a3be0f94afcf381d"
     },
     {
       "path": "seed/strategy/scripts/install-hooks.sh",
@@ -3001,7 +3001,7 @@
     },
     {
       "path": "setup/install-iwe-paths.sh",
-      "sha256": "672677e388baf0e6d4839fd857dbebb85b053fea7b5f660eaf1be472709532c9"
+      "sha256": "61525569e640828f028f25f419977fb9ba57b5c2d50ebbfa2838352a8f3d50ec"
     },
     {
       "path": "setup/optional/setup-cloud-scheduler.sh",
@@ -3033,7 +3033,7 @@
     },
     {
       "path": "update.sh",
-      "sha256": "1442776d1e24f854ae0595cfb0dbff4b150253f7c7b19d53d61f0823fff3f48e"
+      "sha256": "e993456531ba11b68f2f0fca0625e9ba20b45d095d96a77f8527cc83ba3890ec"
     }
   ],
   "excluded_paths": [

--- a/update.sh
+++ b/update.sh
@@ -148,10 +148,27 @@ else
     sed_inplace() { sed -i '' "$@"; }
 fi
 
+# issue #755: `A 2>/dev/null | cut ... || B` never ran B on a missing `shasum`
+# (Alpine/busybox and similar minimal images have neither `shasum` nor
+# `perl`) -- `cut`'s own exit code (0, even on empty stdin) is what `||`
+# checked, not shasum's. hash_file() silently returned "" for every file, both
+# sides of every comparison in this script came out equal ("" = ""), and the
+# whole run finished EXIT=0 having verified nothing (754 files reported as
+# "unchanged" on one real report, 100% false). Fail loudly here, once, up
+# front, instead of at each of the dozens of call sites below.
+if ! command -v shasum >/dev/null 2>&1 && ! command -v sha256sum >/dev/null 2>&1; then
+    echo "ОШИБКА: ни shasum, ни sha256sum не найдены — проверка целостности файлов невозможна." >&2
+    echo "  Установите coreutils (sha256sum) или perl (даёт shasum) и повторите." >&2
+    exit "$EXIT_RUNTIME"
+fi
+
 # === Cross-platform hash ===
 hash_file() {
-    shasum -a 256 "$1" 2>/dev/null | cut -d' ' -f1 || \
-    sha256sum "$1" 2>/dev/null | cut -d' ' -f1
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | cut -d' ' -f1
+    else
+        sha256sum "$1" | cut -d' ' -f1
+    fi
 }
 
 # === Cross-platform Python resolution (issue #402) ===
@@ -607,6 +624,102 @@ RULES_BACKUP_RUN=""
 RULES_SAFE_TO_UPDATE="|"
 UPDATE_INCOMPLETE_MARKER="$SCRIPT_DIR/.update-incomplete"
 UPDATE_TRANSACTION_STARTED=false
+
+# issue #768: a full update.sh run, launched from a disposable copy of the
+# workspace, silently retargeted the REAL ~/Library/LaunchAgents and
+# ~/.zshenv onto the copy — WORKSPACE_DIR correctly points at the copy, but
+# nothing checks whether host-global resources (a real per-user shell rc
+# file, real launchd jobs) already belong to a DIFFERENT, already-configured
+# workspace before rewriting them. Absence of evidence is not evidence of
+# being the primary install — this only detects a conflict with a workspace
+# already on record; a virgin machine still lets the first run claim
+# ownership (peer-session 2026-09-10-09-fmt-issues-triage, Kimi+Codex).
+HOST_GLOBAL_OWNER_CONFLICT=false
+HOST_GLOBAL_OWNER_CONFLICT_REASON=""
+
+canonical_workspace_path() {
+    if [ -d "$1" ]; then
+        (cd "$1" 2>/dev/null && pwd -P)
+    else
+        printf '%s\n' "${1%/}"
+    fi
+}
+
+mark_host_global_conflict() {
+    if [ -n "$HOST_GLOBAL_OWNER_CONFLICT_REASON" ]; then
+        HOST_GLOBAL_OWNER_CONFLICT_REASON="$HOST_GLOBAL_OWNER_CONFLICT_REASON; $1"
+    else
+        HOST_GLOBAL_OWNER_CONFLICT_REASON="$1"
+    fi
+    HOST_GLOBAL_OWNER_CONFLICT=true
+}
+
+detect_host_global_owner_conflict() {
+    local current_root existing_root plist plist_root zsh_roots
+    current_root="$(canonical_workspace_path "$WORKSPACE_DIR")"
+
+    if [ -f "$HOME/.zshenv" ]; then
+        zsh_roots=$(awk '
+          /^# IWE environment \(WP-219, DP.FM.009\):/ { managed=1; next }
+          managed && /^_IWE_ROOT="/ {
+              value=$0
+              sub(/^_IWE_ROOT="/, "", value)
+              sub(/"$/, "", value)
+              print value
+          }
+          managed && /^unset _IWE_ROOT$/ { managed=0 }
+        ' "$HOME/.zshenv")
+
+        while IFS= read -r existing_root; do
+            [ -n "$existing_root" ] || continue
+            if [ "$(canonical_workspace_path "$existing_root")" != "$current_root" ]; then
+                mark_host_global_conflict "~/.zshenv points to $existing_root"
+            fi
+        done <<EOF
+$zsh_roots
+EOF
+    fi
+
+    # Only IWE-owned launchd job names — an unrelated ~/Library/LaunchAgents
+    # entry with a similar prefix from another tool is not this contract.
+    for plist in \
+        "$HOME/Library/LaunchAgents"/com.exocortex.*.plist \
+        "$HOME/Library/LaunchAgents"/com.strategist.*.plist \
+        "$HOME/Library/LaunchAgents"/com.extractor.*.plist
+    do
+        [ -f "$plist" ] || continue
+
+        if [ -x /usr/libexec/PlistBuddy ]; then
+            plist_root=$(/usr/libexec/PlistBuddy \
+                -c 'Print :EnvironmentVariables:IWE_WORKSPACE' \
+                "$plist" 2>/dev/null || true)
+        elif command -v plutil >/dev/null 2>&1; then
+            plist_root=$(plutil -extract EnvironmentVariables.IWE_WORKSPACE raw -o - \
+                "$plist" 2>/dev/null || true)
+        else
+            plist_root=""
+        fi
+
+        if [ -z "$plist_root" ]; then
+            # Neither parser available, or the key isn't there — cannot prove
+            # this plist belongs to the current workspace. Fail closed: treat
+            # as a conflict rather than silently assume ownership.
+            mark_host_global_conflict "$(basename "$plist"): владелец не определён"
+        elif [ "$(canonical_workspace_path "$plist_root")" != "$current_root" ]; then
+            mark_host_global_conflict "$(basename "$plist") points to $plist_root"
+        fi
+    done
+}
+
+if [ "${IWE_ALLOW_FOREIGN_WORKSPACE:-0}" != "1" ]; then
+    detect_host_global_owner_conflict
+fi
+if $HOST_GLOBAL_OWNER_CONFLICT; then
+    echo "⚠ Host-global ресурсы IWE (~/.zshenv, launchd) принадлежат другому или неопределённому workspace:"
+    echo "  $HOST_GLOBAL_OWNER_CONFLICT_REASON"
+    echo "  ~/.zshenv и планировщики задач НЕ будут изменены этим прогоном."
+    echo "  Если это осознанный перенос основной установки: IWE_ALLOW_FOREIGN_WORKSPACE=1 bash update.sh"
+fi
 
 # WP-529 F6 (peer-session 2026-08-19-01, Evgenii post-update defect #5):
 # build-runtime is part of the update transaction. Its failure used to be
@@ -1560,9 +1673,16 @@ run_post_apply_backfills_or_die() {
         return 1
     fi
 
+    local install_paths_args=(
+        --workspace "$WORKSPACE_DIR"
+        --governance "$EFFECTIVE_GOVERNANCE_REPO"
+        --quiet
+    )
+    # issue #768: a foreign/unowned host-global state must not have its real
+    # ~/.zshenv rewritten to point at this WORKSPACE_DIR.
+    $HOST_GLOBAL_OWNER_CONFLICT && install_paths_args+=(--skip-zshenv)
     bash "$SCRIPT_DIR/setup/install-iwe-paths.sh" \
-        --workspace "$WORKSPACE_DIR" --governance "$EFFECTIVE_GOVERNANCE_REPO" \
-        --quiet 2>&1 | sed 's/^/  /'
+        "${install_paths_args[@]}" 2>&1 | sed 's/^/  /'
     local install_paths_status="${PIPESTATUS[0]}"
     if [ "$install_paths_status" -ne 0 ]; then
         echo "  ⚠ install-iwe-paths.sh завершился с ошибкой (exit $install_paths_status). Запустите вручную: bash $SCRIPT_DIR/setup/install-iwe-paths.sh --workspace $WORKSPACE_DIR --governance $EFFECTIVE_GOVERNANCE_REPO"
@@ -1640,6 +1760,13 @@ backfill_extractor_feeders() {
         echo "  ○ Экстрактор: пропущен (IWE_SKIP_EXTRACTOR_FEEDERS=1)."
         return 0
     fi
+    # issue #768: the feeders script schedules a real launchd job under the
+    # current user's real $HOME — a foreign/unowned host-global state must
+    # not have that job's workspace pointer rewritten onto this copy.
+    if $HOST_GLOBAL_OWNER_CONFLICT; then
+        echo "  ○ Экстрактор: host-global расписание не изменено — $HOST_GLOBAL_OWNER_CONFLICT_REASON"
+        return 0
+    fi
     if [ ! -f "$feeders" ]; then
         echo "  ○ Экстрактор: scripts/setup-extractor-feeders.sh не найден, backfill пропущен."
         return 0
@@ -1656,9 +1783,11 @@ backfill_extractor_feeders() {
     # --schedule-only, not install: an update may add the periodic job, but must
     # not redo the install-time decisions (the global git hook template, the
     # init.templateDir pointer, seeding fleeting-notes) on every single run.
-    # IWE_WORKSPACE is deliberately not passed: the feeders script never reads
-    # it, so passing it would only pretend the workspace is configurable here.
+    # IWE_WORKSPACE now passed (issue #768 fix) — the feeders script used to
+    # hardcode $HOME/IWE regardless, which is exactly what let it silently
+    # retarget a real host-global launchd job onto a disposable copy.
     if feeders_output=$(
+        IWE_WORKSPACE="$WORKSPACE_DIR" \
         IWE_GOVERNANCE_REPO="$governance_repo" \
         IWE_RUNTIME="$WORKSPACE_DIR/.iwe-runtime" \
         bash "$feeders" --schedule-only 2>&1); then
@@ -4067,6 +4196,13 @@ for f in "${NEW_FILES[@]}" "${UPDATED_FILES[@]}"; do
 done
 
 if $ROLES_CHANGED && command -v launchctl >/dev/null 2>&1; then
+    # issue #768: role installers register real launchd jobs under the
+    # current user's real $HOME — a foreign/unowned host-global state must
+    # not have those jobs reloaded pointing at this copy.
+    if $HOST_GLOBAL_OWNER_CONFLICT; then
+        echo ""
+        echo "  ○ Переустановка launchd-ролей пропущена: $HOST_GLOBAL_OWNER_CONFLICT_REASON"
+    else
     echo ""
     echo "Роли обновлены. Переустановка..."
     # WP-529 Ф94 (peer-session 2026-09-08-32): $HOME/.iwe-paths is a legacy
@@ -4089,6 +4225,7 @@ if $ROLES_CHANGED && command -v launchctl >/dev/null 2>&1; then
                 echo "  ○ $(basename "$role_dir"): переустановите вручную"
         fi
     done
+    fi
 fi
 
 # === Step 6d2: Regenerate hot-files.list (issue #294/#291) ===


### PR DESCRIPTION
## Summary
- **#768 (already broke a real user's machine):** a full `update.sh` run from a disposable workspace copy silently rewrote the REAL `~/Library/LaunchAgents` and `~/.zshenv` onto the copy's paths. Role reinstall, `install-iwe-paths.sh`, and `setup-extractor-feeders.sh` all perform real host-global side effects with no check for "does this host already belong to a different, already-configured install." Fix: detect a conflict against the recorded owner in `~/.zshenv` and installed launchd plists before touching either; on conflict, skip all three host-global writes with a clear message and an explicit `IWE_ALLOW_FOREIGN_WORKSPACE=1` escape hatch for a genuine machine migration. `setup-extractor-feeders.sh` also stopped hardcoding `$HOME/IWE` internally — it now honors `IWE_WORKSPACE`, which `update.sh` passes explicitly.
- **#767:** `generate-executor-catalog.py` refused an existing catalog missing the `reflexes` key with no actionable next step. Kept the rejection (an existing test requires it), but named the concrete fix in the error and added a narrow `--repair-add-reflexes` one-shot migration mode.
- **#755:** `hash_file()`'s `A 2>/dev/null | cut ... || B` never ran the `sha256sum` fallback when `shasum` was absent — on a system with neither, every hash silently came back empty, every comparison read as "unchanged", and a real report showed 754 files reported unchanged with exit 0 while nothing had actually updated. Now fails loudly up front.

## Context
Продолжение триажа WP-7 (peer-session `2026-09-10-09-fmt-issues-triage`, Kimi+Codex). #768's design went through a dedicated round-2 discussion — Codex verified the root cause independently and wrote the concrete diffs this PR implements; Kimi critiqued the first draft of the detector and found the gap that led to the combined `.zshenv` + launchd-plist check. Cold-context code review after implementation found no Critical/High findings (three documented Medium trade-offs, all pre-acknowledged design choices with an explicit escape hatch).

## Test plan
- [x] `setup/test-update-edge-cases.sh` — 160/160 (new T39 for #755)
- [x] `setup/test-update-issue-226.sh` — 37/37
- [x] executor-catalog contract suite — all green, 3 new assertions for `--repair-add-reflexes`
- [x] `scripts/validate-fmt-scripts.sh`, `scripts/check-seed-drift.sh`, `scripts/check-python-resolver-contract.sh`, `scripts/verify-manifest.sh`, `scripts/check-delivery-route-label.sh` — all green
- [x] `update-manifest.json` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)