### PR TITLE
fix(sync): parse WP relations without false matches

### DIFF
--- a/.claude/scripts/wp-sync-bundle.sh
+++ b/.claude/scripts/wp-sync-bundle.sh
@@ -144,17 +144,96 @@ extract_fm_field() {
     || true
 }
 
-# Extract WP numbers from related: block in frontmatter
+# Extract both an inline field value and its indented continuation from YAML
+# frontmatter. This is intentionally a narrow reader for reference sections,
+# not a general YAML parser: callers recognize WP-N references and legacy
+# numeric list scalars explicitly.
+extract_fm_section() {
+  local file="$1"
+  local field="$2"
+  awk -v field="$field" '
+    /^---$/ { fm_count++; if (fm_count == 2) exit; next }
+    fm_count != 1 { next }
+    $0 ~ ("^" field ":[[:space:]]*") {
+      value=$0
+      sub("^[^:]+:[[:space:]]*", "", value)
+      sub(/^[[:space:]]*#.*/, "", value)
+      sub(/[[:space:]]+#.*/, "", value)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      if (value != "") {
+        print value
+        exit
+      }
+      in_field=1
+      next
+    }
+    in_field && /^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*/ { exit }
+    in_field {
+      value=$0
+      sub(/^[[:space:]]*#.*/, "", value)
+      sub(/[[:space:]]+#.*/, "", value)
+      if (value != "") print value
+    }
+  ' "$file" 2>/dev/null || true
+}
+
+extract_wp_display_name() {
+  local file="$1"
+  local value
+  value=$(extract_fm_field "$file" "name")
+  [[ -n "$value" ]] || value=$(extract_fm_field "$file" "title")
+  echo "$value"
+}
+
+# Extract WP numbers from either an inline or block related field.
 extract_related_wps() {
   local file="$1"
-  awk '
-    /^---$/ { fm_count++; next }
-    fm_count != 1 { next }
-    /^related:/ { in_related=1; next }
-    in_related && /^[a-z_]+:/ && !/^  / { in_related=0; next }
-    in_related { print }
-  ' "$file" 2>/dev/null \
-    | grep -oE 'WP-[0-9]+' \
+  extract_fm_section "$file" "related" \
+    | awk '
+      function trim(value) {
+        sub(/^[[:space:]]+/, "", value)
+        sub(/[[:space:]]+$/, "", value)
+        gsub(/^"|"$/, "", value)
+        return value
+      }
+      function emit_bare(value) {
+        value=trim(value)
+        if (value ~ /^[0-9]+$/) print "WP-" value
+      }
+      function emit_flow(line, content, count, item, i) {
+        line=trim(line)
+        if (line ~ /^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*\[.*\]$/) {
+          sub(/^[^:]+:[[:space:]]*/, "", line)
+        } else if (line ~ /^-[[:space:]]*\[.*\]$/) {
+          sub(/^-[[:space:]]*/, "", line)
+        } else if (line !~ /^\[.*\]$/) {
+          return
+        }
+        content=line
+        sub(/^\[/, "", content)
+        sub(/\]$/, "", content)
+        count=split(content, item, ",")
+        for (i=1; i<=count; i++) emit_bare(item[i])
+      }
+      {
+        line=$0
+        while (match(line, /WP-[0-9]+/)) {
+          print substr(line, RSTART, RLENGTH)
+          line=substr(line, 1, RSTART - 1) "X" substr(line, RSTART + RLENGTH)
+        }
+        emit_flow($0)
+        scalar=trim($0)
+        if (scalar ~ /^[0-9]+$/) {
+          emit_bare(scalar)
+        } else if (scalar ~ /^-[[:space:]]*[0-9]+[[:space:]]*$/) {
+          sub(/^-[[:space:]]*/, "", scalar)
+          emit_bare(scalar)
+        } else if (scalar ~ /^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*[0-9]+[[:space:]]*$/) {
+          sub(/^[^:]+:[[:space:]]*/, "", scalar)
+          emit_bare(scalar)
+        }
+      }
+    ' \
     || true
 }
 
@@ -162,17 +241,61 @@ extract_related_wps() {
 get_rel_type() {
   local file="$1"
   local target_num="$2"
-  awk '
-    /^---$/ { fm++; next }
-    fm != 1 { next }
-    /^related:/ { in_r=1; next }
-    in_r && /^[a-z_]+:/ && !/^  / { in_r=0 }
-    in_r { print }
-  ' "$file" 2>/dev/null \
-    | grep "WP-${target_num}" \
+  local matching_line relation_type
+  matching_line=$(extract_fm_section "$file" "related" \
+    | awk -v target="$target_num" '
+        function trim(value) {
+          sub(/^[[:space:]]+/, "", value)
+          sub(/[[:space:]]+$/, "", value)
+          gsub(/^"|"$/, "", value)
+          return value
+        }
+        function has_bare(line, content, count, item, i, scalar) {
+          line=trim(line)
+          if (line ~ /^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*\[.*\]$/) {
+            sub(/^[^:]+:[[:space:]]*/, "", line)
+          } else if (line ~ /^-[[:space:]]*\[.*\]$/) {
+            sub(/^-[[:space:]]*/, "", line)
+          } else if (line ~ /^\[.*\]$/) {
+            # already a flow sequence
+          } else {
+            scalar=line
+            if (scalar ~ /^-[[:space:]]*[0-9]+[[:space:]]*$/) {
+              sub(/^-[[:space:]]*/, "", scalar)
+            } else if (scalar ~ /^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*[0-9]+[[:space:]]*$/) {
+              sub(/^[^:]+:[[:space:]]*/, "", scalar)
+            }
+            return trim(scalar) == target
+          }
+          content=line
+          sub(/^\[/, "", content)
+          sub(/\]$/, "", content)
+          count=split(content, item, ",")
+          for (i=1; i<=count; i++) {
+            if (trim(item[i]) == target) return 1
+          }
+          return 0
+        }
+        {
+          raw=$0
+          if (raw ~ ("WP-" target "([^0-9]|$)")) { print raw; exit }
+          if (has_bare(raw)) { print raw; exit }
+        }
+      ' \
+    || true)
+  if [[ -z "$matching_line" ]]; then
+    echo "body_ref"
+    return
+  fi
+  relation_type=$(printf '%s\n' "$matching_line" \
     | grep -oE '(depends_on|references|complementary|parent|child)' \
     | head -1 \
-    || echo "body_ref"
+    || true)
+  if [[ -n "$relation_type" ]]; then
+    echo "$relation_type"
+  else
+    echo "related"
+  fi
 }
 
 grep_body_wps() {
@@ -309,7 +432,11 @@ registry_status() {
 
 git_log_for_file() {
   local filepath="$1"
-  if [[ ! -d "$STRATEGY_DIR/.git" ]]; then
+  local git_root strategy_root
+  git_root=$(git -C "$STRATEGY_DIR" rev-parse --show-toplevel 2>/dev/null || true)
+  [[ -z "$git_root" ]] || git_root=$(cd "$git_root" 2>/dev/null && pwd -P || true)
+  strategy_root=$(cd "$STRATEGY_DIR" 2>/dev/null && pwd -P || true)
+  if [[ -z "$git_root" || -z "$strategy_root" || "$git_root" != "$strategy_root" ]]; then
     echo "_git недоступен_"
     return
   fi
@@ -504,7 +631,7 @@ main() {
 
   local status name spawned updated created last_session
   status=$(extract_fm_field "$wp_file" "status")
-  name=$(extract_fm_field "$wp_file" "name")
+  name=$(extract_wp_display_name "$wp_file")
   spawned=$(extract_fm_field "$wp_file" "spawned")
   updated=$(extract_fm_field "$wp_file" "updated")
   # F19 (REVIEW-ARCHITECTURE.md, WP-503 Ф6.6 план): карточки без `updated:` в
@@ -609,7 +736,7 @@ main() {
         local rpath rstatus rname
         rpath=$(wp_path_label "$rfile")
         rstatus=$(extract_fm_field "$rfile" "status")
-        rname=$(extract_fm_field "$rfile" "name")
+        rname=$(extract_wp_display_name "$rfile")
         [[ -z "$rstatus" ]] && rstatus="_не указан_"
         [[ -z "$rname" ]] && rname="_не указано_"
 
@@ -638,7 +765,7 @@ main() {
           local open_phase_with_ref
           open_phase_with_ref=$(
             awk '/^---$/{fm++; next} fm<2{next} /- \[ \]/{print}' "$wp_file" 2>/dev/null \
-            | grep "WP-${rnum}" || true
+            | grep -E "WP-${rnum}([^0-9]|$)" || true
           )
           if [[ -n "$open_phase_with_ref" ]]; then
             echo "DRIFT: WP-${rnum} закрыт (${reg_status}), но текущий РП имеет открытую фазу со ссылкой на него" >> "$drift_file"

--- a/setup/test-update-edge-cases.sh
+++ b/setup/test-update-edge-cases.sh
@@ -24,7 +24,7 @@
 #   T20: index-health skip suppresses size checks but keeps semantic checks (issue #357)
 #   T21: legacy owner:user protocols migrate once with backup; other user files stay protected (issue #354)
 #   T22: Quick Close requires a runner card only when the runner and graph exist (issue #356)
-#   T23: wp-sync-bundle prefers folder cards and reads structured open phase statuses
+#   T23: wp-sync-bundle handles canonical cards, phase statuses, relation shapes, titles, and linked worktrees
 #   T24-T27: update safety, bootstrap/path contracts, multiplier opt-out, #384/#387/#388
 #   T28: settings.json merge preview never touches inputs, honors merge rules (WP-7 F71)
 #   T29: author_mode skip classifier verdicts on synthetic template history (WP-7 F71)
@@ -1508,6 +1508,7 @@ echo "--- T23: wp-sync-bundle uses the canonical folder card and phase statuses 
 
 T23_ROOT="$TEST_WS/t23-root"
 T23_GOV="$T23_ROOT/governance"
+T23_BUNDLE="${WP_SYNC_BUNDLE_UNDER_TEST:-$TEMPLATE_DIR/.claude/scripts/wp-sync-bundle.sh}"
 mkdir -p "$T23_GOV/docs" "$T23_GOV/inbox/WP-777"
 printf '# registry\n' > "$T23_GOV/docs/WP-REGISTRY.md"
 
@@ -1536,7 +1537,7 @@ phases:
 HEREDOC
 
 T23_OUT=$(IWE_WORKSPACE="$T23_ROOT" IWE_GOVERNANCE_REPO=governance \
-    bash "$TEMPLATE_DIR/.claude/scripts/wp-sync-bundle.sh" WP-777 2>&1)
+    bash "$T23_BUNDLE" WP-777 2>&1)
 T23_RC=$?
 if [ "$T23_RC" -eq 0 ] && \
    [[ "$T23_OUT" == *'Файл: `inbox/WP-777/WP-777.md`'* ]] && \
@@ -1562,7 +1563,7 @@ status: in_progress
 HEREDOC
 
 T23_LEGACY_OUT=$(IWE_WORKSPACE="$T23_ROOT" IWE_GOVERNANCE_REPO=governance \
-    bash "$TEMPLATE_DIR/.claude/scripts/wp-sync-bundle.sh" WP-778 2>&1)
+    bash "$T23_BUNDLE" WP-778 2>&1)
 T23_LEGACY_RC=$?
 if [ "$T23_LEGACY_RC" -eq 0 ] && \
    [[ "$T23_LEGACY_OUT" == *'Открытых фаз: 2'* ]] && \
@@ -1582,12 +1583,219 @@ status: done
 HEREDOC
 
 T23_PREFIX_OUT=$(IWE_WORKSPACE="$T23_ROOT" IWE_GOVERNANCE_REPO=governance \
-    bash "$TEMPLATE_DIR/.claude/scripts/wp-sync-bundle.sh" WP-46 2>&1)
+    bash "$T23_BUNDLE" WP-46 2>&1)
 T23_PREFIX_RC=$?
 if [ "$T23_PREFIX_RC" -eq 1 ] && [[ "$T23_PREFIX_OUT" == *'WP-46: файл не найден'* ]]; then
     pass "T23: a shorter WP ID does not resolve a longer numeric prefix"
 else
     fail "T23: numeric-prefix archive lookup regressed (rc=$T23_PREFIX_RC): $T23_PREFIX_OUT"
+fi
+
+T23_GIT_SOURCE="$T23_ROOT/git-source"
+T23_LINKED_WORKSPACE="$T23_ROOT/linked-workspace"
+T23_LINKED_GOV="$T23_LINKED_WORKSPACE/governance"
+mkdir -p "$T23_GIT_SOURCE/docs" "$T23_GIT_SOURCE/inbox/WP-780" \
+    "$T23_GIT_SOURCE/inbox/WP-78" "$T23_GIT_SOURCE/inbox/WP-784" \
+    "$T23_GIT_SOURCE/inbox/WP-785" \
+    "$T23_GIT_SOURCE/inbox/WP-781" "$T23_GIT_SOURCE/inbox/WP-782" \
+    "$T23_GIT_SOURCE/inbox/WP-783" "$T23_LINKED_WORKSPACE"
+cat > "$T23_GIT_SOURCE/docs/WP-REGISTRY.md" <<'HEREDOC'
+| # | Название | Статус |
+|---|---|---|
+| 780 | Inline current | 🔄 in_progress |
+| 78 | Closed prefix | ✅ done |
+| 781 | Legacy related | ⏳ pending |
+| 782 | Titled related | ⏳ pending |
+| 783 | Block related | ⏳ pending |
+| 784 | Boundary current | 🔄 in_progress |
+| 785 | Inline blocker | 🔄 in_progress |
+HEREDOC
+cat > "$T23_GIT_SOURCE/inbox/WP-78/WP-78.md" <<'HEREDOC'
+---
+wp: 78
+title: Closed prefix relation
+status: done
+spawned: 2026-09-10
+phases: []
+---
+HEREDOC
+cat > "$T23_GIT_SOURCE/inbox/WP-780/WP-780.md" <<'HEREDOC'
+---
+wp: 780
+title: Inline current title
+status: in_progress
+spawned: 2026-09-10
+# Inline YAML accepts both canonical WP-N and the numeric legacy form used by
+# existing cards. A following top-level comment is not part of this value.
+related: [WP-781, 782, WP-781, WP-780] # WP-799 is not related.
+# WP-799 belongs to this comment, not to related.
+phases: []
+---
+
+No related references in the body.
+HEREDOC
+cat > "$T23_GIT_SOURCE/inbox/WP-781/WP-781.md" <<'HEREDOC'
+---
+wp: 781
+name: Legacy related name
+title: Ignored title because name has priority
+status: pending
+spawned: 2026-09-10
+phases: []
+---
+HEREDOC
+cat > "$T23_GIT_SOURCE/inbox/WP-782/WP-782.md" <<'HEREDOC'
+---
+wp: 782
+title: Titled related name
+status: pending
+spawned: 2026-09-10
+phases: []
+---
+HEREDOC
+cat > "$T23_GIT_SOURCE/inbox/WP-783/WP-783.md" <<'HEREDOC'
+---
+wp: 783
+title: Block related name
+status: in_progress
+spawned: 2026-09-10
+related: # WP-799 is not related; the indented mapping below is the value.
+  # WP-798 is not related either.
+  depends_on: [WP-781 (uses 5 views)]
+  references: [782]
+phases: []
+---
+
+See WP-5 in the body only.
+HEREDOC
+cat > "$T23_GIT_SOURCE/inbox/WP-784/WP-784.md" <<'HEREDOC'
+---
+wp: 784
+title: Exact relation boundary
+status: in_progress
+spawned: 2026-09-10
+related: [WP-78]
+---
+
+- [ ] Continue WP-780 only.
+HEREDOC
+cat > "$T23_GIT_SOURCE/inbox/WP-785/WP-785.md" <<'HEREDOC'
+---
+wp: 785
+title: Inline blocker current
+status: in_progress
+spawned: 2026-09-10
+blockers: [WP-781]
+phases: []
+---
+
+No related references in the body.
+HEREDOC
+git -C "$T23_GIT_SOURCE" init -q -b main
+git -C "$T23_GIT_SOURCE" config user.email "test@test"
+git -C "$T23_GIT_SOURCE" config user.name "test"
+git -C "$T23_GIT_SOURCE" add docs/WP-REGISTRY.md \
+    inbox/WP-78/WP-78.md inbox/WP-784/WP-784.md inbox/WP-785/WP-785.md \
+    inbox/WP-780/WP-780.md inbox/WP-781/WP-781.md \
+    inbox/WP-782/WP-782.md inbox/WP-783/WP-783.md
+git -C "$T23_GIT_SOURCE" commit -qm "fixture baseline commit"
+git -C "$T23_GIT_SOURCE" worktree add -q -b t23-linked "$T23_LINKED_GOV" main
+
+T23_INLINE_OUT=$(IWE_WORKSPACE="$T23_LINKED_WORKSPACE" IWE_GOVERNANCE_REPO=governance \
+    WP_SYNC_GIT_DAYS=3650 bash "$T23_BUNDLE" WP-780 2>&1)
+T23_INLINE_RC=$?
+T23_INLINE_781=$(printf '%s\n' "$T23_INLINE_OUT" | grep -c '^### WP-781 (related)$' || true)
+T23_INLINE_782=$(printf '%s\n' "$T23_INLINE_OUT" | grep -c '^### WP-782 (related)$' || true)
+T23_INLINE_799=$(printf '%s\n' "$T23_INLINE_OUT" | grep -c '^### WP-799 ' || true)
+if [ "$T23_INLINE_RC" -eq 0 ] && [ -f "$T23_LINKED_GOV/.git" ] && \
+   [ ! -d "$T23_LINKED_GOV/.git" ] && \
+   [ "$T23_INLINE_781" -eq 1 ] && [ "$T23_INLINE_782" -eq 1 ] && \
+   [ "$T23_INLINE_799" -eq 0 ] && \
+   [[ "$T23_INLINE_OUT" == *'- Название: Inline current title'* ]] && \
+   [[ "$T23_INLINE_OUT" == *'- Название: Legacy related name'* ]] && \
+   [[ "$T23_INLINE_OUT" == *'- Название: Titled related name'* ]] && \
+   [[ "$T23_INLINE_OUT" == *'fixture baseline commit'* ]] && \
+   [[ "$T23_INLINE_OUT" != *'_git недоступен_'* ]]; then
+    pass "T23: inline related, title fallback, dedup/self-filter, and linked-worktree history work together"
+else
+    fail "T23: inline related/title/linked-worktree contract regressed (rc=$T23_INLINE_RC): $T23_INLINE_OUT"
+fi
+
+T23_BLOCK_OUT=$(IWE_WORKSPACE="$T23_LINKED_WORKSPACE" IWE_GOVERNANCE_REPO=governance \
+    WP_SYNC_GIT_DAYS=3650 bash "$T23_BUNDLE" WP-783 2>&1)
+T23_BLOCK_RC=$?
+if [ "$T23_BLOCK_RC" -eq 0 ] && \
+   [[ "$T23_BLOCK_OUT" == *'### WP-781 (depends_on)'* ]] && \
+   [[ "$T23_BLOCK_OUT" == *'### WP-782 (references)'* ]] && \
+   [[ "$T23_BLOCK_OUT" == *'### WP-5 (body_ref)'* ]] && \
+   [[ "$T23_BLOCK_OUT" != *'### WP-798 '* ]] && \
+   [[ "$T23_BLOCK_OUT" != *'### WP-799 '* ]]; then
+    pass "T23: block related keeps typed relations"
+else
+    fail "T23: block related relation types regressed (rc=$T23_BLOCK_RC): $T23_BLOCK_OUT"
+fi
+
+T23_BOUNDARY_OUT=$(IWE_WORKSPACE="$T23_LINKED_WORKSPACE" IWE_GOVERNANCE_REPO=governance \
+    bash "$T23_BUNDLE" WP-784 2>&1)
+T23_BOUNDARY_RC=$?
+if [ "$T23_BOUNDARY_RC" -eq 0 ] && \
+   [[ "$T23_BOUNDARY_OUT" == *'### WP-78 (related)'* ]] && \
+   [[ "$T23_BOUNDARY_OUT" == *'- Кол-во: 0'* ]]; then
+    pass "T23: a WP-780 phase reference does not create drift for closed WP-78"
+else
+    fail "T23: relation ID boundary regressed (rc=$T23_BOUNDARY_RC): $T23_BOUNDARY_OUT"
+fi
+
+if grep -q '^extract_blocker_wps()' "$T23_BUNDLE"; then
+    T23_BLOCKER_OUT=$(IWE_WORKSPACE="$T23_LINKED_WORKSPACE" IWE_GOVERNANCE_REPO=governance \
+        bash "$T23_BUNDLE" WP-785 2>&1)
+    T23_BLOCKER_RC=$?
+    if [ "$T23_BLOCKER_RC" -eq 0 ] && \
+       [[ "$T23_BLOCKER_OUT" == *'### WP-781 (body_ref)'* ]]; then
+        pass "T23: runtime variant reads inline blockers"
+    else
+        fail "T23: inline blocker extraction regressed (rc=$T23_BLOCKER_RC): $T23_BLOCKER_OUT"
+    fi
+fi
+git -C "$T23_GIT_SOURCE" worktree remove "$T23_LINKED_GOV" --force >/dev/null 2>&1
+
+T23_NESTED_WORKSPACE="$T23_GIT_SOURCE/nested-workspace"
+T23_NESTED_GOV="$T23_NESTED_WORKSPACE/governance"
+mkdir -p "$T23_NESTED_GOV/docs" "$T23_NESTED_GOV/inbox/WP-790" \
+    "$T23_NESTED_GOV/inbox/WP-791"
+cat > "$T23_NESTED_GOV/docs/WP-REGISTRY.md" <<'HEREDOC'
+| # | Название | Статус |
+|---|---|---|
+| 790 | Nested current | 🔄 in_progress |
+| 791 | Nested related | ⏳ pending |
+HEREDOC
+cat > "$T23_NESTED_GOV/inbox/WP-790/WP-790.md" <<'HEREDOC'
+---
+wp: 790
+title: Nested current
+status: in_progress
+spawned: 2026-09-10
+related: [WP-791]
+phases: []
+---
+HEREDOC
+cat > "$T23_NESTED_GOV/inbox/WP-791/WP-791.md" <<'HEREDOC'
+---
+wp: 791
+title: Nested related
+status: pending
+spawned: 2026-09-10
+phases: []
+---
+HEREDOC
+T23_NESTED_OUT=$(IWE_WORKSPACE="$T23_NESTED_WORKSPACE" IWE_GOVERNANCE_REPO=governance \
+    bash "$T23_BUNDLE" WP-790 2>&1)
+T23_NESTED_RC=$?
+if [ "$T23_NESTED_RC" -eq 0 ] && \
+   [[ "$T23_NESTED_OUT" == *'_git недоступен_'* ]]; then
+    pass "T23: a plain directory nested in another repository is not treated as its Git root"
+else
+    fail "T23: nested non-root Git directory was accepted (rc=$T23_NESTED_RC): $T23_NESTED_OUT"
 fi
 
 # ============================================================

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -329,7 +329,7 @@
     },
     {
       "path": ".claude/scripts/wp-sync-bundle.sh",
-      "sha256": "ee8786d5d76ab64486e17e23e955783cbbfbd9122d1668d7445b1d8945a5a220"
+      "sha256": "ef9cbb17c9f994899c2bd569cae8001dfa991761398e42f172edac2a1b4ac5a1"
     },
     {
       "path": ".claude/settings.json",


### PR DESCRIPTION
Расширяет сборщик связей РП: inline/block related, canonical и legacy numeric forms, точная граница WP-ID, игнорирование комментариев, fallback name→title, typed relations, dedup/self-filter и linked-worktree root. Добавляет регрессионные проверки и обновляет manifest hash. Проверки: template 164/0, runtime/server variants 165/0, manifest verify, bash syntax и shellcheck error-level — успешно. Reviewed in the open WP-286 peer session; Analyzed-by: Kimi.