### PR TITLE
fix(strategist): publish via ds-publish.sh instead of raw pull/push

### DIFF
--- a/roles/strategist/scripts/strategist.sh
+++ b/roles/strategist/scripts/strategist.sh
@@ -290,8 +290,20 @@ ${prompt}"
     if git -C "$WORKSPACE" diff --quiet origin/main..HEAD 2>/dev/null; then
         log "No unpushed commits"
     else
-        git -C "$WORKSPACE" pull --rebase >> "$LOG_FILE" 2>&1 && log "Pulled (rebase)" || log "WARN: pull --rebase failed"
-        git -C "$WORKSPACE" push >> "$LOG_FILE" 2>&1 && log "Pushed to GitHub" || log "WARN: git push failed"
+        # WP-7 Ф101: raw pull --rebase + push on a checkout shared with
+        # concurrent agent sessions routinely hit a dirty tree or a
+        # non-fast-forward push and silently dropped the commit (found via a
+        # W36 week-review that never reached origin/main). ds-publish.sh
+        # isolates this exact commit into a disposable worktree instead of
+        # waiting for a clean window.
+        local push_sha
+        push_sha=$(git -C "$WORKSPACE" rev-parse HEAD)
+        if bash "$WORKSPACE/scripts/ds-publish.sh" "$WORKSPACE" normal \
+            --reason "strategist: $command_file" --from-commit "$push_sha" >> "$LOG_FILE" 2>&1; then
+            log "Pushed to GitHub"
+        else
+            log "WARN: ds-publish.sh failed — публикация не удалась"
+        fi
     fi
 
     # Очистить staging area после Claude сессии (предотвращает staging leak в следующие скрипты)
@@ -535,9 +547,21 @@ case "$1" in
         # If cleanup made changes, commit and push
         if ! git -C "$WORKSPACE" diff --quiet -- inbox/fleeting-notes.md archive/notes/Notes-Archive.md 2>/dev/null; then
             git -C "$WORKSPACE" add inbox/fleeting-notes.md archive/notes/Notes-Archive.md
-            git -C "$WORKSPACE" commit -m "chore: auto-cleanup processed notes from fleeting-notes.md" >> "$LOG_FILE" 2>&1 || true
-            git -C "$WORKSPACE" pull --rebase >> "$LOG_FILE" 2>&1 && log "Cleanup: pulled (rebase)" || log "WARN: cleanup pull --rebase failed"
-            git -C "$WORKSPACE" push >> "$LOG_FILE" 2>&1 && log "Cleanup: pushed" || log "WARN: cleanup push failed"
+            # WP-7 Ф101: same ds-publish.sh move as the main push block above,
+            # plus an explicit commit-result check — `|| true` here used to
+            # swallow a failed commit while still reporting "Cleanup: pushed"
+            # for a commit that never happened.
+            if git -C "$WORKSPACE" commit -m "chore: auto-cleanup processed notes from fleeting-notes.md" >> "$LOG_FILE" 2>&1; then
+                cleanup_sha=$(git -C "$WORKSPACE" rev-parse HEAD)
+                if bash "$WORKSPACE/scripts/ds-publish.sh" "$WORKSPACE" normal \
+                    --reason "strategist: cleanup" --from-commit "$cleanup_sha" >> "$LOG_FILE" 2>&1; then
+                    log "Cleanup: pushed"
+                else
+                    log "WARN: cleanup ds-publish.sh failed"
+                fi
+            else
+                log "WARN: cleanup git commit failed"
+            fi
         else
             log "Cleanup: no changes to commit"
         fi

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -1869,7 +1869,7 @@
     },
     {
       "path": "roles/strategist/scripts/strategist.sh",
-      "sha256": "90b9172aaf3981eb35fe6320cc7e8bb75dc01e59b2d542df9896d2baf93724d4"
+      "sha256": "587b3b571d6abc41dfc9cd235bcbb9dd0ab08a8c31dab605e69abc29b7d1d6f2"
     },
     {
       "path": "roles/strategist/scripts/systemd/iwe-strategist-morning.service",


### PR DESCRIPTION
## Summary
- Strategist's weekly-review push (and its note-review cleanup push) used raw `git pull --rebase` + `git push` on a checkout shared with concurrent agent sessions — a dirty tree, a non-fast-forward push, or a hook edge case silently dropped the commit with only a WARN line logged.
- Found while fact-checking WP-7 Ф101 in a peer session: week 36's full week-review (2026-09-07) was generated and committed locally but never reached `origin/main`, surviving only on a backup branch.
- Also fixes a swallowed commit failure in the cleanup path (`|| true` reported "Cleanup: pushed" even when the commit itself never happened).
- Both push sites now use `ds-publish.sh --from-commit`, the same isolated-worktree publish mechanism `extractor.sh` already uses, matching the fix already applied to the `DS-ai-systems` source-of-truth copy of this script on 2026-09-04.

## Test plan
- [x] `bash -n` syntax check passes
- [x] `shellcheck` clean on the touched lines
- [ ] Live weekly-review run publishes cleanly on a genuinely dirty shared checkout (next scheduled run)