### PR TITLE
docs(artifactor): bring SKILL.md up to date (WP-481 Ф7 + WP-575 Ф2)

### DIFF
--- a/.claude/skills/artifactor/SKILL.md
+++ b/.claude/skills/artifactor/SKILL.md
@@ -1,8 +1,8 @@
 ---
 # see DP.SC.160, DP.ROLE.058
 name: artifactor
-description: "Classifies raw pilot request → structured request with routing and an explicit unresolved strategic-basis gate. Keyword-fast (<200ms) or Haiku fallback (<60s). Does NOT create WP or call executor."
-version: 1.0.0
+description: "Classifies raw pilot request → structured JSON {task_type, class, artifact, budget_estimate, confidence, routing_tag, resolution_path, schema_version, result_type, expected_result_kind, result_kind_resolution, hypothesis_relation}. Keyword-fast (<200ms) or Haiku fallback (<60s). Does NOT create WP or call executor."
+version: 1.1.0
 layer: L1
 status: active
 browser_safe: false
@@ -32,14 +32,12 @@ gates_rationale: "операционный скилл; WP Gate применим 
 
 ## When to use
 
-Classifies raw pilot request → structured JSON with routing. The later WP Gate must
-also resolve how the work relates to a hypothesis; Artifactor does not invent that
-relation from keywords. Does NOT create WP or call executor.
+Classifies raw pilot request → structured JSON {task_type, class, artifact, budget_estimate, confidence, routing_tag, resolution_path, schema_version, result_type, expected_result_kind, result_kind_resolution, hypothesis_relation}. Keyword-fast (<200ms) or Haiku fallback (<60s). Does NOT create WP or call executor.
 
 ## Обещание (контракт)
 
 **Вход:** сырой текст запроса пилота (любой длины, без routing-tag)  
-**Выход:** JSON 7 полей → stdout:
+**Выход:** JSON, schema_version 3 (WP-575 Ф2 — добавлено поле `result_type`) → stdout:
 
 ```json
 {
@@ -49,7 +47,12 @@ relation from keywords. Does NOT create WP or call executor.
   "budget_estimate": "~Xh | ?",
   "confidence": "high | low",
   "routing_tag": "string",
-  "resolution_path": "keyword | llm"
+  "resolution_path": "keyword | llm",
+  "schema_version": 3,
+  "result_type": "system | episteme | unresolved",
+  "expected_result_kind": "kind_id из PACK-digital-platform/pack/digital-platform/result-kinds-registry.yaml | null",
+  "result_kind_resolution": "static | deferred-to-session | unresolved",
+  "hypothesis_relation": "unclassified"
 }
 ```
 
@@ -58,6 +61,12 @@ relation from keywords. Does NOT create WP or call executor.
 - `confidence=high` только при keyword-пути; `confidence=low` при LLM-пути
 - При запросе <5 слов: вернуть `{"error": "INSUFFICIENT_INPUT"}`, стоп
 - `budget_estimate: "?"` только при `problem-framing` или полной неопределённости
+- `result_type` (WP-575 Ф2, hard-distinctions.md №36) — Исполнитель (`system`: агент/скрипт/сервис — действующее) vs Информационный объект (`episteme`: документ/знание/правило — читаемое). Решается ДО имени и класса задачи, независимая ось от `expected_result_kind` — НЕ выводится из `kind_id` (кортеж `kind_id`/`task_type`/`class` присваивается одновременно, вывод из него нарушил бы «раньше имени и класса», и `kind_id` создавался для другого различения). `unresolved` — тип неочевиден → форсирует уточнение у пилота на WP Gate, классификатор НЕ гадает (тот же принцип, что `hypothesis_relation: "unclassified"` ниже).
+- **Маршрутизация по `result_type`** (делает потребитель — `/wp-new`/WP Gate Ритуал, не сам Артефактор, тот же принцип, что и передача `hypothesis_relation` в WP Gate): `system` → обязательна проверка IntegrationGate (новизна инструмента/агента/скрипта/сервиса); `episteme` → Routing Gate (карта размещения документа/знания, `DP.KR.001 §5`); `unresolved` → уточнение у пилота до продолжения.
+- `expected_result_kind` — дискриминатор ожидаемого kind-а результата (WP-481 Ф7, «не бывает общего результата»), НЕ показатель готовности проверки (`gate_ready` — забота `/verify`, не Артефактора)
+- `result_kind_resolution: "unresolved"` — ни один kind реестра не подходит; классификатор НЕ подменяет ближайшим (анти-утечка в супертип)
+- `result_kind_resolution: "deferred-to-session"` — мета-триггер (например `peer_session`), kind решается внутри самого процесса, не в момент классификации
+- **stdout = CONFIG_ERROR** (exit 3) → реестр kind-ов не читается или устарел относительно `KEYWORD_MAP` (дрейф) — fail-closed, эскалировать пилоту, не игнорировать поле
 - В handoff к WP Gate передать `hypothesis_relation: "unclassified"`. До выбора
   `tests | enables | responds | researches | operational` РП остаётся pending,
   а не запускается в работу.
@@ -92,10 +101,16 @@ PY3="$(bash "$S/lib/find-python3.sh")" && "$PY3" "$S/artifactor.py" "$ARGUMENTS"
 - **stdout = JSON** (exit 0) → вернуть пилоту, стоп
 - **stdout = INSUFFICIENT_INPUT** (exit 1) → вернуть `{"error": "INSUFFICIENT_INPUT"}`, стоп
 - **stdout = NO_KEYWORD_MATCH** (exit 2) → перейти к Шагу 2
+- **stderr содержит CONFIG_ERROR** (exit 3) → реестр kind-ов недоступен или устарел (дрейф) — эскалировать пилоту одной строкой, НЕ переходить к Шагу 2 (это не «нет keyword-совпадения», а поломка конфигурации)
 
 ### Шаг 2. LLM-классификация (fallback при NO_KEYWORD_MATCH)
 
-Заполнить все 7 полей, используя правила ниже. Вернуть JSON с `resolution_path: "llm"` и `confidence: "low"`.
+Заполнить все поля, используя правила ниже. Вернуть JSON с `resolution_path: "llm"`, `confidence: "low"`, `schema_version: 3`. Для `expected_result_kind`/`result_kind_resolution` — та же логика, что у keyword-пути: подобрать `kind_id` из `PACK-digital-platform/pack/digital-platform/result-kinds-registry.yaml` по смыслу запроса; если ни один явно не подходит — `expected_result_kind: null`, `result_kind_resolution: "unresolved"` (не подменять ближайшим).
+
+**Шаг 2.0 — тип результата (WP-575 Ф2, ПЕРВЫЙ вопрос, до имени и класса).** Прежде чем формулировать `artifact`/`class`, ответить: результат этой работы будет действующей системой (агент, скрипт, сервис, MCP-инструмент, бот, автоматизация — что-то, что будет ВЫПОЛНЯТЬСЯ) или информационным объектом (документ, знание, правило, отчёт, план — что-то, что будет ЧИТАТЬСЯ)?
+- Оба признака явно присутствуют, или ни один → `result_type: "unresolved"`, не гадать (та же дисциплина, что у `result_kind_resolution: "unresolved"`).
+- Один признак явно доминирует → `result_type: "system"` или `"episteme"` соответственно.
+- Пример: «создай нового бота для X» → `system`. «напиши руководство по Y» → `episteme`. «доделай хвосты РП-N» без указания что именно осталось → `unresolved` (может оказаться и кодом, и документом).
 
 **Правила `class`:**
 
@@ -108,8 +123,9 @@ PY3="$(bash "$S/lib/find-python3.sh")" && "$PY3" "$S/artifactor.py" "$ARGUMENTS"
 
 При сомнении — выбирать более широкий класс (open-loop, не closed-loop).
 
-**Правила `artifact`:** одна строка на русском, существительное-результат.  
-Примеры: «Список тем для трёх постов», «Диагностический отчёт латентности», «ТЗ сценариев».
+**Правила `artifact`:** одна строка на русском, первое слово — существительное, обозначающее документ, систему или состояние системы (не процесс/действие над ним — «Разбор X», «Анализ X», «Проверка X» не годятся, даже когда сами по себе грамматически существительные).  
+Примеры: «Список тем для трёх постов», «Диагностический отчёт латентности», «ТЗ сценариев».  
+Не так: «Разбор 88 неразобранных коммитов» (описывает действие) → так: «Реестр неразобранных коммитов ветки X» (описывает артефакт-результат).
 
 **Общий тест «процесс → результат» (WP-7 Ф140, peer-session 2026-09-11 с Kimi+Codex).** Частные примеры выше не ловят отглагольные существительные без объекта X («Оплата», «Миграция», «Интеграция», «Синхронизация») — формально существительные, но по смыслу называют само действие. Перед тем как принять `artifact`:
 1. Подставь кандидат обратно в глагол: «Оплата»→«оплатить», «Интеграция»→«интегрировать», «Синхронизация»→«синхронизировать», «Миграция»→«мигрировать». Подстановка получилась естественной → кандидат называет процесс, не результат — отклонить.

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -361,7 +361,7 @@
     },
     {
       "path": ".claude/skills/artifactor/SKILL.md",
-      "sha256": "8380ab51fcccff08312098a39553d8a8111cce8482eb52d5bb72a41725a86e62"
+      "sha256": "1a7d8afdc028608e68d4ef5aba71417f169303c1eca86086775665f9a5224c9c"
     },
     {
       "path": ".claude/skills/audit-docs/.audit-context.yaml.example",


### PR DESCRIPTION
## Summary
- `.claude/skills/artifactor/SKILL.md` in `main` was a pre-WP-481-Ф7 version: 7-field schema, no `expected_result_kind`/`result_kind_resolution`/`schema_version`, and (separately) no `result_type` from PR #793. It was never added to `template-sync.sh`'s manifest, so it drifted silently while `scripts/artifactor.py` stayed current via its own entry.
- Not a blind copy from the author source (`iwe-local-config`) — that source is itself missing the `hypothesis_relation` section (fixed separately there), and FMT has two legitimate local improvements this merge preserves: `browser_safe` frontmatter and the python-resolver invocation (`scripts/lib/find-python3.sh`) in Шаг 1.
- Regenerated `update-manifest.json` for the changed file.

## Отдельно (не в этом PR) — и важная находка о самом гейте
Добавил `.claude/skills/artifactor/SKILL.md` в манифест `template-sync.sh` (репозиторий `DS-ai-systems`, отдельный коммит вне этого PR).

**Проверено `--dry-run` после добавления: `fmt_has_local_changes()` для этого файла возвращает `false`, не `true`.** Причина видна в её же коде (`template-sync.sh:332`): "Never delivered by sync → nothing to protect (new file for FMT)" — гейт ищет в git log коммит с префиксом `template-sync: propagate`, трогавший этот путь; такого коммита никогда не было (ни этот PR, ни #793 не были сделаны инструментом). Значит **первый же настоящий (не dry-run) прогон `template-sync.sh` после мержа этого PR молча перезапишет содержимое обратно на авторский источник — потеряются `browser_safe` и python-resolver**, а вовсе не CONFLICT, как я ошибочно написал в первой версии этого текста. Не то же самое поведение, что уже есть у `scripts/artifactor.py` (у него реальная история sync-коммитов есть, гейт работает как задуман).

Это отдельная, более общая находка о самом гейте (слепая зона на первом синке файла), не специфичная для этого файла — не стал чинить самостоятельно, это архитектурное решение о защитном механизме, а не докс-фикс.

## Test plan
- [x] Frontmatter валиден (YAML), `browser_safe: false` сохранён
- [x] JSON-схема в тексте совпадает с реальным выводом `scripts/artifactor.py` (12 полей, включая `hypothesis_relation`)
- [x] Манифест перегенерирован (`generate-manifest.sh`), только этот файл изменил хэш