### PR TITLE
feat(artifactor): add result_type discriminator (system vs episteme)

### DIFF
--- a/scripts/artifactor.py
+++ b/scripts/artifactor.py
@@ -4,7 +4,7 @@
 Keyword-based task classifier for IWE Artifactor skill.
 
 Exit codes:
-  0 — keyword match, JSON on stdout (schema_version 2, WP-481 Ф7 шаги 3-4)
+  0 — keyword match, JSON on stdout (schema_version 3, WP-575 Ф2)
   1 — INSUFFICIENT_INPUT (< 5 words)
   2 — NO_KEYWORD_MATCH (needs LLM fallback)
   3 — CONFIG_ERROR (result-kinds-registry.yaml в PACK-digital-platform
@@ -22,6 +22,25 @@ MethodDescription) → result_kind_resolution: "unresolved", НЕ подмена
 ближайшим kind-ом (анти-утечка в супертип, тот же принцип, что в реестре).
 peer_session — намеренно "deferred-to-session": мета-триггер старта процесса,
 не заявка на конкретный результат (решается на Decision Gate внутри сессии).
+
+result_type (WP-575 Ф2, hard-distinctions.md №36, консенсус пир-сессии
+2026-09-11-14-wp575-artefaktor-tip с Codex): "system" | "episteme" | "unresolved" —
+Исполнитель (агент/скрипт/сервис — действующее) vs Информационный объект
+(документ/знание/правило — читаемое). Независимая ось от kind_id — пятый
+элемент кортежа KEYWORD_MAP, курируется вручную по смыслу КАЖДОЙ ЗАПИСИ
+(один task_type может встречаться с разным result_type у разных ключевых
+слов — например "миграция" и "реализация плана" оба дают task_type
+wp_implement, но result_type "system" и "unresolved" соответственно, т.к.
+результат зависит от конкретной фразы, не только от task_type). НЕ
+выводится из kind_id runtime-вычислением (кортеж kind_id/task_type/class
+присваивается ОДНОВРЕМЕННО в той же записи, значит вывод из него нарушил бы
+требование «раньше имени и класса»; проверка: WorkDone-записи расходятся по
+result_type — day_open=episteme, bot_fix=system — значит оси не совпадают).
+"unresolved" — тип неочевиден по смыслу самого task_type (пример: wp_finish/
+wp_close/wp_implement из "миграция" исключение — там результат может быть
+и кодом, и документом в зависимости от конкретного РП) — форсирует уточнение
+у пилота на WP Gate, не угадывается (тот же принцип, что hypothesis_relation:
+"unclassified").
 """
 
 import os
@@ -59,53 +78,61 @@ def load_registry_kind_ids():
     return ids or None
 
 # Третий элемент — expected kind_id (WP-481 Ф7), четвёртый — название
-# артефакта. Оба значения живут в одной карте: отдельный словарь названий
-# незаметно разошёлся бы с маршрутизацией. None + запись в SPECIAL_RESOLUTION
-# — для двух осознанных исключений (peer_session, spec_writing), не «забыли
-# заполнить».
+# артефакта, пятый — result_type (WP-575 Ф2: "system" | "episteme" |
+# "unresolved", см. докстринг модуля). Все значения живут в одной карте:
+# отдельные параллельные словари незаметно разошлись бы с маршрутизацией.
+# None/"unresolved" + запись в SPECIAL_RESOLUTION — для осознанных исключений
+# (peer_session, spec_writing, и записи с неоднозначным result_type), не
+# «забыли заполнить».
 KEYWORD_MAP = {
     # trivial — WorkDone: детерминированный трейс завершённого протокола
-    "day-open": ("day_open", "trivial", "WorkDone", "План дня"),
-    "day open": ("day_open", "trivial", "WorkDone", "План дня"),
-    "открывай день": ("day_open", "trivial", "WorkDone", "План дня"),
-    "week-close": ("week_close", "trivial", "WorkDone", "Итоги недели"),
-    "week close": ("week_close", "trivial", "WorkDone", "Итоги недели"),
-    "закрывай неделю": ("week_close", "trivial", "WorkDone", "Итоги недели"),
-    "month-close": ("month_close", "trivial", "WorkDone", "Итоги месяца"),
-    "peer-сессия": ("peer_session", "trivial", None, "Итоговый отчёт пир-сессии"),  # SPECIAL_RESOLUTION: deferred-to-session
-    "peer сессия": ("peer_session", "trivial", None, "Итоговый отчёт пир-сессии"),
+    "day-open": ("day_open", "trivial", "WorkDone", "План дня", "episteme"),
+    "day open": ("day_open", "trivial", "WorkDone", "План дня", "episteme"),
+    "открывай день": ("day_open", "trivial", "WorkDone", "План дня", "episteme"),
+    "week-close": ("week_close", "trivial", "WorkDone", "Итоги недели", "episteme"),
+    "week close": ("week_close", "trivial", "WorkDone", "Итоги недели", "episteme"),
+    "закрывай неделю": ("week_close", "trivial", "WorkDone", "Итоги недели", "episteme"),
+    "month-close": ("month_close", "trivial", "WorkDone", "Итоги месяца", "episteme"),
+    "peer-сессия": ("peer_session", "trivial", None, "Итоговый отчёт пир-сессии", "unresolved"),  # SPECIAL_RESOLUTION: deferred-to-session; result_type тоже неизвестен до Decision Gate внутри сессии
+    "peer сессия": ("peer_session", "trivial", None, "Итоговый отчёт пир-сессии", "unresolved"),
     # closed-loop
-    "бот упал": ("bot_fix", "closed-loop", "WorkDone", "Исправленный бот"),
-    "ошибк бота": ("bot_fix", "closed-loop", "WorkDone", "Исправленный бот"),     # matches «ошибка» and «ошибки»
-    "фиксы": ("bug_fix", "closed-loop", "WorkDone", "Исправленный дефект"),
-    "устранить": ("bug_fix", "closed-loop", "WorkDone", "Исправленный дефект"),
-    "доделать рп": ("wp_finish", "closed-loop", "WorkDone", "Завершённая фаза РП"),
-    "хвосты рп": ("wp_finish", "closed-loop", "WorkDone", "Завершённая фаза РП"),
-    "закрыть рп": ("wp_close", "closed-loop", "WorkDone", "Отчёт о закрытии РП"),
-    "передать андрею": ("wp_close", "closed-loop", "WorkDone", "Переданный результат РП"),
-    "актуализация wp": ("wp_actualize", "closed-loop", "WorkDone", "Актуализированная карточка РП"),
-    "ревью рп": ("code_review", "closed-loop", "Episteme", "Отчёт ревью"),
-    "ревью работы": ("code_review", "closed-loop", "Episteme", "Отчёт ревью"),
-    "разбор ke": ("ke_review", "closed-loop", "ChoiceResult", "Решение по кандидатам знаний"),  # R15 accept/reject/defer, не граф claim'ов
-    "триаж": ("wp_triage", "closed-loop", "ChoiceResult", "Решение по триажу РП"),
-    "реализация плана": ("wp_implement", "closed-loop", "WorkDone", "Реализованный план"),
-    "миграция": ("wp_implement", "closed-loop", "WorkDone", "Выполненная миграция"),
-    "создай pack": ("pack_create", "closed-loop", "Episteme", "Паспорт Pack"),
-    "новый pack": ("pack_create", "closed-loop", "Episteme", "Паспорт Pack"),
-    "ротация секретов": ("ops_security", "closed-loop", "WorkDone", "Ротированные секреты"),
-    "fmt remaining": ("fmt_deploy", "closed-loop", "WorkDone", "Доставленный шаблон"),
+    "бот упал": ("bot_fix", "closed-loop", "WorkDone", "Исправленный бот", "system"),
+    "ошибк бота": ("bot_fix", "closed-loop", "WorkDone", "Исправленный бот", "system"),     # matches «ошибка» and «ошибки»
+    "фиксы": ("bug_fix", "closed-loop", "WorkDone", "Исправленный дефект", "system"),
+    "устранить": ("bug_fix", "closed-loop", "WorkDone", "Исправленный дефект", "system"),
+    "доделать рп": ("wp_finish", "closed-loop", "WorkDone", "Завершённая фаза РП", "unresolved"),  # результат зависит от конкретного РП — код или документ
+    "хвосты рп": ("wp_finish", "closed-loop", "WorkDone", "Завершённая фаза РП", "unresolved"),
+    "закрыть рп": ("wp_close", "closed-loop", "WorkDone", "Отчёт о закрытии РП", "unresolved"),
+    "передать андрею": ("wp_close", "closed-loop", "WorkDone", "Переданный результат РП", "unresolved"),
+    "актуализация wp": ("wp_actualize", "closed-loop", "WorkDone", "Актуализированная карточка РП", "episteme"),
+    "ревью рп": ("code_review", "closed-loop", "Episteme", "Отчёт ревью", "episteme"),
+    "ревью работы": ("code_review", "closed-loop", "Episteme", "Отчёт ревью", "episteme"),
+    "разбор ke": ("ke_review", "closed-loop", "ChoiceResult", "Решение по кандидатам знаний", "episteme"),  # R15 accept/reject/defer, не граф claim'ов
+    "триаж": ("wp_triage", "closed-loop", "ChoiceResult", "Решение по триажу РП", "episteme"),
+    "реализация плана": ("wp_implement", "closed-loop", "WorkDone", "Реализованный план", "unresolved"),  # план может реализоваться и кодом, и документом
+    "миграция": ("wp_implement", "closed-loop", "WorkDone", "Выполненная миграция", "system"),
+    "создай pack": ("pack_create", "closed-loop", "Episteme", "Паспорт Pack", "episteme"),
+    "новый pack": ("pack_create", "closed-loop", "Episteme", "Паспорт Pack", "episteme"),
+    "ротация секретов": ("ops_security", "closed-loop", "WorkDone", "Ротированные секреты", "system"),
+    "fmt remaining": ("fmt_deploy", "closed-loop", "WorkDone", "Доставленный шаблон", "system"),
     # open-loop
-    "диагностика": ("diagnosis", "open-loop", "Episteme", "Диагностический отчёт"),
-    "темы для пост": ("content_plan", "open-loop", "ChoiceResult", "План публикаций"),   # matches «поста» and «постов»; выбор темы+аудитории+дня, не просто перечень
-    "темы, идеи": ("content_plan", "open-loop", "ChoiceResult", "План публикаций"),
-    "темы идеи": ("content_plan", "open-loop", "ChoiceResult", "План публикаций"),
-    "сценарии тз": ("spec_writing", "open-loop", None, "Техническое задание"),  # SPECIAL_RESOLUTION: unresolved — ни один из 6 kind-ов не подходит (найдено на WP-421)
-    "стратег": ("strategy", "open-loop", "ChoiceResult", "Актуализированная стратегия"),
+    "диагностика": ("diagnosis", "open-loop", "Episteme", "Диагностический отчёт", "episteme"),
+    "темы для пост": ("content_plan", "open-loop", "ChoiceResult", "План публикаций", "episteme"),   # matches «поста» and «постов»; выбор темы+аудитории+дня, не просто перечень
+    "темы, идеи": ("content_plan", "open-loop", "ChoiceResult", "План публикаций", "episteme"),
+    "темы идеи": ("content_plan", "open-loop", "ChoiceResult", "План публикаций", "episteme"),
+    "сценарии тз": ("spec_writing", "open-loop", None, "Техническое задание", "episteme"),  # SPECIAL_RESOLUTION: unresolved kind — ни один из 6 kind-ов не подходит (найдено на WP-421); result_type при этом однозначен (документ)
+    "стратег": ("strategy", "open-loop", "ChoiceResult", "Актуализированная стратегия", "episteme"),
     # problem-framing
-    "придумать": ("design", "problem-framing", "ProblemCard", "Карточка проблемы"),
-    "что-то с": ("design", "problem-framing", "ProblemCard", "Карточка проблемы"),
-    "надо что-то": ("design", "problem-framing", "ProblemCard", "Карточка проблемы"),
+    "придумать": ("design", "problem-framing", "ProblemCard", "Карточка проблемы", "episteme"),
+    "что-то с": ("design", "problem-framing", "ProblemCard", "Карточка проблемы", "episteme"),
+    "надо что-то": ("design", "problem-framing", "ProblemCard", "Карточка проблемы", "episteme"),
 }
+
+VALID_RESULT_TYPES = ("system", "episteme", "unresolved")
+for _kw, _entry in KEYWORD_MAP.items():
+    if _entry[4] not in VALID_RESULT_TYPES:
+        raise AssertionError(f"KEYWORD_MAP[{_kw!r}]: invalid result_type {_entry[4]!r}")
+del _kw, _entry
 
 # task_type → почему expected_result_kind = None. Единственное легитимное
 # основание для None — одна из этих двух причин, не «забыли решить».
@@ -122,16 +149,18 @@ BUDGET_BY_CLASS = {
 }
 
 
-def classify(text: str) -> tuple[str, str, str | None, str] | tuple[None, None, None, None]:
-    """Return (task_type, cls, kind_id, artifact) or four None values.
+def classify(
+    text: str,
+) -> tuple[str, str, str | None, str, str] | tuple[None, None, None, None, None]:
+    """Return (task_type, cls, kind_id, artifact, result_type) or five None values.
 
     kind_id may be None (see SPECIAL_RESOLUTION) even when task_type matched.
     """
     lower = text.lower()
-    for kw, (task_type, cls, kind_id, artifact) in KEYWORD_MAP.items():
+    for kw, (task_type, cls, kind_id, artifact, result_type) in KEYWORD_MAP.items():
         if kw in lower:
-            return task_type, cls, kind_id, artifact
-    return None, None, None, None
+            return task_type, cls, kind_id, artifact, result_type
+    return None, None, None, None, None
 
 
 def resolve_result_kind(task_type: str, kind_id: str | None) -> tuple[str | None, str]:
@@ -175,7 +204,7 @@ def main() -> None:
 
     # Keyword check first — short protocol triggers (e.g. "day-open") must be recognised
     # before the length guard fires.
-    task_type, cls, kind_id, artifact = classify(text)
+    task_type, cls, kind_id, artifact, result_type = classify(text)
     if task_type is not None:
         expected_result_kind, result_kind_resolution = resolve_result_kind(task_type, kind_id)
         result = {
@@ -186,7 +215,8 @@ def main() -> None:
             "confidence": "high",
             "routing_tag": task_type,
             "resolution_path": "keyword",
-            "schema_version": 2,
+            "schema_version": 3,
+            "result_type": result_type,
             "expected_result_kind": expected_result_kind,
             "result_kind_resolution": result_kind_resolution,
             # Стратегическая связь не выводится из ключевых слов: Артефактор

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2029,7 +2029,7 @@
     },
     {
       "path": "scripts/artifactor.py",
-      "sha256": "7627424bcf4e1a8b84f749873485bbc3d4d1557b89c098547d1100b5d7688429"
+      "sha256": "bf08b68fefbfa577e053dd47af437ec52e2caeb8eedb17328f1cf0f2c3a77982"
     },
     {
       "path": "scripts/attestation-build-statement.sh",


### PR DESCRIPTION
## Summary
- WP-575 Ф2: Артефактор явно классифицирует тип результата (Исполнитель/система vs Информационный объект/документ) как независимую ось от `expected_result_kind`, до имени и класса задачи. `schema_version` 2 → 3.
- Только `scripts/artifactor.py` — `.claude/skills/artifactor/SKILL.md` в этом PR намеренно НЕ трогается (см. примечание ниже).

## Как доставлено
Перенесено вручную поверх актуального `main` (авторская доставка через прямой Edit, разрешено хуком `extensions-gate.sh` для `FMT-exocortex-template` при `author_mode: true`). `template-sync.sh --dry-run` на этом хосте показал `CONFLICT` на `scripts/artifactor.py` — его собственный источник (корневая read-only копия `~/IWE/scripts/`) на этой машине устарел и отстаёт даже от уже смёрженного в `main` исправления именования `KEYWORD_MAP` (PR #789). Слепой `FORCE_SYNC=1` откатил бы это исправление — вместо этого содержимое перенесено вручную, с сохранением уже смёрженного фикса, и проверено живыми прогонами против текущего `main`.

## Отдельная находка (не в этом PR)
`.claude/skills/artifactor/SKILL.md` в `main` этого репозитория — версия ДО WP-481 Ф7 (7 полей вместо актуальных 10-11, нет `expected_result_kind`/`result_kind_resolution`/`schema_version`). Файл никогда не был добавлен в манифест `template-sync.sh` (`scripts/artifactor.py` там есть, `SKILL.md` — нет). Это отдельный, более крупный дрейф, требующий отдельного решения — не включён в этот PR.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('scripts/artifactor.py').read())"` — валидный синтаксис
- [x] Диф против авторского источника (`iwe-local-config/scripts/artifactor.py`) — расходится только в ожидаемых плейсхолдерах шаблона (`{{WORKSPACE_DIR}}`, `DS-strategy`)
- [x] Живой прогон (`IWE_ROOT=~/IWE python3 scripts/artifactor.py "открывай день"` → `episteme`; `"бот упал"` → `system`) — совпадает с авторским источником
- [x] Полный набор тестов (47/47) прошёл в авторском источнике перед переносом (iwe-local-config), код идентичен