### PR TITLE
fix(wp484): ship crash-safe Kimi peer lifecycle

### DIFF
--- a/scripts/kimi-peer-adapter.sh
+++ b/scripts/kimi-peer-adapter.sh
@@ -12,7 +12,9 @@
 #   IWE_PEER_DIFF_REPOS   — CSV of repos for diff (default: auto-detect from first --add-dir)
 #   IWE_PEER_DIFF_LIMIT   — soft limit for diff size in bytes (default: 61440)
 #   IWE_PEER_DIFF_PARTIAL — truncated diff size in bytes (default: 30720)
-#   IWE_PEER_INLINE       — inline files into prompt instead of --add-dir (default: 0)
+#   IWE_PEER_INLINE       — legacy compatibility switch; text-only mode always inlines
+#                           filtered context and never exposes --add-dir to Kimi
+#   IWE_PEER_HEARTBEAT_SECONDS — peer watchdog heartbeat interval (default: 120)
 #   IWE_HINDSIGHT_RETAIN  — enable hindsight L2 retain (default: 0)
 #   KIMI_BIN              — override kimi binary path
 #   KIMI_MAX_TOKENS       — hard token limit per session via guard (default: 800000)
@@ -25,17 +27,33 @@
 #   3 — PII Hard Block (sanity-check found high-severity pattern)
 #   4 — --add-dir too large (>100MB or >5000 files or >KIMI_MAX_ADD_DIR_TOKENS)
 #   5 — peer session already running (pidfile lock)
-#   6 — WP Gate блок отсутствует в peer-prompt.md (с 2026-06-09)
+#   6 — auth failure (§0в.1, WP-516 Ф5); до 12.08.2026 код 6 означал «WP Gate блок
+#       отсутствует в peer-prompt.md» — теперь этот случай возвращает 1
 #   77 — session stopped by token guard (limit exceeded)
 
 set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/peer-adapter-common.sh
+# This file runs without `set -e` (see below), so a missing/unreadable lib
+# would otherwise fall through silently and fail tens of seconds later on an
+# undefined function with a confusing, unrelated-looking error (cold review,
+# WP-524 peer-session 2026-08-16-01) — check explicitly instead.
+if ! source "$SCRIPT_DIR/lib/peer-adapter-common.sh"; then
+  echo "ERROR: cannot load $SCRIPT_DIR/lib/peer-adapter-common.sh" >&2
+  exit 1
+fi
+
+# Codex's Linux sandbox disables network for non-escalated commands; the Kimi
+# CLI cannot reach its API from there (WP-524, verified live 15.08 — the run
+# died even earlier, on the read-only semaphore path).  Fail fast, same as
+# claude-peer-adapter.sh.
+peer_adapter_check_sandbox_network "Kimi CLI" 1
 
 # Declared before cleanup_peer's trap is armed (below) so `set -u` can't fault
 # on an unset read if the script exits early, before the lock is ever attempted.
 OAUTH_LOCK_DIR="${IWE_PEER_LOCK_DIR:-/tmp/kimi-peer-locks}/kimi-oauth-refresh.lockdir"
 OAUTH_LOCK_HELD=false
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # KIMI_BIN auto-detect: env override → PATH → VS Code extension paths (macOS/Linux/WSL)
 KIMI_BIN="${KIMI_BIN:-$(command -v kimi 2>/dev/null || true)}"
@@ -57,17 +75,35 @@ if [ -z "$KIMI_BIN" ] || [ ! -x "$KIMI_BIN" ]; then
   echo "             ~/AppData/Roaming/Code/.../moonshot-ai.kimi-code (Windows)" >&2
   exit 1
 fi
+# WP-524 (Codex review): resolve to an absolute path — the disposable-workdir
+# `cd` further down (v2 text-only invocation) would otherwise break a relative
+# KIMI_BIN override.
+case "$KIMI_BIN" in
+  /*) ;;
+  *) KIMI_BIN="$(cd "$(dirname "$KIMI_BIN")" && pwd)/$(basename "$KIMI_BIN")" ;;
+esac
 
 ADD_DIRS=()
 MODEL_ARG=()
 
+# WP-516 Ф5: межвендорский whitelist (§0в.1) = {-p, --model, --add-dir}.
+# Неизвестный флаг — явная ошибка, не молчаливый игнор: иначе запрошенный
+# режим (напр. безопасности) может не примениться незаметно для вызывающего.
+# --permission-mode исключён из whitelist: способен ослабить read-only
+# гарантию sandbox; claude-адаптер отклоняет его всегда (exit 64).
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -p)                shift ;;
-    --model)           MODEL_ARG=("--model" "$2"); shift 2 ;;
-    --add-dir)         ADD_DIRS+=("$2"); shift 2 ;;
-    --permission-mode) shift 2 ;;
-    *)                 shift ;;
+    --model)
+      [ $# -ge 2 ] || { echo "ERROR: --model requires a value" >&2; exit 1; }
+      MODEL_ARG=("--model" "$2"); shift 2 ;;
+    --add-dir)
+      [ $# -ge 2 ] || { echo "ERROR: --add-dir requires a value" >&2; exit 1; }
+      ADD_DIRS+=("$2"); shift 2 ;;
+    *)
+      echo "ERROR: unknown flag '$1'. Known: -p, --model, --add-dir" >&2
+      exit 1
+      ;;
   esac
 done
 
@@ -94,7 +130,9 @@ for ADD_DIR in "${ADD_DIRS[@]+"${ADD_DIRS[@]}"}"; do
       echo "  Файл: $PEER_PROMPT_FILE" >&2
       echo "  Добавьте секцию по шаблону ~/.tmp/peer-prompt-TEMPLATE.md" >&2
       echo "  Чтобы продолжить без блока — удалите peer-prompt.md или добавьте # WP_GATE_SKIP" >&2
-      exit 6
+      # WP-516 Ф5 (§0в.1): код 6 зарезервирован под auth failure — WP-Gate
+      # возвращает общий код 1 (ранее 6, конфликтовало с каноническим контрактом).
+      exit 1
     fi
   fi
 done
@@ -102,10 +140,7 @@ done
 # === Фильтрация --add-dir через .agentigore + PII sanity-check ===
 
 FILTERED_DIRS=()
-# `mktemp -d -t PREFIX` means different things on GNU and BSD (docs/PLATFORM-COMPAT.md).
-# Passing an explicit template keeps the readable prefix and behaves the same on both —
-# identical form to codex-peer-adapter.sh.
-TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/kimi-peer-XXXXXX")
+TMP_ROOT=$(mktemp -d)
 
 # Merged .agentigore (union: ~/.iwe → git-root → session_dir)
 MERGED_AGENTIGORE="$TMP_ROOT/.agentigore"
@@ -297,8 +332,11 @@ fi
 # === Inline session files into prompt (WP-395 Ф3 performance fix) ===
 # --add-dir causes Kimi CLI to index/analyze files, taking 5+ minutes.
 # Instead, include file contents inline in the prompt — reduces time to ~10s.
-# Opt-in via IWE_PEER_INLINE=1; default uses legacy --add-dir for backward compatibility.
-if [ "${IWE_PEER_INLINE:-0}" = "1" ] && [ ${#FILTERED_DIRS[@]} -ge 2 ]; then
+# Kimi peer calls are text-only by contract: the model receives a filtered text
+# projection, never a directory it can inspect.  This also avoids the CLI's
+# expensive workspace indexing.  IWE_PEER_INLINE remains accepted only for old
+# callers; it can no longer disable the safe default.
+if [ ${#FILTERED_DIRS[@]} -ge 2 ]; then
   INLINE_FILES="$TMP_ROOT/peer-prompt.inline"
   {
     cat "$PROMPT_FILE"
@@ -331,76 +369,464 @@ if [ -z "$KIMI_TASK" ]; then
   KIMI_TASK="kimi-peer-ppid-${PPID:-$$}"
 fi
 KIMI_SESSION_ID="$KIMI_TASK"
-
-# === Peer session semaphore for watchdog visibility (WP-7 KHP2) ===
-# Peer sessions are not standalone sessions, but watchdog only scans
-# .iwe-runtime/sessions/kimi-*.open. Create a peer-specific semaphore and
-# keep a background heartbeat so a stuck peer call is detected the same way
-# as a stuck standalone session.
-IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
-SESSION_DIR="$IWE_ROOT/.iwe-runtime/sessions"
-PEER_SEM_FILE="$SESSION_DIR/kimi-peer-${KIMI_SESSION_ID//\//_}.open"
-mkdir -p "$SESSION_DIR"
+case "$KIMI_SESSION_ID" in
+  [A-Za-z0-9]* )
+    if ! [[ "$KIMI_SESSION_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+      KIMI_SESSION_ID="kimi-peer-ppid-${PPID:-$$}"
+    fi
+    ;;
+  *) KIMI_SESSION_ID="kimi-peer-ppid-${PPID:-$$}" ;;
+esac
+IWE_PEER_HEARTBEAT_SECONDS="${IWE_PEER_HEARTBEAT_SECONDS:-120}"
+case "$IWE_PEER_HEARTBEAT_SECONDS" in
+  ''|*[!0-9]*|0)
+    echo "ERROR: IWE_PEER_HEARTBEAT_SECONDS must be a positive integer." >&2
+    rm -rf "$TMP_ROOT"
+    exit 1
+    ;;
+esac
 _KIMI_SESSION_START_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-{
-  echo "opened_at: $_KIMI_SESSION_START_TIME"
-  echo "wp: WP-7"
-  echo "task: $KIMI_TASK"
-  echo "agent: kimi-peer"
-  echo "heartbeat_at: $_KIMI_SESSION_START_TIME"
-} > "$PEER_SEM_FILE"
 
-peer_heartbeat_loop() {
-  local sem="$1"
-  while [ -f "$sem" ]; do
-    {
-      echo "heartbeat_at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-      echo "heartbeat_pid: $$"
-    } >> "$sem"
-    sleep 120
-  done
-}
-peer_heartbeat_loop "$PEER_SEM_FILE" &
-PEER_HB_PID=$!
-
-# === Pidfile lock: предотвращаем параллельные/зависшие копии одной peer-сессии ===
-# Если предыдущий вызов адаптера не завершился (VS Code reconnect, SIGKILL, баг),
-# новый вызов с тем же session_id обнаружит живой PID и выйдет с ошибкой.
+# === Kernel-held exact lock for one peer-session id ===
+# The old check-then-overwrite pidfile let concurrent adapters both become
+# owners and let one cleanup unlink the other's lock.  A tiny Python helper
+# holds `flock(2)` for the adapter lifetime; owner death reparents the helper,
+# which exits and lets the kernel release the lock without stale cleanup.
 LOCK_DIR="${IWE_PEER_LOCK_DIR:-/tmp/kimi-peer-locks}"
-mkdir -p "$LOCK_DIR"
-LOCK_FILE="$LOCK_DIR/${KIMI_SESSION_ID//\//_}.pid"
+LOCK_FILE="$LOCK_DIR/${KIMI_SESSION_ID}.pid"
+SESSION_LOCK_READY="$TMP_ROOT/session-lock.ready"
+SESSION_LOCK_HELPER_PID=""
+SESSION_LOCK_HELD=false
 OUR_PID="$$"
 
-if [ -f "$LOCK_FILE" ]; then
-  OLD_PID=$(cat "$LOCK_FILE" 2>/dev/null | tr -d '[:space:]')
-  if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
-    echo "ABORT: peer session '$KIMI_SESSION_ID' already running (PID $OLD_PID)" >&2
-    exit 5
+release_session_lock() {
+  [ "$SESSION_LOCK_HELD" = true ] || return 0
+  if jobs -pr | grep -qx "$SESSION_LOCK_HELPER_PID"; then
+    kill "$SESSION_LOCK_HELPER_PID" 2>/dev/null || true
   fi
-  # stale lock — перезаписываем
+  wait "$SESSION_LOCK_HELPER_PID" 2>/dev/null || true
+  SESSION_LOCK_HELD=false
+}
+
+acquire_session_lock() {
+  local _wait status helper_rc=1
+  mkdir -p "$LOCK_DIR" || return 1
+  python3 - "$LOCK_DIR" "$LOCK_FILE" "$SESSION_LOCK_READY" "$OUR_PID" <<'PY' &
+import errno
+import fcntl
+import os
+import signal
+import stat
+import sys
+import time
+
+directory, path, ready, owner_pid_text = sys.argv[1:]
+owner_pid = int(owner_pid_text)
+
+
+def publish_status(value):
+    tmp = f"{ready}.{os.getpid()}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    out = os.open(tmp, flags, 0o600)
+    try:
+        os.write(out, (value + "\n").encode("utf-8", "replace"))
+        os.fsync(out)
+    finally:
+        os.close(out)
+    os.replace(tmp, ready)
+
+
+def process_alive(pid):
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+try:
+    os.makedirs(directory, mode=0o700, exist_ok=True)
+    directory_stat = os.lstat(directory)
+    if not stat.S_ISDIR(directory_stat.st_mode) or directory_stat.st_uid != os.getuid():
+        raise RuntimeError("unsafe peer lock directory")
+    os.chmod(directory, 0o700)
+
+    flags = os.O_RDWR | os.O_CREAT
+    flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    fd = os.open(path, flags, 0o600)
+    value = os.fstat(fd)
+    current = os.lstat(path)
+    if (not stat.S_ISREG(value.st_mode)
+            or value.st_uid != os.getuid()
+            or value.st_nlink != 1
+            or (value.st_dev, value.st_ino) != (current.st_dev, current.st_ino)):
+        raise RuntimeError("unsafe peer lock file")
+    os.fchmod(fd, 0o600)
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        if exc.errno in (errno.EACCES, errno.EAGAIN):
+            publish_status("busy")
+            raise SystemExit(5)
+        raise
+
+    # The previous owner may have unlinked this inode while we were between
+    # open() and flock(). Never hold a private, unreachable lock while another
+    # adapter owns the newly-created path.
+    current = os.lstat(path)
+    if (value.st_dev, value.st_ino) != (current.st_dev, current.st_ino):
+        publish_status("retry-boundary")
+        raise SystemExit(75)
+
+    # Compatibility with an old live adapter that wrote this same pidfile but
+    # did not yet use flock.  A dead legacy PID is stale data, not authority.
+    os.lseek(fd, 0, os.SEEK_SET)
+    previous = os.read(fd, 128).decode("ascii", "ignore").strip()
+    if previous.isdigit() and int(previous) != owner_pid and process_alive(int(previous)):
+        publish_status("busy-legacy")
+        raise SystemExit(5)
+
+    os.ftruncate(fd, 0)
+    os.lseek(fd, 0, os.SEEK_SET)
+    os.write(fd, f"{owner_pid}\n".encode("ascii"))
+    os.fsync(fd)
+    publish_status("acquired")
+
+    def request_stop(_signum, _frame):
+        nonlocal_stop[0] = True
+
+    nonlocal_stop = [False]
+    signal.signal(signal.SIGHUP, request_stop)
+    signal.signal(signal.SIGINT, request_stop)
+    signal.signal(signal.SIGTERM, request_stop)
+    while not nonlocal_stop[0] and os.getppid() == owner_pid:
+        try:
+            linked = os.lstat(path)
+            os.lseek(fd, 0, os.SEEK_SET)
+            payload = os.read(fd, 128).decode("ascii", "ignore").strip()
+            if ((linked.st_dev, linked.st_ino) != (value.st_dev, value.st_ino)
+                    or payload != str(owner_pid)):
+                os.kill(owner_pid, signal.SIGTERM)
+                break
+        except (FileNotFoundError, ProcessLookupError):
+            break
+        time.sleep(0.1)
+except SystemExit:
+    raise
+except Exception as exc:
+    try:
+        publish_status(f"error:{type(exc).__name__}")
+    except Exception:
+        pass
+    raise SystemExit(1)
+finally:
+    # Remove only the path that still names our locked inode and still carries
+    # our owner PID. A replacement created by another process is preserved.
+    try:
+        if "fd" in locals():
+            linked = os.lstat(path)
+            value = os.fstat(fd)
+            os.lseek(fd, 0, os.SEEK_SET)
+            payload = os.read(fd, 128).decode("ascii", "ignore").strip()
+            if ((linked.st_dev, linked.st_ino) == (value.st_dev, value.st_ino)
+                    and payload == str(owner_pid)):
+                os.unlink(path)
+    except (FileNotFoundError, OSError):
+        pass
+PY
+  SESSION_LOCK_HELPER_PID=$!
+
+  for _wait in $(seq 1 100); do
+    [ -s "$SESSION_LOCK_READY" ] && break
+    kill -0 "$SESSION_LOCK_HELPER_PID" 2>/dev/null || break
+    sleep 0.05
+  done
+  status="$(cat "$SESSION_LOCK_READY" 2>/dev/null || true)"
+  case "$status" in
+    acquired)
+      SESSION_LOCK_HELD=true
+      return 0
+      ;;
+    busy|busy-legacy)
+      wait "$SESSION_LOCK_HELPER_PID" 2>/dev/null || helper_rc=$?
+      echo "ABORT: peer session '$KIMI_SESSION_ID' already running." >&2
+      [ "$helper_rc" -eq 5 ] && return 5
+      return 1
+      ;;
+    *)
+      if jobs -pr | grep -qx "$SESSION_LOCK_HELPER_PID"; then
+        kill "$SESSION_LOCK_HELPER_PID" 2>/dev/null || true
+      fi
+      wait "$SESSION_LOCK_HELPER_PID" 2>/dev/null || helper_rc=$?
+      echo "ERROR: cannot acquire exact peer-session lock for '$KIMI_SESSION_ID' (${status:-no status}, rc=$helper_rc)." >&2
+      return 1
+      ;;
+  esac
+}
+
+acquire_session_lock
+SESSION_LOCK_RC=$?
+if [ "$SESSION_LOCK_RC" -ne 0 ]; then
+  rm -rf "$TMP_ROOT"
+  exit "$SESSION_LOCK_RC"
 fi
-echo "$OUR_PID" > "$LOCK_FILE"
 
 # agent-status-report.sh — DRY path, fail-safe if missing (e.g. standalone test)
 _IWE_ARS="$HOME/IWE/scripts/agent-status-report.sh"
 
+# Peer calls need watchdog visibility, but they are not session-guard sessions.
+# Keep their beacons outside the authoritative `sessions/*.open` namespace so
+# a status aid can never become a malformed admission barrier.  The pid lock is
+# acquired first: a rejected duplicate must not overwrite the live owner's
+# beacon or leave a background heartbeat behind.
+IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
+PEER_HEARTBEAT_DIR="$IWE_ROOT/.iwe-runtime/peer-heartbeats"
+PEER_HEARTBEAT_FILE="$PEER_HEARTBEAT_DIR/kimi-peer-${KIMI_SESSION_ID}.heartbeat"
+PEER_HEARTBEAT_DEV=""
+PEER_HEARTBEAT_INO=""
+PEER_HB_PID=""
+PEER_HEARTBEAT_READY="$TMP_ROOT/peer-heartbeat.ready"
+
+create_peer_heartbeat() {
+  local identity
+  identity=$(python3 - "$PEER_HEARTBEAT_DIR" "$PEER_HEARTBEAT_FILE" "$KIMI_TASK" \
+    "$OUR_PID" <<'PY'
+import datetime
+import os
+import stat
+import sys
+import uuid
+
+directory, path, task, owner_pid = sys.argv[1:]
+os.makedirs(directory, mode=0o700, exist_ok=True)
+directory_stat = os.lstat(directory)
+if (not stat.S_ISDIR(directory_stat.st_mode)
+        or directory_stat.st_uid != os.getuid()):
+    raise SystemExit("unsafe peer heartbeat directory")
+os.chmod(directory, 0o700)
+
+task = task.replace("\r", " ").replace("\n", " ")
+opened_at = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+try:
+    fd = os.open(path, flags, 0o600)
+except FileExistsError:
+    # The exact session lock proves there is no current owner. Preserve stale
+    # evidence under a no-clobber name, then allocate a fresh inode. An orphan
+    # loop holding the old dev:ino can no longer delete the new owner's beacon.
+    old = os.lstat(path)
+    if (not stat.S_ISREG(old.st_mode)
+            or old.st_uid != os.getuid()
+            or old.st_nlink != 1):
+        raise RuntimeError("unsafe existing peer heartbeat file")
+    stale = f"{path}.stale.{uuid.uuid4().hex}"
+    os.rename(path, stale)
+    fd = os.open(path, flags, 0o600)
+try:
+    value = os.fstat(fd)
+    current = os.lstat(path)
+    if (not stat.S_ISREG(value.st_mode)
+            or value.st_uid != os.getuid()
+            or value.st_nlink != 1
+            or (value.st_dev, value.st_ino) != (current.st_dev, current.st_ino)):
+        raise RuntimeError("unsafe peer heartbeat file")
+    os.fchmod(fd, 0o600)
+    os.ftruncate(fd, 0)
+    payload = (
+        f"opened_at: {opened_at}\n"
+        "wp: WP-7\n"
+        f"task: {task}\n"
+        "agent: kimi-peer\n"
+        f"owner_pid: {owner_pid}\n"
+        f"heartbeat_at: {opened_at}\n"
+    ).encode("utf-8")
+    os.write(fd, payload)
+    os.fsync(fd)
+    print(f"{value.st_dev} {value.st_ino}")
+finally:
+    os.close(fd)
+PY
+  ) || return 1
+  read -r PEER_HEARTBEAT_DEV PEER_HEARTBEAT_INO <<EOF
+$identity
+EOF
+  [ -n "$PEER_HEARTBEAT_DEV" ] && [ -n "$PEER_HEARTBEAT_INO" ]
+}
+
+remove_peer_heartbeat() {
+  python3 - "$PEER_HEARTBEAT_FILE" "$PEER_HEARTBEAT_DEV" "$PEER_HEARTBEAT_INO" <<'PY'
+import os
+import stat
+import sys
+
+path, expected_dev, expected_ino = sys.argv[1:]
+try:
+    value = os.lstat(path)
+except FileNotFoundError:
+    raise SystemExit(0)
+if (not stat.S_ISREG(value.st_mode)
+        or value.st_uid != os.getuid()
+        or value.st_nlink != 1
+        or (value.st_dev, value.st_ino) != (int(expected_dev), int(expected_ino))):
+    raise SystemExit("peer heartbeat identity changed; preserving replacement")
+os.unlink(path)
+PY
+}
+
+start_peer_heartbeat() {
+  python3 - "$PEER_HEARTBEAT_FILE" "$PEER_HEARTBEAT_DEV" "$PEER_HEARTBEAT_INO" \
+    "$OUR_PID" "$IWE_PEER_HEARTBEAT_SECONDS" "$PEER_HEARTBEAT_READY" <<'PY' &
+import datetime
+import os
+import signal
+import stat
+import sys
+import threading
+import time
+
+path, expected_dev, expected_ino, owner_pid_text, interval_text, ready = sys.argv[1:]
+expected_identity = (int(expected_dev), int(expected_ino))
+owner_pid = int(owner_pid_text)
+interval = int(interval_text)
+stop = threading.Event()
+
+
+def request_stop(_signum, _frame):
+    stop.set()
+
+
+for watched_signal in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(watched_signal, request_stop)
+
+flags = os.O_WRONLY | os.O_APPEND
+flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+fd = os.open(path, flags)
+try:
+    value = os.fstat(fd)
+    if (not stat.S_ISREG(value.st_mode)
+            or value.st_uid != os.getuid()
+            or value.st_nlink != 1
+            or (value.st_dev, value.st_ino) != expected_identity):
+        raise RuntimeError("peer heartbeat identity changed")
+
+    ready_fd = os.open(
+        ready,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+        0o600,
+    )
+    try:
+        os.write(ready_fd, b"ready\n")
+        os.fsync(ready_fd)
+    finally:
+        os.close(ready_fd)
+
+    next_write = 0.0
+    while not stop.is_set() and os.getppid() == owner_pid:
+        try:
+            current = os.lstat(path)
+        except FileNotFoundError:
+            break
+        if (current.st_dev, current.st_ino) != expected_identity:
+            break
+        now_monotonic = time.monotonic()
+        if now_monotonic >= next_write:
+            now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            os.write(fd, f"heartbeat_at: {now}\nheartbeat_pid: {owner_pid}\n".encode("ascii"))
+            os.fsync(fd)
+            next_write = now_monotonic + interval
+        remaining = max(0.01, next_write - time.monotonic())
+        stop.wait(min(1.0, remaining))
+finally:
+    os.close(fd)
+    try:
+        current = os.lstat(path)
+        if (current.st_dev, current.st_ino) == expected_identity:
+            os.unlink(path)
+    except FileNotFoundError:
+        pass
+PY
+  PEER_HB_PID=$!
+  local _wait
+  for _wait in $(seq 1 100); do
+    [ -s "$PEER_HEARTBEAT_READY" ] && return 0
+    jobs -pr | grep -qx "$PEER_HB_PID" || break
+    sleep 0.05
+  done
+  if jobs -pr | grep -qx "$PEER_HB_PID"; then
+    kill "$PEER_HB_PID" 2>/dev/null || true
+  fi
+  wait "$PEER_HB_PID" 2>/dev/null || true
+  return 1
+}
+
 # Cleanup: удалить lock + перевести статус в idle при любом выходе
+CLEANUP_PEER_STARTED=false
 cleanup_peer() {
-  rm -f "$LOCK_FILE"
+  local hb_reap_guard
+  [ "$CLEANUP_PEER_STARTED" = false ] || return 0
+  CLEANUP_PEER_STARTED=true
   [ -x "$_IWE_ARS" ] && bash "$_IWE_ARS" --session-id "$KIMI_SESSION_ID" kimi idle 2>/dev/null &
-  # Stop peer heartbeat and remove watchdog semaphore
-  kill "$PEER_HB_PID" 2>/dev/null || true
-  rm -f "$PEER_SEM_FILE"
+  # Stop and reap the direct heartbeat helper. It checks the adapter's exact
+  # parent relationship itself, so SIGKILL of the adapter also makes it exit.
+  # The bounded reap guard prevents an unexpected helper fault from hanging
+  # this EXIT trap.
+  if [ -n "$PEER_HB_PID" ]; then
+    if jobs -pr | grep -qx "$PEER_HB_PID"; then
+      kill "$PEER_HB_PID" 2>/dev/null || true
+      ( sleep 5; kill -9 "$PEER_HB_PID" 2>/dev/null ) &
+      hb_reap_guard=$!
+    else
+      hb_reap_guard=""
+    fi
+    wait "$PEER_HB_PID" 2>/dev/null || true
+    [ -z "$hb_reap_guard" ] || kill "$hb_reap_guard" 2>/dev/null || true
+  fi
+  if [ -n "$PEER_HEARTBEAT_DEV" ] && [ -n "$PEER_HEARTBEAT_INO" ]; then
+    remove_peer_heartbeat 2>/dev/null || true
+  fi
+  release_session_lock
   rm -rf "$TMP_ROOT"
   # Only release the OAuth-refresh lock if this invocation actually holds it —
   # an invocation that gave up waiting must never remove the winner's lock.
   # rm -rf, not rmdir: the lock dir holds a pid file (staleness check), not empty.
   [ "$OAUTH_LOCK_HELD" = true ] && rm -rf "$OAUTH_LOCK_DIR" 2>/dev/null
+  return 0
 }
-trap cleanup_peer EXIT INT TERM
+trap cleanup_peer EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if ! create_peer_heartbeat; then
+  echo "ERROR: cannot create owned peer heartbeat in $PEER_HEARTBEAT_DIR" >&2
+  exit 1
+fi
+if ! start_peer_heartbeat; then
+  echo "ERROR: peer heartbeat helper failed to start." >&2
+  exit 1
+fi
+
 [ -x "$_IWE_ARS" ] && bash "$_IWE_ARS" --session-id "$KIMI_SESSION_ID" kimi peer-session "$KIMI_TASK" 2>/dev/null &
 
-# === Запуск Kimi с inline prompt + guard + 5min timeout (perl alarm) ===
+# === Запуск Kimi with process-group deadline ===
+# `perl alarm; exec` used to signal only the CLI launcher.  If Kimi had spawned
+# an MCP/tool child, the child could survive and hold the writer indefinitely.
+# The supervisor below starts the CLI in its own session and terminates that
+# entire process group when the deadline expires (WP-516).
+IWE_PEER_TIMEOUT_SECONDS="${IWE_PEER_TIMEOUT_SECONDS:-300}"
+case "$IWE_PEER_TIMEOUT_SECONDS" in
+  ''|*[!0-9]*|0)
+    echo "ERROR: IWE_PEER_TIMEOUT_SECONDS must be a positive integer." >&2
+    exit 64
+    ;;
+esac
+
+# run_with_deadline() — see scripts/lib/peer-adapter-common.sh (sourced above).
+
 GUARD_BIN="${SCRIPT_DIR}/kimi-session-guard.sh"
 [ ! -x "$GUARD_BIN" ] && GUARD_BIN="${HOME}/.iwe/kimi-session-guard.sh"
 GUARD_ARGS=()
@@ -408,15 +834,18 @@ if [ -x "$GUARD_BIN" ]; then
   GUARD_ARGS=("$GUARD_BIN" --max-tokens "${KIMI_MAX_TOKENS:-800000}" --)
 fi
 
-# === Kimi CLI style detect (kimi-code >=0.29 dropped --quiet and stdin prompt mode) ===
-# Legacy CLI: prompt via stdin, flags --quiet --yolo.
-# New CLI (kimi-code): prompt ONLY as -p argument (stdin is ignored, '-' is literal),
-# -p is mutually exclusive with --yolo/--auto; response is extracted from
-# --output-format stream-json, because text mode mixes reasoning bullets into stdout.
-if "$KIMI_BIN" --help 2>/dev/null | grep -q -- '--quiet'; then
-  KIMI_CLI_STYLE="legacy"
-else
+# === Kimi CLI style detect ===
+# `--quiet` is no longer a reliable legacy marker: current kimi-code retains it
+# as an alias while supporting the modern `--agent-file` API.  The latter is
+# required for the no-tools profile below, so it is the capability probe.
+# Legacy CLI: prompt via stdin, flags --quiet --yolo.  Modern CLI: `-p` plus
+# `--agent-file`, stream-json, and no auto-approved tools.
+KIMI_HELP_FILE="$TMP_ROOT/kimi-help.txt"
+"$KIMI_BIN" --help > "$KIMI_HELP_FILE" 2>/dev/null || true
+if grep -q -- '--agent-file' "$KIMI_HELP_FILE"; then
   KIMI_CLI_STYLE="prompt-arg"
+else
+  KIMI_CLI_STYLE="legacy"
 fi
 
 KIMI_STDERR="$TMP_ROOT/kimi.stderr"
@@ -435,23 +864,73 @@ if [ "$KIMI_CLI_STYLE" = "prompt-arg" ]; then
   fi
   # A model alias missing from the new CLI's config.toml fails the whole call
   # (config.invalid) — drop unknown aliases and fall back to default_model.
-  KIMI_CODE_CFG="$HOME/.kimi-code/config.toml"
+  # kimi-code itself loads ~/.kimi/config.toml (not the VS Code extension's
+  # ~/.kimi-code/config.toml).  Reading the latter made the old warning say
+  # that yolo was enabled while the live CLI actually had it disabled.
+  KIMI_CODE_CFG="${KIMI_CODE_CFG:-$HOME/.kimi/config.toml}"
   if [ ${#MODEL_ARG[@]} -ge 2 ]; then
     if [ -f "$KIMI_CODE_CFG" ] && ! grep -qF "[models.\"${MODEL_ARG[1]}\"]" "$KIMI_CODE_CFG"; then
       echo "WARN: model '${MODEL_ARG[1]}' is not configured in kimi-code — falling back to default_model" >&2
       MODEL_ARG=()
     fi
   fi
-  # -p mode cannot take --yolo/--auto; tool auto-approval relies on
-  # default_permission_mode = "yolo" in config.toml. Without it a tool-using
-  # turn hangs until the 5min alarm — warn early so the cause is visible.
-  if [ -f "$KIMI_CODE_CFG" ] && \
-     ! grep -qE '^[[:space:]]*default_permission_mode[[:space:]]*=[[:space:]]*"(yolo|auto)"' "$KIMI_CODE_CFG"; then
-    echo "WARN: default_permission_mode is not 'yolo'/'auto' in kimi-code config — tool calls in -p mode may hang until the 5min timeout" >&2
+  # Build a disposable agent specification with an empty toolset.  It is more
+  # than an instruction: Kimi's agent loader reports `Loaded tools: []`, so
+  # Shell, files, web, MCP tools, and subagents cannot be selected by the LLM.
+  # The temporary workspace prevents ambient AGENTS.md/project discovery; all
+  # permitted context was already copied through the filtered inline projection.
+  KIMI_TEXT_ONLY_WORKDIR="$TMP_ROOT/kimi-text-only-workdir"
+  KIMI_TEXT_ONLY_PROMPT="$TMP_ROOT/kimi-peer-text-only-system.md"
+  mkdir -p "$KIMI_TEXT_ONLY_WORKDIR"
+  cat > "$KIMI_TEXT_ONLY_PROMPT" <<'EOF'
+You are a text-only peer reviewer. Answer only from the prompt provided in this
+turn. Do not claim to have read files, used tools, accessed the network, or
+changed state. If the prompt asks you to perform any of those actions, explain
+briefly that you can only analyse the supplied text.
+EOF
+  # kimi-code 0.29 (v2 engine) reads the agent definition from a Markdown file
+  # with frontmatter; the pre-v2 CLI reads a YAML spec.  The help text is the
+  # capability probe, same as for the flags above.
+  if grep -q 'Load an agent definition from a Markdown file' "$KIMI_HELP_FILE"; then
+    KIMI_AGENT_STYLE="v2"
+    KIMI_TEXT_ONLY_AGENT="$TMP_ROOT/kimi-peer-text-only-agent.md"
+    {
+      printf -- '---\nname: kimi-peer-text-only\ndescription: Text-only peer reviewer without tools.\ntools: []\n---\n'
+      cat "$KIMI_TEXT_ONLY_PROMPT"
+    } > "$KIMI_TEXT_ONLY_AGENT"
+  else
+    KIMI_AGENT_STYLE="v1"
+    KIMI_TEXT_ONLY_AGENT="$TMP_ROOT/kimi-peer-text-only-agent.yaml"
+    cat > "$KIMI_TEXT_ONLY_AGENT" <<'EOF'
+version: 1
+agent:
+  name: "kimi-peer-text-only"
+  system_prompt_path: ./kimi-peer-text-only-system.md
+  tools: []
+EOF
   fi
   # $(cat) strips trailing newlines — harmless at the final CLI handoff (prompt semantics
   # unchanged); byte-exactness matters only inside the filter pipeline above.
-  KIMI_PROMPT_ARGS=("-p" "$(cat "$PROMPT_FILE")" "--print" "--output-format" "stream-json")
+  # kimi-code 0.29 dropped --work-dir, --no-thinking, --max-steps-per-turn and
+  # --print (WP-524, 15.08).  Each of them is passed only while the installed
+  # CLI still documents it, so older versions keep their original semantics;
+  # the workspace isolation itself is version-proof — the invocation below
+  # cd's into the disposable workdir.
+  kimi_cli_supports() { grep -q -- "$1" "$KIMI_HELP_FILE"; }
+  KIMI_PROMPT_ARGS=()
+  kimi_cli_supports '--work-dir' && KIMI_PROMPT_ARGS+=("--work-dir" "$KIMI_TEXT_ONLY_WORKDIR")
+  kimi_cli_supports '--no-thinking' && KIMI_PROMPT_ARGS+=("--no-thinking")
+  kimi_cli_supports '--max-steps-per-turn' && KIMI_PROMPT_ARGS+=("--max-steps-per-turn" "1")
+  KIMI_PROMPT_ARGS+=(
+    "--agent-file" "$KIMI_TEXT_ONLY_AGENT"
+    "-p" "$(cat "$PROMPT_FILE")"
+    "--output-format" "stream-json"
+  )
+  kimi_cli_supports '--print' && KIMI_PROMPT_ARGS+=("--print")
+else
+  echo "ERROR: installed Kimi CLI lacks --agent-file; refusing an unsafe legacy peer invocation." >&2
+  echo "  Upgrade Kimi CLI to a version that supports a no-tools agent profile." >&2
+  exit 1
 fi
 
 # OAuth-refresh lock: all Kimi processes on this machine share one token file
@@ -499,14 +978,19 @@ if ! acquire_oauth_lock; then
   exit 1
 fi
 
-# Inline mode: prompt already contains the files, --add-dir not needed
+# Text-only mode always inlines the filtered context.  Passing --add-dir would
+# re-expose a workspace even though the no-tools profile does not need it.
 KIMI_DIR_ARGS=()
-if [ "${IWE_PEER_INLINE:-0}" != "1" ]; then
-  KIMI_DIR_ARGS=(${FILTERED_DIRS[@]+"${FILTERED_DIRS[@]}"})
-fi
 
 if [ "$KIMI_CLI_STYLE" = "prompt-arg" ]; then
-  KIMI_RAW=$(perl -e 'alarm 300; exec @ARGV' -- \
+  # kimi-code 0.29 gates --agent-file behind the v2 engine, enabled by this
+  # env var.  Set it only for the v2 agent format (peer-session 2026-08-15-05,
+  # Codex review): an experimental flag may change more than the gate, so a
+  # pre-v2 CLI must not receive it.
+  if [ "$KIMI_AGENT_STYLE" = "v2" ]; then
+    export KIMI_CODE_EXPERIMENTAL_FLAG=1
+  fi
+  KIMI_RAW=$(cd "$KIMI_TEXT_ONLY_WORKDIR" && run_with_deadline "$IWE_PEER_TIMEOUT_SECONDS" \
     "${GUARD_ARGS[@]+"${GUARD_ARGS[@]}"}" "$KIMI_BIN" \
     "${KIMI_PROMPT_ARGS[@]}" \
     ${MODEL_ARG[@]+"${MODEL_ARG[@]}"} \
@@ -514,7 +998,7 @@ if [ "$KIMI_CLI_STYLE" = "prompt-arg" ]; then
     < /dev/null \
     2>"$KIMI_STDERR")
 else
-  KIMI_RAW=$(perl -e 'alarm 300; exec @ARGV' -- \
+  KIMI_RAW=$(run_with_deadline "$IWE_PEER_TIMEOUT_SECONDS" \
     "${GUARD_ARGS[@]+"${GUARD_ARGS[@]}"}" "$KIMI_BIN" --quiet --yolo \
     ${MODEL_ARG[@]+"${MODEL_ARG[@]}"} \
     ${KIMI_DIR_ARGS[@]+"${KIMI_DIR_ARGS[@]}"} \
@@ -526,14 +1010,29 @@ fi
 # (verified empirically in peer-session 2026-07-01-31-oauth-refresh-regression).
 PERL_EXIT=$?
 
+adapter_diagnostic() {
+  local cli_exit="$1"
+  local stdout_bytes stderr_bytes
+  stdout_bytes=$(printf '%s' "$KIMI_RAW" | wc -c | tr -d '[:space:]')
+  stderr_bytes=$(wc -c < "$KIMI_STDERR" | tr -d '[:space:]')
+  printf 'DIAGNOSTIC: vendor=kimi cli_exit=%s timeout_seconds=%s stdout_bytes=%s stderr_bytes=%s\n' \
+    "$cli_exit" "$IWE_PEER_TIMEOUT_SECONDS" "$stdout_bytes" "$stderr_bytes" >&2
+}
+
 if [ "$KIMI_CLI_STYLE" = "prompt-arg" ]; then
   # stream-json: keep only assistant text; meta lines (resume hint) drop out naturally.
   # Exit 10 = input WAS JSON but held no assistant text (e.g. CLI retry loop died
   # mid-turn with only meta/tool events) — that is "no answer", not format drift.
+  # Unparsable lines are counted and reported, never dropped in silence (WP-524
+  # F6, peer-session 2026-09-05-28): the transport is NDJSON, so a corrupted
+  # line costs a WHOLE assistant message, not a character — and a reply that
+  # arrives short but well-formed is indistinguishable from a complete one.
   KIMI_OUTPUT=$(printf '%s\n' "$KIMI_RAW" | python3 -c '
 import json, sys
 parts = []
 saw_json = False
+corrupt = 0
+noise = 0
 for line in sys.stdin:
     line = line.strip()
     if not line:
@@ -541,6 +1040,13 @@ for line in sys.stdin:
     try:
         evt = json.loads(line)
     except ValueError:
+        # A line that starts with "{" was meant to be an NDJSON record, so it is
+        # a lost message. Anything else is CLI noise (banners, node warnings) and
+        # must not cry wolf, or the real warning stops being read.
+        if line.startswith("{"):
+            corrupt += 1
+        else:
+            noise += 1
         continue
     saw_json = True
     if evt.get("role") != "assistant":
@@ -553,6 +1059,16 @@ for line in sys.stdin:
             if isinstance(block, dict) and block.get("type") == "text":
                 parts.append(block.get("text", ""))
 text = "\n".join(p for p in parts if p)
+if corrupt and text:
+    # Own marker, not a bare "WARNING:" — the adapter already emits unrelated
+    # WARNING lines (language check), and a caller grepping for those would cry
+    # wolf on every reply that is mostly YAML.
+    sys.stderr.write(
+        "INTEGRITY-WARNING: %d stream-json record(s) failed to parse while the reply "
+        "came back non-empty — the reply may be missing a whole message.\n" % corrupt
+    )
+elif corrupt or noise:
+    sys.stderr.write("DIAGNOSTIC: corrupt_json_lines=%d noise_lines=%d\n" % (corrupt, noise))
 sys.stdout.write(text)
 sys.exit(10 if (saw_json and not text) else 0)
 ')
@@ -583,6 +1099,7 @@ if [ "$PERL_EXIT" -eq 75 ]; then
     echo "--- kimi stderr (tail) ---" >&2
     tail -20 "$KIMI_STDERR" >&2
   fi
+  adapter_diagnostic "$PERL_EXIT"
   exit 1
 fi
 
@@ -590,13 +1107,23 @@ fi
 if [ "$PERL_EXIT" -eq 77 ]; then
   echo "ERROR: Kimi session stopped by token guard (limit ${KIMI_MAX_TOKENS:-800000} exceeded)." >&2
   echo "  Tip: reduce --add-dir size, split task, or raise KIMI_MAX_TOKENS." >&2
+  adapter_diagnostic "$PERL_EXIT"
   exit 1
 fi
 
 # Timeout guard
 if [ "$PERL_EXIT" -eq 142 ]; then
-  echo "ERROR: Kimi peer call timed out after 5 minutes (SIGALRM)" >&2
-  echo "KIMI_TIMEOUT: peer call exceeded 5min limit — check for Unicode issues or network problems" >&2
+  echo "ERROR: Kimi peer call timed out after ${IWE_PEER_TIMEOUT_SECONDS}s; its process group was terminated." >&2
+  echo "KIMI_TIMEOUT: peer call exceeded configured deadline" >&2
+  [ -s "$KIMI_STDERR" ] && tail -20 "$KIMI_STDERR" >&2
+  adapter_diagnostic "$PERL_EXIT"
+  exit 1
+fi
+
+if [ "$PERL_EXIT" -ne 0 ]; then
+  echo "ERROR: Kimi peer call failed with exit code $PERL_EXIT." >&2
+  [ -s "$KIMI_STDERR" ] && tail -20 "$KIMI_STDERR" >&2
+  adapter_diagnostic "$PERL_EXIT"
   exit 1
 fi
 
@@ -607,6 +1134,7 @@ if [ -z "$KIMI_OUTPUT" ]; then
     echo "--- kimi stderr (tail) ---" >&2
     tail -5 "$KIMI_STDERR" >&2
   fi
+  adapter_diagnostic "$PERL_EXIT"
   exit 1
 fi
 
@@ -658,6 +1186,16 @@ with open(path, "a", encoding="utf-8") as f:
     f.write(json.dumps(rec, ensure_ascii=False) + "\n")
 PYEOF
 } 2>/dev/null &
+
+# WP-516 Ф5 (§0в.1): stdout обязан начинаться с frontmatter; ответ без
+# frontmatter = нарушение формата → exit 1 с диагностикой.
+# Проверка — для peer-реплик turn-loop. Служебные вызовы писателя
+# (review/verify/synth), чей вывод — НЕ peer-реплика, отключают её
+# через IWE_PEER_PLAIN=1 (слой IWE-интеграции, §0в.1).
+if [ "${IWE_PEER_PLAIN:-0}" != "1" ]; then
+  peer_adapter_check_frontmatter "$KIMI_OUTPUT"
+  peer_adapter_check_language "$KIMI_OUTPUT"
+fi
 
 # cleanup_peer() через trap переведёт статус в idle и удалит lock
 echo "$KIMI_OUTPUT"

--- a/scripts/kimi-session-watchdog.sh
+++ b/scripts/kimi-session-watchdog.sh
@@ -2,8 +2,8 @@
 #
 # kimi-session-watchdog.sh
 # External mechanical guard against silent/hung Kimi sessions.
-# Monitors active Kimi semaphores and alerts the pilot if the agent
-# has not sent a heartbeat within 180 seconds.
+# Formal sessions and observational peer beacons use separate namespaces:
+# only formal `sessions/*.open` files participate in session-guard admission.
 #
 # Run manually:
 #   bash scripts/kimi-session-watchdog.sh
@@ -13,10 +13,35 @@ set -euo pipefail
 
 IWE_ROOT="${IWE_ROOT:-$HOME/IWE}"
 SESSION_DIR="$IWE_ROOT/.iwe-runtime/sessions"
-SILENCE_THRESHOLD_S=180
-CHECK_INTERVAL_S=60
+PEER_HEARTBEAT_DIR="$IWE_ROOT/.iwe-runtime/peer-heartbeats"
+SILENCE_THRESHOLD_S="${SILENCE_THRESHOLD_S:-180}"
+CHECK_INTERVAL_S="${CHECK_INTERVAL_S:-60}"
+
+require_positive_integer() {
+  local name="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9]*|0)
+      echo "ERROR: $name must be a positive integer." >&2
+      return 1
+      ;;
+  esac
+}
+
+require_positive_integer SILENCE_THRESHOLD_S "$SILENCE_THRESHOLD_S"
+require_positive_integer CHECK_INTERVAL_S "$CHECK_INTERVAL_S"
 
 now_epoch() { date +%s; }
+
+mac_notify() {
+  local msg="$1" subtitle="$2"
+  # Both fields become AppleScript string literals. Escape slash first so the
+  # quote escaping itself cannot be neutralized by caller-controlled text.
+  msg=${msg//\\/\\\\}; msg=${msg//\"/\\\"}
+  subtitle=${subtitle//\\/\\\\}; subtitle=${subtitle//\"/\\\"}
+  if command -v osascript >/dev/null 2>&1; then
+    osascript -e "display notification \"$msg\" with title \"IWE Kimi Watchdog\" subtitle \"$subtitle\" sound name \"Purr\"" 2>/dev/null || true
+  fi
+}
 
 notify_pilot() {
   local session_file="$1"
@@ -27,10 +52,7 @@ notify_pilot() {
 
   local msg="Kimi молчит ${age}s в WP:${wp}. Возможно, зависание."
 
-  # macOS notification center
-  if command -v osascript >/dev/null 2>&1; then
-    osascript -e "display notification \"$msg\" with title \"IWE Kimi Watchdog\" subtitle \"$task\" sound name \"Purr\"" 2>/dev/null || true
-  fi
+  mac_notify "$msg" "$task"
 
   # Also append to a local alert log
   echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ") | $msg | $session_file" >> "$IWE_ROOT/.iwe-runtime/logs/kimi-watchdog.log"
@@ -57,15 +79,39 @@ latest_heartbeat_age() {
   echo "$((now - hb_epoch))"
 }
 
+check_heartbeat_file() {
+  local session="$1"
+  local age
+  age="$(latest_heartbeat_age "$session")"
+  if [ "$age" -gt "$SILENCE_THRESHOLD_S" ]; then
+    notify_pilot "$session" "$age"
+  fi
+}
+
+scan_once() {
+  local session
+  for session in "$SESSION_DIR"/kimi-*.open; do
+    [ -f "$session" ] && [ ! -L "$session" ] || continue
+    check_heartbeat_file "$session"
+  done
+
+  # Peer calls need watchdog visibility, but their liveness hints must never
+  # masquerade as formal sessions or become an admission/commit barrier.
+  for session in "$PEER_HEARTBEAT_DIR"/kimi-peer-*.heartbeat; do
+    [ -f "$session" ] && [ ! -L "$session" ] || continue
+    check_heartbeat_file "$session"
+  done
+}
+
+run_forever() {
+  while true; do
+    scan_once
+    sleep "$CHECK_INTERVAL_S"
+  done
+}
+
 mkdir -p "$IWE_ROOT/.iwe-runtime/logs"
 
-while true; do
-  for session in "$SESSION_DIR"/kimi-*.open; do
-    [ -f "$session" ] || continue
-    age="$(latest_heartbeat_age "$session")"
-    if [ "$age" -gt "$SILENCE_THRESHOLD_S" ]; then
-      notify_pilot "$session" "$age"
-    fi
-  done
-  sleep "$CHECK_INTERVAL_S"
-done
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  run_forever
+fi

--- a/scripts/lib/language-check.py
+++ b/scripts/lib/language-check.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Alert-only проверка: финальный ответ пилоту вышел не на русском.
+
+WP-484 Ф89 (11.08) — дважды за одну сессию финальный ответ вышел на
+английском после плотного англоязычного технического участка (git log/diff,
+commit-хэши, промпты внешним агентам). Второй раз — сразу после того, как
+первый эпизод был зафиксирован в память той же сессии: текстовое правило без
+механической проверки не сработало дважды подряд.
+
+Модель (peer-session 2026-08-12-06-wp484-watchdog-lang-check, ходы 11-12):
+вырезать fenced/inline код, URL, файловые пути перед подсчётом — они всегда
+латиница и не относятся к вопросу «на каком языке написан ОТВЕТ». Скобки
+вырезаются не целиком: A2 (inject-communication-style.sh) требует английские
+термины ПОСЛЕ русского описания в скобках — «переход на новую версию марафона
+(РП330)» — но кириллические asides в скобках («см. выше», «например, на
+тесте всё ок») тоже частый паттерн, и их вырезание убирало бы кириллический
+сигнал, а не английский термин. Классификатор оценивает КАЖДЫЙ top-level
+скобочный блок целиком (>50% латиницы внутри всего блока, включая любую
+вложенность, → это глосса, вырезать; иначе — обычный текст, оставить) — не
+рекурсивный спуск по уровням вложенности. Known limitation (peer-session
+ход 17, сознательно принято как advisory-инструмент, не автокорректор):
+вложенный смешанный случай "(важное значение (important meaning) объяснение)"
+может дать неверную классификацию всего блока, если внешний и внутренний
+уровень имеют разный язык — вложенность на практике редка, а ложный alert
+стоит лишнего просмотра, не потери данных.
+
+Использование:
+    echo "$текст" | python3 language-check.py
+    → JSON {"alert": bool, "ratio": float, "reason": str} в stdout
+
+Alert-only: вызывающий код решает, что делать с сигналом (лог,
+additionalContext, .err) — этот модуль никогда не блокирует и не изменяет
+входной текст.
+"""
+import json
+import re
+import sys
+
+# non-blocking self-check шаг (решение Ф89: alert, не block) — порог и лимиты
+# рабочие гипотезы, требуют калибровки на живых ответах.
+CYRILLIC_RATIO_THRESHOLD = 0.30
+MIN_RESIDUAL_LEN = 20
+GLOSS_LATIN_THRESHOLD = 0.50
+
+_CYRILLIC_RE = re.compile(r"[Ѐ-ӿ]")
+_LATIN_RE = re.compile(r"[A-Za-z]")
+_ALPHA_RE = re.compile(r"[Ѐ-ӿA-Za-z]")
+
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+_URL_RE = re.compile(r"https?://\S+")
+# Путь: содержит `/` ИЛИ известное файловое расширение, без пробелов внутри.
+# `\w` в Python re юникодный по умолчанию — матчит кириллицу наравне с
+# латиницей, из-за чего обычные русские конструкции через слэш («и/или»,
+# «да/нет», «чтение/запись») распознавались как путь и вырезались вместе с
+# кириллицей внутри них (review-02, peer-session ход 18). Явный ASCII-класс
+# вместо `\w` — пути и расширения файлов физически не бывают кириллическими.
+_PATH_RE = re.compile(
+    r"\b(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\b|\b[A-Za-z0-9_-]+\.(?:sh|py|md|yaml|yml|json|ts|tsx|js|txt|log)\b"
+)
+
+
+def _strip_glosses(text):
+    """Вырезать топ-уровневые скобки, чьё содержимое >50% латиницы.
+
+    Ручной посимвольный проход вместо regex — `[^)]*` не держит вложенные
+    скобки (peer-session ход 12), а вложенность в русской прозе реальна:
+    "(термин (уточнение) ещё текст)".
+    """
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "(":
+            depth = 1
+            j = i + 1
+            while j < n and depth > 0:
+                if text[j] == "(":
+                    depth += 1
+                elif text[j] == ")":
+                    depth -= 1
+                j += 1
+            inner = text[i + 1 : j - 1] if depth == 0 else text[i + 1 : n]
+            alpha_len = len(_ALPHA_RE.findall(inner))
+            latin_len = len(_LATIN_RE.findall(inner))
+            is_gloss = alpha_len > 0 and (latin_len / alpha_len) > GLOSS_LATIN_THRESHOLD
+            if not is_gloss:
+                out.append(text[i:j] if depth == 0 else text[i:n])
+            i = j if depth == 0 else n
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
+def strip_non_prose(text):
+    """Вырезать код/URL/пути/A2-глоссы перед подсчётом языка ответа."""
+    text = _FENCED_CODE_RE.sub(" ", text)
+    text = _INLINE_CODE_RE.sub(" ", text)
+    text = _URL_RE.sub(" ", text)
+    text = _PATH_RE.sub(" ", text)
+    text = _strip_glosses(text)
+    return text
+
+
+def check_language(text):
+    residual = strip_non_prose(text)
+    alpha_chars = _ALPHA_RE.findall(residual)
+
+    # MIN_RESIDUAL_LEN гейтит статистическую значимость ratio, которая зависит
+    # от количества БУКВ, не общей длины остатка (review-02, peer-session ход
+    # 18): текст с обилием WP-номеров/дат/хэшей давал длинный residual с 1-2
+    # буквами внутри — ratio считался по микровыборке (0/1, 1/2…), давая
+    # alert почти из ничего. Мерить len(alpha_chars) напрямую.
+    if len(alpha_chars) < MIN_RESIDUAL_LEN:
+        return {"alert": False, "ratio": None, "reason": "too few alphabetic chars after stripping code/paths/glosses, skipped"}
+
+    cyrillic_count = len(_CYRILLIC_RE.findall(residual))
+    ratio = cyrillic_count / len(alpha_chars)
+
+    if ratio < CYRILLIC_RATIO_THRESHOLD:
+        return {"alert": True, "ratio": round(ratio, 3), "reason": f"cyrillic ratio {ratio:.2f} below threshold {CYRILLIC_RATIO_THRESHOLD}"}
+
+    return {"alert": False, "ratio": round(ratio, 3), "reason": "cyrillic ratio within threshold"}
+
+
+def main():
+    text = sys.stdin.read()
+    result = check_language(text)
+    print(json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/peer-adapter-common.sh
+++ b/scripts/lib/peer-adapter-common.sh
@@ -1,0 +1,115 @@
+# shellcheck shell=bash
+# peer-adapter-common.sh — shared preamble helpers for <vendor>-peer-adapter.sh
+# (DP.SC.154, §0в.1 contract). Sourced, not executed: declares functions only,
+# no side effects on source. Deliberately does not set its own `set -e/-u/-o
+# pipefail` — callers differ (claude-peer-adapter.sh runs -euo pipefail,
+# kimi-peer-adapter.sh runs -uo pipefail without -e) and a sourced file must
+# not change the caller's shell options.
+# see peer-session 2026-08-16-01-wp524-preamble-dedup (WP-524, consensus with
+# Codex) — extracted from claude-peer-adapter.sh + kimi-peer-adapter.sh, which
+# had carried these blocks byte-identical since the 15.08 sandbox-network fix.
+
+# peer_adapter_check_sandbox_network <cli-label> <exit-code>
+# Codex's Linux sandbox disables network for non-escalated commands; the
+# vendor CLI then dies on its API call with little to no diagnostic output
+# (WP-524, verified live 15.08 on codex-cli 0.147). Fail fast with an
+# actionable message instead of leaking that opaque failure downstream.
+# <exit-code> is the caller's, not this helper's: claude-peer-adapter.sh
+# passes 69, kimi-peer-adapter.sh passes 1 — unifying that divergence is a
+# separate decision, not bundled into this refactor (Codex review, WP-524).
+peer_adapter_check_sandbox_network() {
+  local cli_label="$1" exit_code="${2:?peer_adapter_check_sandbox_network: exit code required}"
+  if [ "${CODEX_SANDBOX_NETWORK_DISABLED:-}" = "1" ]; then
+    echo "ERROR: network is disabled in this sandbox (CODEX_SANDBOX_NETWORK_DISABLED=1) — the $cli_label cannot reach its API. Re-run through the approved escalated route." >&2
+    exit "$exit_code"
+  fi
+}
+
+# run_with_deadline <seconds> <cmd> [args...]
+# Runs cmd in its own process group and kills the whole group (TERM then
+# KILL) on timeout, so a supervised CLI can't leave an orphaned child behind
+# a plain `timeout` (WP-516: the previous `perl alarm; exec` signalled only
+# the launcher, not a forked CLI child).
+run_with_deadline() {
+  local deadline_seconds="$1"
+  shift
+  perl -MPOSIX=setsid -e '
+    use strict;
+    use warnings;
+
+    my $seconds = shift @ARGV;
+    my $child = fork();
+    die "ERROR: cannot fork peer CLI supervisor: $!\n" unless defined $child;
+    if ($child == 0) {
+      setsid() or die "ERROR: cannot isolate peer CLI process group: $!\n";
+      exec @ARGV or die "ERROR: cannot exec peer CLI: $!\n";
+    }
+
+    my $timed_out = 0;
+    local $SIG{ALRM} = sub {
+      $timed_out = 1;
+      kill "TERM", -$child;
+      select undef, undef, undef, 2;
+      kill "KILL", -$child;
+    };
+    alarm $seconds;
+    waitpid($child, 0);
+    my $status = $?;
+    alarm 0;
+    exit 142 if $timed_out;
+    exit 128 + ($status & 127) if $status & 127;
+    exit $status >> 8;
+  ' "$deadline_seconds" "$@"
+}
+
+# peer_adapter_check_frontmatter <output-text>
+# §0в.1: a peer reply's stdout must open with a `---` frontmatter fence on
+# its first non-empty line and close with a second `---`; violation is a
+# format error, not "no answer". Callers gate the call itself on
+# IWE_PEER_PLAIN (service calls like review/verify/synth aren't peer replies
+# and opt out at the call site) — this helper only checks, it never reads
+# that env var, so a caller can't accidentally skip the check through it.
+# Argument is passed by value (Codex review: nameref was considered and
+# rejected — no measured cost on adapter-sized replies, and by-value avoids
+# nameref's bash-version and `set -u` footguns in a file every adapter sources).
+peer_adapter_check_frontmatter() {
+  local output="${1-}"
+  local first_line fm_fences
+  # awk in one process: a `sed | head` pipeline hit SIGPIPE under `pipefail`
+  # on a long valid reply and killed the adapter without diagnostics
+  # (review-02, WP-516 Ф5) — kept from the original inline check.
+  first_line=$(printf '%s\n' "$output" | awk 'length { print; exit }')
+  fm_fences=$(printf '%s\n' "$output" | grep -c '^---$' || true)
+  if [ "$first_line" != "---" ] || [ "${fm_fences:-0}" -lt 2 ]; then
+    echo "ERROR: peer response missing frontmatter (first non-empty line must be '---' with a closing '---')." >&2
+    exit 1
+  fi
+}
+
+# peer_adapter_check_language <output-text>
+# WP-484 Ф89/Ф92: alert-only self-check — доля кириллицы в ответе после
+# вычитания кода/путей/A2-глосс. Никогда не блокирует вывод, только
+# предупреждает в stderr (не видна peer-реплике, IWE_PEER_PLAIN=1 её не
+# печатает). Уже жила инлайн-копией в codex-/hermes-peer-adapter.sh
+# (Ф89, 11.08) — здесь единственное определение для новых вызывающих
+# (kimi/claude), чтобы не плодить третью копию (P2). language-check.py
+# лежит рядом с этим файлом (scripts/lib/), путь резолвится через
+# BASH_SOURCE этого файла — не зависит от cwd вызывающего адаптера.
+peer_adapter_check_language() {
+  local output="${1-}"
+  local lib_dir lang_check python_resolver resolved_python lang_result
+  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  lang_check="$lib_dir/language-check.py"
+  python_resolver="$lib_dir/find-python3.sh"
+  if [ -f "$lang_check" ] && [ -x "$python_resolver" ]; then
+    resolved_python=$("$python_resolver" 2>/dev/null || true)
+  else
+    resolved_python=""
+  fi
+  if [ -n "$resolved_python" ]; then
+    lang_result=$(printf '%s' "$output" | "$resolved_python" "$lang_check" 2>/dev/null || true)
+    if printf '%s' "$lang_result" | grep -q '"alert": true'; then
+      echo "WARNING: peer response may not be in Russian (language-check alert) — $lang_result" >&2
+    fi
+  fi
+}

--- a/setup/test-update-edge-cases.sh
+++ b/setup/test-update-edge-cases.sh
@@ -35,6 +35,7 @@
 #   T34: Unicode context caps count characters, not bytes (issue #435)
 #   T35: /extend catalog matches every invoked extension point (issues #436/#508)
 #   T36: extension loader sorts suffixes and preserves no-op/error exit codes (issue #508)
+#   T40: Kimi peer heartbeat stays outside authoritative session admission (WP-484)
 #
 # Exit: 0 = all PASS, N = N tests failed
 #
@@ -3083,6 +3084,359 @@ else
     else
         fail "T39: expected EXIT_RUNTIME(3) with a shasum/sha256sum diagnostic, got status=$T39_STATUS: $T39_OUT"
     fi
+fi
+
+# ============================================================
+# T40: Kimi peer heartbeat is observational, never a session semaphore (WP-484)
+# ============================================================
+echo "--- T40: Kimi peer heartbeat namespace and watchdog consumer (WP-484) ---"
+
+T40_ROOT="$TEST_WS/t40-kimi-peer-heartbeat"
+T40_IWE="$T40_ROOT/iwe"
+T40_HOME="$T40_ROOT/home"
+T40_ADD_DIR="$T40_ROOT/peer-beacon-session"
+T40_LOCK_DIR="$T40_ROOT/locks"
+T40_BIN="$T40_ROOT/fake-kimi"
+T40_READY="$T40_ROOT/ready"
+T40_RELEASE="$T40_ROOT/release"
+mkdir -p "$T40_HOME" "$T40_ADD_DIR"
+
+cat > "$T40_BIN" <<'EOF'
+#!/bin/bash
+if [ "${1:-}" = "--help" ]; then
+    echo "--agent-file Load an agent definition from a Markdown file"
+    exit 0
+fi
+printf '%s\n' "$$" >> "$T40_READY"
+while [ ! -f "$T40_RELEASE" ]; do sleep 0.05; done
+printf '%s\n' '{"role":"assistant","content":"CONSENSUS: beacon probe complete"}'
+EOF
+chmod +x "$T40_BIN"
+export T40_READY T40_RELEASE
+
+HOME="$T40_HOME" CODEX_SANDBOX='' CODEX_SANDBOX_NETWORK_DISABLED='' \
+    IWE_PEER_PLAIN=1 IWE_ROOT="$T40_IWE" \
+    IWE_PEER_LOCK_DIR="$T40_LOCK_DIR" IWE_PEER_HEARTBEAT_SECONDS=1 \
+    IWE_PEER_TIMEOUT_SECONDS=10 \
+    KIMI_BIN="$T40_BIN" \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_ADD_DIR" \
+    </dev/null >"$T40_ROOT/adapter.out" 2>"$T40_ROOT/adapter.err" &
+T40_ADAPTER_PID=$!
+for _t40_wait in $(seq 1 200); do
+    [ -f "$T40_READY" ] && break
+    sleep 0.05
+done
+
+T40_BEACON="$T40_IWE/.iwe-runtime/peer-heartbeats/kimi-peer-peer-beacon-session.heartbeat"
+mkdir -p "$T40_IWE/.iwe-runtime/sessions"
+T40_OPEN_COUNT=$(find "$T40_IWE/.iwe-runtime/sessions" -name '*.open' 2>/dev/null | wc -l | tr -d ' ')
+if [ -f "$T40_READY" ] && [ -f "$T40_BEACON" ] && [ ! -L "$T40_BEACON" ] && \
+   [ "$T40_OPEN_COUNT" = 0 ] && grep -q '^agent: kimi-peer$' "$T40_BEACON"; then
+    pass "T40a: peer adapter writes visibility beacon outside sessions/*.open"
+else
+    fail "T40a: peer beacon entered admission namespace or was not created: $(find "$T40_IWE/.iwe-runtime" -type f 2>/dev/null | tr '\n' ' ')"
+fi
+
+T40_ID_BEFORE=$(python3 -c 'import os,sys; s=os.lstat(sys.argv[1]); print(f"{s.st_dev}:{s.st_ino}")' "$T40_BEACON" 2>/dev/null)
+T40_SUM_BEFORE=$(head -6 "$T40_BEACON" | cksum 2>/dev/null)
+if HOME="$T40_HOME" CODEX_SANDBOX='' CODEX_SANDBOX_NETWORK_DISABLED='' \
+   IWE_PEER_PLAIN=1 IWE_ROOT="$T40_IWE" \
+   IWE_PEER_LOCK_DIR="$T40_LOCK_DIR" IWE_PEER_HEARTBEAT_SECONDS=1 \
+   IWE_PEER_TIMEOUT_SECONDS=2 \
+   KIMI_BIN="$T40_BIN" \
+   bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_ADD_DIR" \
+   </dev/null >"$T40_ROOT/duplicate.out" 2>"$T40_ROOT/duplicate.err"; then
+    T40_DUPLICATE_RC=0
+else
+    T40_DUPLICATE_RC=$?
+fi
+T40_ID_AFTER=$(python3 -c 'import os,sys; s=os.lstat(sys.argv[1]); print(f"{s.st_dev}:{s.st_ino}")' "$T40_BEACON" 2>/dev/null)
+T40_SUM_AFTER=$(head -6 "$T40_BEACON" | cksum 2>/dev/null)
+if [ "$T40_DUPLICATE_RC" -eq 5 ] && [ -n "$T40_ID_BEFORE" ] && \
+   [ "$T40_ID_AFTER" = "$T40_ID_BEFORE" ] && [ "$T40_SUM_AFTER" = "$T40_SUM_BEFORE" ]; then
+    pass "T40b: rejected duplicate cannot replace the live owner's beacon"
+else
+    fail "T40b: duplicate mutated the beacon (rc=$T40_DUPLICATE_RC before=$T40_ID_BEFORE/$T40_SUM_BEFORE after=$T40_ID_AFTER/$T40_SUM_AFTER)"
+fi
+
+touch "$T40_RELEASE"
+if wait "$T40_ADAPTER_PID"; then
+    T40_ADAPTER_RC=0
+else
+    T40_ADAPTER_RC=$?
+fi
+if [ "$T40_ADAPTER_RC" -eq 0 ] && [ ! -e "$T40_BEACON" ] && \
+   [ ! -e "$T40_IWE/.iwe-runtime/sessions/kimi-peer-peer-beacon-session.open" ]; then
+    pass "T40c: normal peer exit removes its beacon without leaving .open"
+else
+    fail "T40c: peer heartbeat cleanup failed (rc=$T40_ADAPTER_RC)"
+fi
+
+T40_JOURNAL="$T40_HOME/.iwe/agent-sessions.jsonl"
+for _t40_wait in $(seq 1 100); do
+    [ -s "$T40_JOURNAL" ] && break
+    sleep 0.05
+done
+if python3 - "$T40_JOURNAL" <<'PY'
+import datetime
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+record = json.loads(path.read_text(encoding="utf-8").splitlines()[-1])
+assert record["agent"] == "kimi"
+assert record["session_id"] == "peer-beacon-session"
+datetime.datetime.fromisoformat(record["start_time"].replace("Z", "+00:00"))
+datetime.datetime.fromisoformat(record["end_time"].replace("Z", "+00:00"))
+PY
+then
+    pass "T40d: successful peer call records a timestamped session journal entry"
+else
+    fail "T40d: successful peer call lost its session journal entry"
+fi
+
+# Start eight adapters on one id without a pre-established winner. Exactly one
+# may enter the fake CLI; the kernel lock must reject the other seven.
+T40_RACE_ADD="$T40_ROOT/peer-race-session"
+T40_RACE_READY="$T40_ROOT/race-ready"
+T40_RACE_RELEASE="$T40_ROOT/race-release"
+mkdir -p "$T40_RACE_ADD" "$T40_ROOT/race-results"
+t40_racer() {
+    local index="$1" rc
+    if HOME="$T40_HOME" CODEX_SANDBOX='' CODEX_SANDBOX_NETWORK_DISABLED='' \
+       IWE_PEER_PLAIN=1 IWE_ROOT="$T40_IWE" \
+       IWE_PEER_LOCK_DIR="$T40_LOCK_DIR" IWE_PEER_HEARTBEAT_SECONDS=1 \
+       IWE_PEER_TIMEOUT_SECONDS=10 T40_READY="$T40_RACE_READY" \
+       T40_RELEASE="$T40_RACE_RELEASE" KIMI_BIN="$T40_BIN" \
+       bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_RACE_ADD" \
+       </dev/null >"$T40_ROOT/race-results/$index.out" 2>"$T40_ROOT/race-results/$index.err"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    printf '%s\n' "$rc" > "$T40_ROOT/race-results/$index.rc"
+}
+T40_RACE_PIDS=""
+for _t40_index in $(seq 1 8); do
+    t40_racer "$_t40_index" &
+    T40_RACE_PIDS="$T40_RACE_PIDS $!"
+done
+for _t40_wait in $(seq 1 100); do
+    T40_RACE_DONE=$(find "$T40_ROOT/race-results" -name '*.rc' | wc -l | tr -d ' ')
+    [ "$T40_RACE_DONE" -ge 7 ] && break
+    sleep 0.05
+done
+touch "$T40_RACE_RELEASE"
+for _t40_pid in $T40_RACE_PIDS; do
+    wait "$_t40_pid" || true
+done
+if [ -f "$T40_RACE_READY" ]; then
+    T40_RACE_ENTERED=$(wc -l < "$T40_RACE_READY" | tr -d ' ')
+else
+    T40_RACE_ENTERED=0
+fi
+T40_RACE_OK=$(grep -l '^0$' "$T40_ROOT"/race-results/*.rc 2>/dev/null | wc -l | tr -d ' ')
+T40_RACE_BUSY=$(grep -l '^5$' "$T40_ROOT"/race-results/*.rc 2>/dev/null | wc -l | tr -d ' ')
+if [ "$T40_RACE_ENTERED" -eq 1 ] && [ "$T40_RACE_OK" -eq 1 ] && \
+   [ "$T40_RACE_BUSY" -eq 7 ]; then
+    pass "T40e: concurrent same-id adapters elect exactly one owner"
+else
+    fail "T40e: peer lock split ownership (entered=$T40_RACE_ENTERED ok=$T40_RACE_OK busy=$T40_RACE_BUSY)"
+fi
+
+# SIGKILL skips the adapter's EXIT trap. Its two direct helpers must observe
+# reparenting, release the kernel lock and remove only their own beacon.
+T40_CRASH_ADD="$T40_ROOT/peer-crash-session"
+T40_CRASH_READY="$T40_ROOT/crash-ready"
+T40_CRASH_RELEASE="$T40_ROOT/crash-release"
+T40_CRASH_BEACON="$T40_IWE/.iwe-runtime/peer-heartbeats/kimi-peer-peer-crash-session.heartbeat"
+T40_CRASH_LOCK="$T40_LOCK_DIR/peer-crash-session.pid"
+mkdir -p "$T40_CRASH_ADD"
+HOME="$T40_HOME" CODEX_SANDBOX='' CODEX_SANDBOX_NETWORK_DISABLED='' \
+    IWE_PEER_PLAIN=1 IWE_ROOT="$T40_IWE" \
+    IWE_PEER_LOCK_DIR="$T40_LOCK_DIR" IWE_PEER_HEARTBEAT_SECONDS=1 \
+    IWE_PEER_TIMEOUT_SECONDS=10 T40_READY="$T40_CRASH_READY" \
+    T40_RELEASE="$T40_CRASH_RELEASE" KIMI_BIN="$T40_BIN" \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_CRASH_ADD" \
+    </dev/null >"$T40_ROOT/crash.out" 2>"$T40_ROOT/crash.err" &
+T40_CRASH_PID=$!
+for _t40_wait in $(seq 1 200); do
+    [ -s "$T40_CRASH_READY" ] && [ -f "$T40_CRASH_BEACON" ] && break
+    sleep 0.05
+done
+T40_CRASH_STARTED=0
+if [ -s "$T40_CRASH_READY" ] && [ -f "$T40_CRASH_BEACON" ]; then
+    T40_CRASH_STARTED=1
+fi
+kill -9 "$T40_CRASH_PID" 2>/dev/null || true
+wait "$T40_CRASH_PID" 2>/dev/null || true
+touch "$T40_CRASH_RELEASE"
+for _t40_wait in $(seq 1 100); do
+    [ ! -e "$T40_CRASH_BEACON" ] && [ ! -e "$T40_CRASH_LOCK" ] && break
+    sleep 0.05
+done
+if [ "$T40_CRASH_STARTED" -eq 1 ] && \
+   [ ! -e "$T40_CRASH_BEACON" ] && [ ! -e "$T40_CRASH_LOCK" ]; then
+    pass "T40f: owner SIGKILL cannot leave a live-looking beacon or held lock"
+else
+    fail "T40f: owner SIGKILL setup/cleanup failed (started=$T40_CRASH_STARTED beacon=$(test -e "$T40_CRASH_BEACON" && echo yes || echo no) lock=$(test -e "$T40_CRASH_LOCK" && echo yes || echo no))"
+fi
+
+# TERM must terminate the adapter after cleanup; the old multi-signal cleanup
+# handler returned to normal execution and could print a response after giving
+# up its lock. Release the fake CLI only to let Bash deliver its deferred trap.
+T40_TERM_ADD="$T40_ROOT/peer-term-session"
+T40_TERM_READY="$T40_ROOT/term-ready"
+T40_TERM_RELEASE="$T40_ROOT/term-release"
+T40_TERM_BEACON="$T40_IWE/.iwe-runtime/peer-heartbeats/kimi-peer-peer-term-session.heartbeat"
+mkdir -p "$T40_TERM_ADD"
+HOME="$T40_HOME" CODEX_SANDBOX='' CODEX_SANDBOX_NETWORK_DISABLED='' \
+    IWE_PEER_PLAIN=1 IWE_ROOT="$T40_IWE" \
+    IWE_PEER_LOCK_DIR="$T40_LOCK_DIR" IWE_PEER_HEARTBEAT_SECONDS=1 \
+    IWE_PEER_TIMEOUT_SECONDS=10 T40_READY="$T40_TERM_READY" \
+    T40_RELEASE="$T40_TERM_RELEASE" KIMI_BIN="$T40_BIN" \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_TERM_ADD" \
+    </dev/null >"$T40_ROOT/term.out" 2>"$T40_ROOT/term.err" &
+T40_TERM_PID=$!
+for _t40_wait in $(seq 1 200); do
+    [ -s "$T40_TERM_READY" ] && [ -f "$T40_TERM_BEACON" ] && break
+    sleep 0.05
+done
+kill -TERM "$T40_TERM_PID" 2>/dev/null || true
+touch "$T40_TERM_RELEASE"
+if wait "$T40_TERM_PID"; then
+    T40_TERM_RC=0
+else
+    T40_TERM_RC=$?
+fi
+if [ "$T40_TERM_RC" -eq 143 ] && [ ! -s "$T40_ROOT/term.out" ] && \
+   [ ! -e "$T40_TERM_BEACON" ]; then
+    pass "T40g: TERM exits after exact cleanup and cannot continue the peer call"
+else
+    fail "T40g: TERM did not stop the adapter (rc=$T40_TERM_RC output=$(wc -c < "$T40_ROOT/term.out" | tr -d ' '))"
+fi
+
+mkdir -p "$T40_IWE/.iwe-runtime/peer-heartbeats"
+cat > "$T40_BEACON" <<'EOF'
+opened_at: 2020-01-01T00:00:00Z
+wp: WP-7
+task: bounded consumer probe
+agent: kimi-peer
+heartbeat_at: 2020-01-01T00:00:00Z
+EOF
+T40_WATCHDOG_OUT=$(IWE_ROOT="$T40_IWE" SILENCE_THRESHOLD_S=1 \
+    bash -c 'source "$1"; notify_pilot(){ printf "%s|%s\n" "$1" "$2"; }; scan_once' \
+    t40 "$TEMPLATE_DIR/scripts/kimi-session-watchdog.sh" 2>&1)
+T40_WATCHDOG_RC=$?
+if [ "$T40_WATCHDOG_RC" -eq 0 ] && [[ "$T40_WATCHDOG_OUT" == *"$T40_BEACON|"* ]]; then
+    pass "T40h: watchdog consumes the separate peer-heartbeats namespace"
+else
+    fail "T40h: watchdog ignored the peer heartbeat (rc=$T40_WATCHDOG_RC out=$T40_WATCHDOG_OUT)"
+fi
+
+T40_FRESH_NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+cat > "$T40_BEACON" <<EOF
+opened_at: $T40_FRESH_NOW
+wp: WP-7
+task: fresh consumer probe
+agent: kimi-peer
+heartbeat_at: $T40_FRESH_NOW
+EOF
+T40_FRESH_OUT=$(IWE_ROOT="$T40_IWE" SILENCE_THRESHOLD_S=300 \
+    bash -c 'source "$1"; notify_pilot(){ printf "%s|%s\n" "$1" "$2"; }; scan_once' \
+    t40 "$TEMPLATE_DIR/scripts/kimi-session-watchdog.sh" 2>&1)
+if [ -z "$T40_FRESH_OUT" ]; then
+    pass "T40i: watchdog does not alert on a fresh peer heartbeat"
+else
+    fail "T40i: watchdog falsely reported a fresh heartbeat: $T40_FRESH_OUT"
+fi
+
+if IWE_ROOT="$T40_IWE" CHECK_INTERVAL_S=0 \
+   bash -c 'source "$1"' t40 "$TEMPLATE_DIR/scripts/kimi-session-watchdog.sh" \
+   >"$T40_ROOT/invalid-interval.out" 2>&1; then
+    T40_BAD_INTERVAL_RC=0
+else
+    T40_BAD_INTERVAL_RC=$?
+fi
+if IWE_ROOT="$T40_IWE" SILENCE_THRESHOLD_S=not-a-number \
+   bash -c 'source "$1"' t40 "$TEMPLATE_DIR/scripts/kimi-session-watchdog.sh" \
+   >"$T40_ROOT/invalid-threshold.out" 2>&1; then
+    T40_BAD_THRESHOLD_RC=0
+else
+    T40_BAD_THRESHOLD_RC=$?
+fi
+if [ "$T40_BAD_INTERVAL_RC" -ne 0 ] && [ "$T40_BAD_THRESHOLD_RC" -ne 0 ] && \
+   grep -q 'positive integer' "$T40_ROOT/invalid-interval.out" && \
+   grep -q 'positive integer' "$T40_ROOT/invalid-threshold.out"; then
+    pass "T40j: watchdog rejects zero and non-numeric timing controls"
+else
+    fail "T40j: watchdog accepted an unsafe timing value (interval=$T40_BAD_INTERVAL_RC threshold=$T40_BAD_THRESHOLD_RC)"
+fi
+
+T40_OSA_DIR="$T40_ROOT/fake-osa-bin"
+T40_OSA_CAPTURE="$T40_ROOT/osascript-args.json"
+mkdir -p "$T40_OSA_DIR"
+cat > "$T40_OSA_DIR/osascript" <<'EOF'
+#!/bin/bash
+python3 - "$T40_OSA_CAPTURE" "$@" <<'PY'
+import json
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_text(json.dumps(sys.argv[2:]), encoding="utf-8")
+PY
+EOF
+chmod +x "$T40_OSA_DIR/osascript"
+export T40_OSA_CAPTURE
+if ! PATH="$T40_OSA_DIR:$PATH" command -v osascript >/dev/null 2>&1; then
+    fail "T40k: fake osascript is not discoverable"
+fi
+cat > "$T40_BEACON" <<'EOF'
+opened_at: 2020-01-01T00:00:00Z
+wp: WP-7
+task: probe"; display dialog "PWN
+agent: kimi-peer
+heartbeat_at: 2020-01-01T00:00:00Z
+EOF
+PATH="$T40_OSA_DIR:$PATH" IWE_ROOT="$T40_IWE" SILENCE_THRESHOLD_S=1 \
+    bash -c 'source "$1"; notify_pilot "$2" 999' \
+    t40 "$TEMPLATE_DIR/scripts/kimi-session-watchdog.sh" "$T40_BEACON"
+if python3 - "$T40_OSA_CAPTURE" <<'PY'
+import json
+import pathlib
+import sys
+
+args = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert len(args) == 2 and args[0] == "-e"
+program = args[1]
+assert 'subtitle "probe\\"; display dialog \\"PWN"' in program
+assert 'subtitle "probe"; display dialog "PWN"' not in program
+PY
+then
+    pass "T40k: watchdog escapes peer labels before AppleScript interpolation"
+else
+    fail "T40k: watchdog exposed an unescaped peer label to AppleScript"
+fi
+
+T40_PYTHON3=$("$TEMPLATE_DIR/scripts/lib/find-python3.sh" 2>/dev/null || true)
+if [ -n "$T40_PYTHON3" ]; then
+    T40_LANG_RESULT=$(printf '%s\n' 'This complete response is deliberately written only in English prose.' | \
+        "$T40_PYTHON3" "$TEMPLATE_DIR/scripts/lib/language-check.py" 2>/dev/null || true)
+else
+    T40_LANG_RESULT=""
+fi
+if [ -n "$T40_PYTHON3" ] && "$T40_PYTHON3" - "$T40_LANG_RESULT" <<'PY'
+import json
+import sys
+
+result = json.loads(sys.argv[1])
+assert result["alert"] is True
+PY
+then
+    pass "T40l: template delivers the peer language-check dependency"
+else
+    fail "T40l: peer language-check dependency is missing or inactive"
 fi
 
 # ============================================================

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -2389,11 +2389,11 @@
     },
     {
       "path": "scripts/kimi-peer-adapter.sh",
-      "sha256": "a31ffe012292419672b2819d0843f002578d881e96da0363e9cab2b7c324a7fd"
+      "sha256": "c91b04fa03d3e15a856c79266f07d1146989b670b584c2e0442781315554da69"
     },
     {
       "path": "scripts/kimi-session-watchdog.sh",
-      "sha256": "0be30d1b62a22d10ae4b18bf4b0e78740f7b09d20497df377b3b828dc456eb2b"
+      "sha256": "6045878646195725126759fd976f4a44865a9943788ab3c4542ccf27aa4451f0"
     },
     {
       "path": "scripts/kimi-standalone-preflight.sh",
@@ -2424,6 +2424,10 @@
       "sha256": "b938fca2780186b9383f3174a6d21b218f3b5f3a50e5d411a38179d584689cdd"
     },
     {
+      "path": "scripts/lib/language-check.py",
+      "sha256": "ba445fe2f2f7cb85bdf81c582597871b66f114e2f9022f0f26d86039bade233a"
+    },
+    {
       "path": "scripts/lib/ledger-path.sh",
       "sha256": "725d8de49c7c0d04645521ba646ff7ba952e412574e87d2514b3769464fbf48c"
     },
@@ -2442,6 +2446,10 @@
     {
       "path": "scripts/lib/notification-render.sh",
       "sha256": "ac1c9e55dd710e4d62d05b2fae19157c012dba0688c178475cf5f047ba909a38"
+    },
+    {
+      "path": "scripts/lib/peer-adapter-common.sh",
+      "sha256": "874e916b4914f32b6918ffee44080c30ab7e4cf0f3ced7252e4dd6de6abf6088"
     },
     {
       "path": "scripts/lib/telegram.sh",


### PR DESCRIPTION
## Что исправлено

- атомарное владение peer-сессией через удерживаемую ядром блокировку;
- отдельный наблюдательный heartbeat без authoritative `sessions/*.open`;
- точная очистка после сигналов и смерти родителя;
- watchdog для отдельного namespace с безопасным уведомлением;
- поставка `peer-adapter-common.sh` и `language-check.py` через manifest.

## Проверки

- `setup/test-update-edge-cases.sh`: 176/176
- `setup/validate-template.sh`: пройдено
- `scripts/validate-fmt-scripts.sh`: пройдено
- `scripts/verify-manifest.sh`: пройдено
- `bash -n`, ShellCheck error, `git diff --check`: пройдено

Независимый повторный review: 0 Critical / 0 High / 0 Medium.