### PR TITLE
docs(manifest-coverage): document why validate_manifest_coverage.sh is not wired into CI

### DIFF
--- a/scripts/tests/validate_manifest_coverage.sh
+++ b/scripts/tests/validate_manifest_coverage.sh
@@ -9,6 +9,19 @@
 # (found 03.08, running it for real: 6/6 false "not in manifest" errors on
 # files that were plainly present). Now parses the manifest as JSON and checks
 # the actual files[].path contract instead of grepping for a substring.
+#
+# issue #707: this script's contract ("every file under scripts/tests/ must
+# be in the manifest") disagrees with generate-manifest.sh's own SKIP_PATTERNS
+# (most of scripts/tests/ is deliberately excluded — author-only pytest/dev
+# fixtures, opted into delivery per-file via SCRIPT_CONTRACT_EXPLICIT_INCLUDE).
+# It is intentionally NOT wired into .github/workflows/validate-template.yml
+# for that reason -- it would fail on every routine commit that adds an
+# author-only test. scripts/check-manifest-coverage.py is the CI-enforced,
+# contract-respecting check (git-tracked files vs. manifest.files +
+# manifest.excluded_paths); this script is author-only ad-hoc tooling for
+# spot-checking "did I forget to explicit-include a test I meant to ship" --
+# run it by hand, do not add it to CI without first reconciling it with
+# SCRIPT_CONTRACT_EXPLICIT_INCLUDE (it will otherwise fail on every commit).
 
 set -euo pipefail
 

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2805,7 +2805,7 @@
     },
     {
       "path": "scripts/tests/validate_manifest_coverage.sh",
-      "sha256": "8ca218f39bc6357c0ba4399a7de89c5465b2368f8820ba8c0102d00c67ec6007"
+      "sha256": "c997b4e94b29aede85a5db7df1cfbff2b9638e606bb89dc318a45f0767fd4d3d"
     },
     {
       "path": "scripts/update-derived-snapshot.py",


### PR DESCRIPTION
## Summary
- Documents that `scripts/tests/validate_manifest_coverage.sh` enforces a stricter contract than the template's actual delivery policy (`generate-manifest.sh`'s `SKIP_PATTERNS`/`SCRIPT_CONTRACT_EXPLICIT_INCLUDE`), and is intentionally NOT wired into CI for that reason.
- `scripts/check-manifest-coverage.py` remains the CI-enforced, contract-respecting check (already wired in `.github/workflows/validate-template.yml`).
- No behavior change — comment-only, resolves the "two contracts silently disagree, nothing catches it" ambiguity from #707 by making the authority explicit.

Fixes #707

## Context
Продолжение триажа WP-7 (peer-session `2026-09-10-09-fmt-issues-triage`, Kimi+Codex). Left as documentation rather than a functional change since actually wiring `validate_manifest_coverage.sh` into CI would require reconciling it against `SCRIPT_CONTRACT_EXPLICIT_INCLUDE` first (a larger, separate change).

## Test plan
- [x] `bash -n` syntax check
- [x] `scripts/validate-fmt-scripts.sh` — 0 violations
- [x] `update-manifest.json` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)