### PR TITLE
feat(scripts): deliver canon writer-barrier tools (WP-530 Ф5.2)

### DIFF
--- a/scripts/canon-dirty-proposals.sh
+++ b/scripts/canon-dirty-proposals.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# canon-dirty-proposals.sh <repo-path> <snapshot-dir> <new-head-oid> -- turn a
+# canon-dirty-snapshot.sh snapshot into per-path proposals against the new HEAD
+# (WP-530 Ф38 / Ф3 step 5, Kimi: the pilot must see both sides -- what origin
+# added and what the snapshot carries -- before anything is committed).
+#
+# For every snapshotted path:
+#   tracked in old and new HEAD  -> three-way merge (base = old HEAD blob,
+#                                   ours = snapshot, theirs = new HEAD blob) via
+#                                   `git merge-file -p`; conflict markers stay in
+#                                   the proposal and are counted in INDEX.md
+#   identical to new HEAD        -> listed as "already on origin", no proposal
+#   untracked / new in snapshot  -> proposal = the snapshot file as-is
+# Nothing is written into the repo; proposals live under <snapshot-dir>/proposals.
+set -uo pipefail
+REPO="$1"; SNAP="$2"; NEW_HEAD="$3"
+OLD_HEAD=$(cat "$SNAP/old_head.txt")
+PROPOSALS="$SNAP/proposals"; mkdir -p "$PROPOSALS"
+INDEX="$SNAP/INDEX.md"
+{
+  echo "# Предложения по возврату незакоммиченного содержимого"
+  echo
+  echo "old_head: $OLD_HEAD · new_head: $NEW_HEAD · снимок: $SNAP"
+  echo
+  echo "| путь | вид | уникальных строк снимка vs new HEAD | конфликтных блоков | предложение |"
+  echo "|---|---|---|---|---|"
+} > "$INDEX"
+n_same=0; n_merge=0; n_new=0; n_conf=0
+while read -r h p; do
+  [ "$h" = "DELETED" ] && continue
+  [ -n "$p" ] || continue
+  snap="$SNAP/files/$p"
+  [ -e "$snap" ] || [ -L "$snap" ] || continue
+  if [ -L "$snap" ]; then
+    mkdir -p "$PROPOSALS/$(dirname "$p")"; cp -a "$snap" "$PROPOSALS/$p"; n_new=$((n_new+1))
+    printf '| %s | симлинк -> %s | - | 0 | proposals/%s |\n' "$p" "$(readlink "$snap")" "$p" >> "$INDEX"; continue
+  fi
+  new_blob=$(git -C "$REPO" rev-parse -q --verify "$NEW_HEAD:$p" 2>/dev/null || true)
+  if [ -n "$new_blob" ] && [ "$new_blob" = "$h" ]; then
+    n_same=$((n_same+1)); continue
+  fi
+  mkdir -p "$PROPOSALS/$(dirname "$p")"
+  if [ -n "$new_blob" ]; then
+    uniq_lines=$(comm -23 <(sort -u "$snap") <(git -C "$REPO" show "$NEW_HEAD:$p" | sort -u) | grep -vc '^\s*$')
+    old_blob=$(git -C "$REPO" rev-parse -q --verify "$OLD_HEAD:$p" 2>/dev/null || true)
+    base=$(mktemp); theirs=$(mktemp)
+    if [ -n "$old_blob" ]; then git -C "$REPO" show "$OLD_HEAD:$p" > "$base"; else : > "$base"; fi
+    git -C "$REPO" show "$NEW_HEAD:$p" > "$theirs"
+    if ! git merge-file -p -L "снимок" -L "старый HEAD" -L "новый HEAD" "$snap" "$base" "$theirs" > "$PROPOSALS/$p" 2>/dev/null \
+       && [ ! -s "$PROPOSALS/$p" ]; then
+      # merge-file cannot merge binaries: the proposal is the snapshot itself, marked as such
+      cp -a "$snap" "$PROPOSALS/$p"; rm -f "$base" "$theirs"; n_new=$((n_new+1))
+      printf '| %s | бинарный, снимок как есть | - | 0 | proposals/%s |\n' "$p" "$p" >> "$INDEX"; continue
+    fi
+    conflicts=$(grep -c '^<<<<<<< ' "$PROPOSALS/$p")
+    # append-only sections (Осталось/Журнал) usually conflict only because both
+    # sides appended at the same spot; the union variant keeps both blocks in
+    # order (snapshot first) for the pilot to compare against the marked one.
+    [ "$conflicts" -gt 0 ] && git merge-file -p --union "$snap" "$base" "$theirs" > "$PROPOSALS/$p.union"
+    rm -f "$base" "$theirs"
+    n_merge=$((n_merge+1)); [ "$conflicts" -gt 0 ] && n_conf=$((n_conf+1))
+    variant="proposals/$p"; [ "$conflicts" -gt 0 ] && variant="$variant (+ .union)"
+    printf '| %s | tracked, 3-way | %s | %s | %s |\n' "$p" "$uniq_lines" "$conflicts" "$variant" >> "$INDEX"
+  else
+    cp -a "$snap" "$PROPOSALS/$p"; n_new=$((n_new+1))
+    printf '| %s | новый файл | %s | 0 | proposals/%s |\n' "$p" "$(grep -vc '^\s*$' "$snap")" "$p" >> "$INDEX"
+  fi
+done < "$SNAP/manifest.sha256"
+{
+  echo
+  echo "Уже на origin байт-в-байт (предложение не нужно): $n_same · трёхсторонних предложений: $n_merge (с конфликтами: $n_conf) · новых файлов: $n_new"
+} >> "$INDEX"
+echo "index: $INDEX (same=$n_same merge=$n_merge conflicts=$n_conf new=$n_new)"

--- a/scripts/canon-dirty-snapshot.sh
+++ b/scripts/canon-dirty-snapshot.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# canon-dirty-snapshot.sh <repo-path> <snapshot-dir> -- double snapshot of every
+# uncommitted path of a checkout before the Ф3 ref replacement (WP-530 Ф38,
+# Kimi amendment 1: `cp -a` copies + textual diffs + untracked hash list, then a
+# self-check that every listed path is in the snapshot with the same hash).
+# Read-only towards the repo. Exit 0 = snapshot complete and verified; 1 = not.
+set -uo pipefail
+REPO="$1"; SNAP="$2"
+cd "$REPO" || exit 2
+mkdir -p "$SNAP/files" "$SNAP/proposals"
+git rev-parse HEAD > "$SNAP/old_head.txt"
+git stash list > "$SNAP/stash-list.txt"
+git status --porcelain -z > "$SNAP/status.z"
+git status --porcelain > "$SNAP/status.txt"
+git diff > "$SNAP/tracked.diff"
+git diff --cached > "$SNAP/staged.diff"
+git diff --cached --name-only -z > "$SNAP/staged-paths.z"
+: > "$SNAP/manifest.sha256"
+: > "$SNAP/manifest.stat"
+find . -type d -empty -not -path './.git/*' | sort > "$SNAP/empty-dirs.txt"
+record() {  # <path> -- content hash + stat line (+ symlink target) for one path
+  if [ -L "$1" ]; then printf '%s %s\n' "$(printf '%s' "$(readlink "$1")" | git hash-object --stdin)" "$1" >> "$SNAP/manifest.sha256"
+  else printf '%s %s\n' "$(git hash-object "$1")" "$1" >> "$SNAP/manifest.sha256"; fi
+  if [ -L "$1" ]; then printf 'link %s -> %s\n' "$1" "$(readlink "$1")" >> "$SNAP/manifest.stat"
+  else printf '%s %s\n' "$(stat -f '%HT %Lp %z %m' "$1")" "$1" >> "$SNAP/manifest.stat"; fi
+}
+# every path git reports (modified, staged, untracked) -- copied with metadata
+git status --porcelain -z | while IFS= read -r -d '' entry; do
+  p="${entry:3}"
+  # renames/copies carry a second NUL-terminated field (the old path): consume it, snapshot the new one
+  case "${entry:0:1}${entry:1:1}" in R*|C*|*R|*C) IFS= read -r -d '' _old_path ;; esac
+  [ -e "$p" ] || [ -L "$p" ] || { printf 'DELETED %s\n' "$p" >> "$SNAP/manifest.sha256"; continue; }
+  if [ -d "$p" ] && [ ! -L "$p" ]; then
+    find "$p" \( -type f -o -type l \) | while read -r f; do
+      mkdir -p "$SNAP/files/$(dirname "$f")"; cp -a "$f" "$SNAP/files/$f"; record "$f"
+    done
+  else
+    mkdir -p "$SNAP/files/$(dirname "$p")"; cp -a "$p" "$SNAP/files/$p"; record "$p"
+  fi
+done
+# self-check: every manifest entry exists in the snapshot with the same hash
+bad=0
+while read -r h p; do
+  [ "$h" = "DELETED" ] && continue
+  [ -e "$SNAP/files/$p" ] || [ -L "$SNAP/files/$p" ] || { echo "MISSING in snapshot: $p" >&2; bad=1; continue; }
+  if [ -L "$p" ]; then
+    [ "$(printf '%s' "$(readlink "$SNAP/files/$p")" | git hash-object --stdin)" = "$h" ] || { echo "HASH MISMATCH in snapshot: $p" >&2; bad=1; }
+    [ "$(readlink "$SNAP/files/$p")" = "$(readlink "$p")" ] || { echo "SYMLINK MISMATCH in snapshot: $p" >&2; bad=1; }
+  else
+    [ "$(git hash-object "$SNAP/files/$p")" = "$h" ] || { echo "HASH MISMATCH in snapshot: $p" >&2; bad=1; }
+    [ "$(stat -f '%HT %Lp %z' "$SNAP/files/$p")" = "$(stat -f '%HT %Lp %z' "$p")" ] || { echo "STAT MISMATCH in snapshot: $p" >&2; bad=1; }
+  fi
+done < "$SNAP/manifest.sha256"
+n=$(grep -vc '^DELETED' "$SNAP/manifest.sha256")
+[ "$bad" = 0 ] && echo "snapshot ok: $n files in $SNAP (old_head $(cut -c1-9 "$SNAP/old_head.txt"))" || { echo "snapshot INCOMPLETE" >&2; exit 1; }

--- a/scripts/canon-dirty-snapshot.sh
+++ b/scripts/canon-dirty-snapshot.sh
@@ -18,11 +18,22 @@ git diff --cached --name-only -z > "$SNAP/staged-paths.z"
 : > "$SNAP/manifest.sha256"
 : > "$SNAP/manifest.stat"
 find . -type d -empty -not -path './.git/*' | sort > "$SNAP/empty-dirs.txt"
+# GNU-first (Linux/coreutils), BSD fallback (macOS) -- same order and same
+# rationale as iwe_file_mtime_date() in scripts/lib/common.sh: this pilot's
+# own hosts span both (Mac + tsekh-1 Linux), and the reverse check order has
+# previously broken the Linux branch of stat -f/-c detection.
+portable_stat_line() {  # <path> -- "type perm size mtime", one format picked once per host
+  if stat --version >/dev/null 2>&1; then
+    stat -c '%F %a %s %Y' -- "$1"
+  else
+    stat -f '%HT %Lp %z %m' -- "$1"
+  fi
+}
 record() {  # <path> -- content hash + stat line (+ symlink target) for one path
   if [ -L "$1" ]; then printf '%s %s\n' "$(printf '%s' "$(readlink "$1")" | git hash-object --stdin)" "$1" >> "$SNAP/manifest.sha256"
   else printf '%s %s\n' "$(git hash-object "$1")" "$1" >> "$SNAP/manifest.sha256"; fi
   if [ -L "$1" ]; then printf 'link %s -> %s\n' "$1" "$(readlink "$1")" >> "$SNAP/manifest.stat"
-  else printf '%s %s\n' "$(stat -f '%HT %Lp %z %m' "$1")" "$1" >> "$SNAP/manifest.stat"; fi
+  else printf '%s %s\n' "$(portable_stat_line "$1")" "$1" >> "$SNAP/manifest.stat"; fi
 }
 # every path git reports (modified, staged, untracked) -- copied with metadata
 git status --porcelain -z | while IFS= read -r -d '' entry; do
@@ -48,7 +59,7 @@ while read -r h p; do
     [ "$(readlink "$SNAP/files/$p")" = "$(readlink "$p")" ] || { echo "SYMLINK MISMATCH in snapshot: $p" >&2; bad=1; }
   else
     [ "$(git hash-object "$SNAP/files/$p")" = "$h" ] || { echo "HASH MISMATCH in snapshot: $p" >&2; bad=1; }
-    [ "$(stat -f '%HT %Lp %z' "$SNAP/files/$p")" = "$(stat -f '%HT %Lp %z' "$p")" ] || { echo "STAT MISMATCH in snapshot: $p" >&2; bad=1; }
+    [ "$(portable_stat_line "$SNAP/files/$p" | cut -d' ' -f1-3)" = "$(portable_stat_line "$p" | cut -d' ' -f1-3)" ] || { echo "STAT MISMATCH in snapshot: $p" >&2; bad=1; }
   fi
 done < "$SNAP/manifest.sha256"
 n=$(grep -vc '^DELETED' "$SNAP/manifest.sha256")

--- a/scripts/canon-reconcile-published.sh
+++ b/scripts/canon-reconcile-published.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# canon-reconcile-published.sh <repo-path> <branch> [<pinned-oid>] -- replace a
+# canonical checkout's branch ref with the just-published origin tip when, and
+# only when, the local history it would drop is provably already on origin.
+#
+# The gap this closes (WP-530 Ф38, peer-session 2026-09-11-07, Claude+Kimi+Codex):
+# sessions commit straight into the canonical checkout, isolate-push.sh carries
+# those commits to origin as cherry-picks (new SHAs), and nothing afterwards
+# moves the canonical ref -- so the canon is never an ancestor of origin again.
+# canon-refresh.sh (clean + purely behind) and canon-reconcile.sh (dirty +
+# purely behind) both refuse a diverged history by design; without this step the
+# divergence grows until a human merges by hand (74/230 on 11.09).
+#
+# Contract (fail closed -- any doubt means "touch nothing, say why"):
+#   preflight  no live session is writing into this host's checkouts (semaphores
+#              under $IWE_RUNTIME/sessions without isolated_worktree and with a
+#              live pid -- Codex, round 3: a re-check right before reset shrinks
+#              the race with a concurrent writer but cannot close it, and this
+#              script takes no snapshot of tracked dirt; until a barrier every
+#              writer honours exists (Ф5.1) the only safe answer is skip + retry
+#              on the next publish) · branch as expected · index and tracked
+#              tree clean · every local-only commit patch-equivalent to the
+#              target (`git cherry` has no `+`, no local merge commits) · every
+#              path `git reset --hard` would CREATE (added in target vs current
+#              HEAD) is either absent on disk or identical in type, mode and
+#              content -- checked on disk, so ignored files, case-folded names
+#              and file-vs-directory clashes count too (cold review 11.09).
+#   action     `git update-ref` with compare-and-swap on the old head, then
+#              `git reset --hard` so index and tracked tree follow the ref.
+#   postcheck  HEAD == pinned · tracked tree clean · the set of untracked paths
+#              (mode, hash, path) is unchanged apart from paths the target now
+#              tracks -- a changed hash, a missing path or a NEW path means
+#              someone wrote during the window: reported, never called success.
+# This script never writes inside the repository except through git itself:
+# its own log goes to $IWE_RUNTIME/canon-reconcile-published.log (a ledger
+# event inside the canon would dirty the very tree it is reconciling -- cold
+# review 11.09 found the resulting 15-minute publish loop).
+#
+# Exit: 0 = replaced, or nothing to do (already ancestor -> canon-refresh's job)
+#       1 = refused (canon untouched) or post-check failed (ref already replaced
+#           -- the message says which; both are logged)
+#       2 = usage / repo error
+set -uo pipefail
+
+usage() { echo "usage: canon-reconcile-published.sh <repo-path> <branch> [<pinned-oid>]" >&2; exit 2; }
+[ $# -ge 2 ] || usage
+REPO="$1"; BRANCH="$2"; PINNED_ARG="${3:-}"
+cd "$REPO" 2>/dev/null || { echo "canon-reconcile-published: cannot cd to $REPO" >&2; exit 2; }
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "canon-reconcile-published: $REPO is not a git repo" >&2; exit 2; }
+GIT_DIR=$(git rev-parse --git-dir)
+RUNTIME_DIR="${IWE_RUNTIME:-${IWE_WORKSPACE:-$HOME/IWE}/.iwe-runtime}"
+LOG_FILE="$RUNTIME_DIR/canon-reconcile-published.log"
+TMP_FILES=()
+cleanup() { rm -f "${TMP_FILES[@]+"${TMP_FILES[@]}"}"; }
+trap cleanup EXIT
+
+log_line() {  # <status> <text> -- append-only log outside the repository
+  mkdir -p "$RUNTIME_DIR" 2>/dev/null || return 0
+  printf '%s %s repo=%s branch=%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$REPO" "$BRANCH" "$2" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+refuse() {  # <reason> -- nothing was changed
+  echo "canon-reconcile-published: refused -- $1 (canon untouched, publish not rolled back)" >&2
+  log_line refused "$1"
+  exit 1
+}
+
+fail_after_swap() {  # <reason> -- the ref is already replaced; say so honestly
+  echo "canon-reconcile-published: post-check FAILED after the ref was replaced -- $1. HEAD=$(git rev-parse HEAD); inspect the tree before trusting it" >&2
+  log_line post-check-failed "$1"
+  exit 1
+}
+
+if [ -d "$GIT_DIR/rebase-merge" ] || [ -d "$GIT_DIR/rebase-apply" ] || [ -f "$GIT_DIR/MERGE_HEAD" ] || [ -f "$GIT_DIR/CHERRY_PICK_HEAD" ]; then
+  refuse "repo is mid-rebase/merge/cherry-pick"
+fi
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+[ "$CURRENT_BRANCH" = "$BRANCH" ] || refuse "checked-out branch is '$CURRENT_BRANCH', expected '$BRANCH'"
+
+# Same lock as git-dirty-guard.sh / canon-refresh.sh / canon-reconcile.sh /
+# sync-strategy-files.sh: whoever holds it runs to completion first.
+LOCK_DIR="$GIT_DIR/dirty-guard.lock"
+LOCK_META="$LOCK_DIR/owner"
+HOST_NOW="${HOSTNAME:-$(hostname 2>/dev/null || echo unknown)}"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  if [ -f "$LOCK_META" ]; then
+    OTHER_HOST=$(awk -F= '$1=="host"{print $2}' "$LOCK_META" 2>/dev/null)
+    OTHER_PID=$(awk -F= '$1=="pid"{print $2}' "$LOCK_META" 2>/dev/null)
+    if [ "$OTHER_HOST" = "$HOST_NOW" ] && [ -n "$OTHER_PID" ] && ! kill -0 "$OTHER_PID" 2>/dev/null; then
+      echo "canon-reconcile-published: reclaiming stale lock (pid=$OTHER_PID gone)" >&2
+      rm -rf "$LOCK_DIR" 2>/dev/null
+    fi
+  fi
+  mkdir "$LOCK_DIR" 2>/dev/null || { echo "canon-reconcile-published: lock busy, skipping this cycle"; exit 0; }
+fi
+trap 'cleanup; rm -rf "$LOCK_DIR" 2>/dev/null' EXIT
+printf 'host=%s\npid=%s\n' "$HOST_NOW" "$$" > "$LOCK_META"
+
+# 1. no live canonical writer (strict, Codex round 3). Isolated sessions never
+#    touch this tree; only semaphores without isolated_worktree count.
+LIVE_WRITERS=""
+for sem in "$RUNTIME_DIR"/sessions/*.open; do
+  [ -f "$sem" ] || continue
+  grep -q '^isolated_worktree:' "$sem" && continue
+  sem_pid=$(awk '$1=="pid:"{print $2; exit}' "$sem")
+  # no pid (Kimi/Codex semaphores never carry one) = no proof of death -> treat as live, like session-guard's own sweep
+  if [ -z "$sem_pid" ] || kill -0 "$sem_pid" 2>/dev/null; then LIVE_WRITERS="$LIVE_WRITERS $(basename "$sem" .open)"; fi
+done
+[ -z "$LIVE_WRITERS" ] || refuse "live canonical writer(s):$LIVE_WRITERS -- skipped, will retry on the next publish"
+
+# explicit refspec: `git fetch origin <branch>` alone is not guaranteed to move origin/<branch>
+git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" --quiet 2>/dev/null || refuse "git fetch origin $BRANCH failed"
+OLD_HEAD=$(git rev-parse HEAD)
+REMOTE_TIP=$(git rev-parse "origin/$BRANCH")
+if [ -n "$PINNED_ARG" ]; then
+  PINNED=$(git rev-parse --verify "${PINNED_ARG}^{commit}" 2>/dev/null) || refuse "pinned oid $PINNED_ARG is not a commit here"
+  git merge-base --is-ancestor "$PINNED" "$REMOTE_TIP" || refuse "pinned oid is not on origin/$BRANCH"
+  # origin moved past the caller's pin: re-evaluate against the live tip, never replace with a stale one
+  [ "$PINNED" = "$REMOTE_TIP" ] || echo "canon-reconcile-published: origin/$BRANCH advanced past pinned ${PINNED:0:12}, targeting live tip ${REMOTE_TIP:0:12}"
+fi
+PINNED="$REMOTE_TIP"
+
+if [ "$OLD_HEAD" = "$PINNED" ]; then echo "canon-reconcile-published: already at $PINNED"; exit 0; fi
+if git merge-base --is-ancestor "$OLD_HEAD" "$PINNED"; then
+  echo "canon-reconcile-published: HEAD is a plain ancestor of the target -- canon-refresh.sh owns that shape, nothing to do"
+  exit 0
+fi
+
+# 2. index + tracked tree must be clean (untracked/ignored files are allowed, see 4).
+TRACKED_DIRTY=$(git status --porcelain --untracked-files=no 2>/dev/null)
+[ -z "$TRACKED_DIRTY" ] || refuse "tracked/staged changes present ($(printf '%s\n' "$TRACKED_DIRTY" | wc -l | tr -d ' ') paths)"
+
+# 3. every local-only commit must already be on the target as an equivalent patch.
+UNIQUE=$(git cherry "$PINNED" "$OLD_HEAD" 2>/dev/null | awk '$1=="+"{print $2}')
+[ -z "$UNIQUE" ] || refuse "local-only commits not on target: $(printf '%s ' $UNIQUE)"
+# `git cherry` skips merge commits entirely -- an unexpected local merge is not proven delivered.
+LOCAL_MERGES=$(git rev-list --merges "$PINNED..$OLD_HEAD")
+[ -z "$LOCAL_MERGES" ] || refuse "local merge commit(s) not provable by patch-id: $(printf '%s ' $LOCAL_MERGES)"
+
+# 4. everything `git reset --hard` would CREATE on disk must be absent or identical.
+#    Checked on disk (not via git's untracked listing), so ignored files, names
+#    that differ only by case on APFS, and file-vs-directory clashes are covered.
+tracked_and_deleted_by_target() {  # <path> -- a blob in OLD_HEAD that the target removes (reset deletes it itself)
+  [ -n "$(git ls-tree "$OLD_HEAD" -- "$1" | awk '$1!="040000"')" ] && [ -z "$(git ls-tree "$PINNED" -- "$1" | awk '$1!="040000"')" ]
+}
+disk_entry() {  # <path> -> "<mode> <hash>" of what is on disk, or "" if absent
+  if [ -L "$1" ]; then printf '120000 %s' "$(printf '%s' "$(readlink "$1")" | git hash-object --stdin)"
+  elif [ -d "$1" ]; then printf 'dir'
+  elif [ -x "$1" ]; then printf '100755 %s' "$(git hash-object "$1")"
+  elif [ -e "$1" ]; then printf '100644 %s' "$(git hash-object "$1")"
+  fi
+}
+COLLISION=""
+while IFS= read -r -d '' status && IFS= read -r -d '' p; do
+  [ "$status" = "A" ] || continue
+  entry=$(git ls-tree "$PINNED" -- "$p" | head -1)
+  t_mode=$(printf '%s' "$entry" | awk '{print $1}'); t_hash=$(printf '%s' "$entry" | awk '{print $3}')
+  on_disk=$(disk_entry "$p")
+  if [ "$on_disk" = "dir" ] && [ -n "$(git ls-tree "$OLD_HEAD" -- "$p/")" ] && [ -z "$(git ls-files --others -- "$p/")" ]; then
+    on_disk=""   # tracked directory with nothing untracked inside: dir->file conversion, reset handles it
+  fi
+  if [ -n "$on_disk" ] && [ "$on_disk" != "$t_mode $t_hash" ]; then COLLISION="$p (on disk: ${on_disk%% *}, target wants $t_mode $t_hash)"; break; fi
+  # case-insensitive filesystem: `-e` matched a differently-cased name; git would write into that inode
+  # under the target's spelling and the post-check could only report it afterwards -- refuse up front
+  if [ -n "$on_disk" ] && ! ls -a "$(dirname "$p")" 2>/dev/null | grep -qFx "$(basename "$p")"; then COLLISION="$p (a differently-cased name occupies this path on disk)"; break; fi
+  # an ancestor of the new path exists on disk as a symlink (reset would destroy it and create a real
+  # directory) or as a plain file that the target does not itself delete (file->dir conversion of a
+  # tracked file is reset's normal job; an untracked/ignored file in the way is a collision)
+  d=$(dirname "$p")
+  while [ "$d" != "." ]; do
+    if [ -L "$d" ]; then COLLISION="$d (on disk a symlink, target needs a directory for $p)"; break 2; fi
+    if [ -e "$d" ] && [ ! -d "$d" ] && ! tracked_and_deleted_by_target "$d"; then COLLISION="$d (on disk a file, target needs a directory for $p)"; break 2; fi
+    d=$(dirname "$d")
+  done
+done < <(git diff-tree -r -z --name-status --no-renames "$OLD_HEAD" "$PINNED")
+[ -z "$COLLISION" ] || refuse "collision with what reset would write: $COLLISION"
+
+untracked_inventory() {  # "<mode> <hash> <path>" per untracked (non-ignored) file, sorted
+  git ls-files --others --exclude-standard -z | while IFS= read -r -d '' p; do
+    printf '%s %s\n' "$(disk_entry "$p")" "$p"
+  done | LC_ALL=C sort -k3
+}
+UNTRACKED_BEFORE=$(mktemp); TMP_FILES+=("$UNTRACKED_BEFORE")
+untracked_inventory > "$UNTRACKED_BEFORE"
+
+# Re-check the tracked tree right before the irreversible step (still under lock).
+[ -z "$(git status --porcelain --untracked-files=no)" ] || refuse "tracked tree changed during preflight"
+
+# 5. compare-and-swap on the ref, then bring index + tracked tree along.
+git update-ref -m "canon-reconcile-published: $OLD_HEAD -> $PINNED" "refs/heads/$BRANCH" "$PINNED" "$OLD_HEAD" \
+  || refuse "compare-and-swap on refs/heads/$BRANCH lost (HEAD moved)"
+git reset --hard --quiet || fail_after_swap "git reset --hard failed -- index/tree need manual sync to $PINNED"
+
+# 6. post-check.
+[ "$(git rev-parse HEAD)" = "$PINNED" ] || fail_after_swap "HEAD is not the pinned oid"
+[ -z "$(git status --porcelain --untracked-files=no)" ] || fail_after_swap "tracked tree not clean"
+UNTRACKED_AFTER=$(mktemp); TMP_FILES+=("$UNTRACKED_AFTER"); untracked_inventory > "$UNTRACKED_AFTER"
+# expected after-set = before-set minus paths the target now tracks (proven identical in 4)
+EXPECTED=$(mktemp); TMP_FILES+=("$EXPECTED")
+while IFS= read -r line; do
+  p="${line#* * }"
+  t=$(git ls-tree "$PINNED" -- "$p" 2>/dev/null | awk 'NR==1{print $1" "$3}')
+  [ "$t" = "${line% "$p"}" ] || printf '%s\n' "$line"
+done < "$UNTRACKED_BEFORE" > "$EXPECTED"
+DIFF=$(diff "$EXPECTED" "$UNTRACKED_AFTER" | grep '^[<>]' | head -3)
+[ -z "$DIFF" ] || fail_after_swap "untracked set changed during the operation (< expected / > actual): $(printf '%s' "$DIFF" | tr '\n' ';')"
+
+echo "canon-reconcile-published: $REPO refs/heads/$BRANCH ${OLD_HEAD:0:12} -> ${PINNED:0:12} (all dropped commits were patch-equivalent on target; untracked intact)"
+log_line replaced "$OLD_HEAD -> $PINNED"
+exit 0

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2052,6 +2052,18 @@
       "sha256": "39188448fa00e5d70f1bddd157a5467b7b44c2eea3b15a4b33efca6ef2f23c81"
     },
     {
+      "path": "scripts/canon-dirty-proposals.sh",
+      "sha256": "4f33b3658380441d0e2dd93697f538206c7ded1ad8fc3d80a08614ed64de4901"
+    },
+    {
+      "path": "scripts/canon-dirty-snapshot.sh",
+      "sha256": "0140a4bfd9887f2d33bdca0643da31be10c9744638761eea6d241d1866702bc1"
+    },
+    {
+      "path": "scripts/canon-reconcile-published.sh",
+      "sha256": "3dc026a0f8dbd2e135f585528f2da21dfddc0922d94c82e7ef2d5e8251bf17b2"
+    },
+    {
       "path": "scripts/changelog-append.sh",
       "sha256": "53fd0abc41b738a69f9e85607c09918f552fe8eb071404b098706bf7f1514884"
     },

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2057,7 +2057,7 @@
     },
     {
       "path": "scripts/canon-dirty-snapshot.sh",
-      "sha256": "0140a4bfd9887f2d33bdca0643da31be10c9744638761eea6d241d1866702bc1"
+      "sha256": "ab297ff262ef9bed3ce72123a70c4569dd4e32eb9340a53bfd1875fc508837ff"
     },
     {
       "path": "scripts/canon-reconcile-published.sh",


### PR DESCRIPTION
## Summary
- `canon-reconcile-published.sh`, `canon-dirty-snapshot.sh`, `canon-dirty-proposals.sh` only lived in the author's `~/IWE/scripts/` (not a git repo), so no git mechanism could deliver them to other hosts — confirmed live on tsekh-1 (48 commits behind before the tool could even reach that host).
- Host-agnostic (`<repo-path> <branch>` interface, `$IWE_RUNTIME`), no author-specific paths — same delivery profile as existing `route-task.sh`/`server-calendar.sh`.
- Registered in `update-manifest.json` for `update.sh` coverage.

## Test plan
- [x] `template-sync.sh --dry-run` (scoped via `TEMPLATE_SYNC_ONLY`) — PASSED, 3 new files, 0 conflicts
- [x] Pre-commit hooks: syntax, shebang, help, smoke-clean-env, executable-bit, manifest-coverage, release-sync — all PASS
- [x] Cold-context review (independent subagent) of both source changes (SKILL.md caller-fix + this manifest addition) — no issues found
- [ ] Confirm on a second host after merge (tsekh-1) that `update.sh`/manual delivery actually lands these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)