### PR TITLE
fix(wp484): ship crash-safe Kimi peer adapter

### DIFF
--- a/.claude/lib/find-python3.sh
+++ b/.claude/lib/find-python3.sh
@@ -3,7 +3,10 @@
 # issues #453/#463, Evgenii 18.08).
 #
 # Contract (peer-session 2026-08-19-01, codex В1): standalone executable, not a
-# sourced lib. stdout = path to a python3 whose `import yaml` succeeds, exit 0.
+# sourced lib. By default stdout = path to a python3 whose `import yaml`
+# succeeds, exit 0. `--stdlib-only` keeps the same candidate resolution but
+# requires only the Python standard library; callers that do not import PyYAML
+# must use it rather than acquiring an unrelated optional dependency.
 # No candidate → exit 1 with actionable diagnostics on stderr. Callers use
 # command substitution and MUST check the exit code, failing with an explicit
 # dependency error instead of a misleading domain error ("calendar_ids не
@@ -15,6 +18,14 @@
 # to a yaml-less interpreter.
 set -u
 
+stdlib_only=false
+case "${1:-}" in
+    --stdlib-only) stdlib_only=true; shift ;;
+    "") ;;
+    *) echo "ERROR: unknown find-python3.sh argument: $1" >&2; exit 2 ;;
+esac
+[ "$#" -eq 0 ] || { echo "ERROR: find-python3.sh accepts only --stdlib-only" >&2; exit 2; }
+
 candidates=(
     python3
     /opt/homebrew/bin/python3
@@ -24,7 +35,7 @@ candidates=(
 
 for cand in "${candidates[@]}"; do
     resolved=$(command -v "$cand" 2>/dev/null) || continue
-    if "$resolved" -c "import yaml" >/dev/null 2>&1; then
+    if $stdlib_only || "$resolved" -c "import yaml" >/dev/null 2>&1; then
         printf '%s\n' "$resolved"
         exit 0
     fi
@@ -36,11 +47,16 @@ done
 # that made this branch dead code in server-calendar.sh).
 if [ -d /nix/store ]; then
     while IFS= read -r cand; do
-        if "$cand" -c "import yaml" >/dev/null 2>&1; then
+        if $stdlib_only || "$cand" -c "import yaml" >/dev/null 2>&1; then
             printf '%s\n' "$cand"
             exit 0
         fi
     done < <(find /nix/store -maxdepth 3 -name python3 -path "*env*/bin/*" 2>/dev/null)
+fi
+
+if $stdlib_only; then
+    echo "ERROR: python3 не найден (проверены: PATH, /opt/homebrew, /usr/local, /usr/bin, Nix)." >&2
+    exit 1
 fi
 
 {

--- a/scripts/kimi-peer-adapter.sh
+++ b/scripts/kimi-peer-adapter.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# kimi-peer-adapter.sh v3 — адаптер Kimi для peer-conversation.sh с PII-фильтрацией
+# kimi-peer-adapter.sh v4 — адаптер Kimi для peer-conversation.sh с PII-фильтрацией
 # see DP.SC.154 (З-Ф5), DP.ROLE.039, WP-365 Ф2-Ф3 (peer-session 2026-05-29-27)
 #
 # Принимает аргументы в стиле Claude (-p --model X --add-dir Y --permission-mode Z),
@@ -15,6 +15,8 @@
 #   IWE_PEER_INLINE       — legacy compatibility switch; text-only mode always inlines
 #                           filtered context and never exposes --add-dir to Kimi
 #   IWE_PEER_HEARTBEAT_SECONDS — peer watchdog heartbeat interval (default: 120)
+#   IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS — global OAuth-lock wait (default: 90)
+#   IWE_PEER_WP           — heartbeat classification: WP-N or NO-WP (default: derive)
 #   IWE_HINDSIGHT_RETAIN  — enable hindsight L2 retain (default: 0)
 #   KIMI_BIN              — override kimi binary path
 #   KIMI_MAX_TOKENS       — hard token limit per session via guard (default: 800000)
@@ -44,16 +46,203 @@ if ! source "$SCRIPT_DIR/lib/peer-adapter-common.sh"; then
   exit 1
 fi
 
+# Declared before cleanup_peer's trap is armed (below) so `set -u` can't fault
+# on an unset read if the script exits early, before the lock is ever attempted.
+OAUTH_LOCK_DIR="${IWE_PEER_LOCK_DIR:-/tmp/kimi-peer-locks}/kimi-oauth-refresh.lockdir"
+
+# A pre-v4 scheduler can pause after deciding that the historical mkdir lock
+# is stale and resume its unconditional `rm -rf` after a new implementation
+# has published at the same path. No new writer can close that ABA race. The
+# one-time cutover is therefore deliberately explicit: the operator first
+# disables every legacy launcher and drains every already-running legacy
+# contender, then asserts that fact here. The resulting fence is immutable;
+# rollback binaries see PID -1 as permanently live and fail closed.
+if [ "${1:-}" = "--cutover-oauth-lineage-v4" ]; then
+  if [ "$#" -ne 1 ] || [ "${IWE_OAUTH_CUTOVER_QUIESCED:-}" != "1" ]; then
+    echo "ERROR: OAuth v4 cutover requires no other arguments and IWE_OAUTH_CUTOVER_QUIESCED=1 after a proven legacy drain." >&2
+    exit 1
+  fi
+  if ! kill -0 "-1" 2>/dev/null; then
+    echo "ERROR: this shell does not preserve the deployed legacy 'kill -0 -1' fence contract." >&2
+    exit 1
+  fi
+  python3 - "${IWE_PEER_LOCK_DIR:-/tmp/kimi-peer-locks}" "$OAUTH_LOCK_DIR" <<'PY'
+import errno
+import fcntl
+import os
+import secrets
+import stat
+import sys
+
+root_directory, fence_path = sys.argv[1:]
+lease_path = os.path.join(root_directory, "kimi-oauth-refresh.lease")
+lineage_path = os.path.join(root_directory, "kimi-oauth-refresh.lineage-v4")
+prefix = "kimi-oauth-refresh.fence-v4."
+NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+CLOEXEC = getattr(os, "O_CLOEXEC", 0)
+
+
+def same_inode(left, right):
+    return (left.st_dev, left.st_ino) == (right.st_dev, right.st_ino)
+
+
+def path_names_inode(path, value):
+    return same_inode(os.lstat(path), value)
+
+
+def open_owned_regular(path, create=False):
+    flags = os.O_RDWR | NOFOLLOW | CLOEXEC
+    if create:
+        flags |= os.O_CREAT
+    descriptor = os.open(path, flags, 0o600)
+    value = os.fstat(descriptor)
+    if (not stat.S_ISREG(value.st_mode)
+            or value.st_uid != os.getuid()
+            or value.st_nlink != 1
+            or not path_names_inode(path, value)):
+        os.close(descriptor)
+        raise RuntimeError(f"unsafe OAuth file: {path}")
+    os.fchmod(descriptor, 0o600)
+    return descriptor, value
+
+
+def publish_owned_regular(path, payload):
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | NOFOLLOW | CLOEXEC
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        os.write(descriptor, (payload + "\n").encode("ascii"))
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def read_ascii(descriptor):
+    return os.pread(descriptor, 256, 0).decode("ascii", "strict").strip()
+
+
+def valid_nonce(value):
+    return (len(value) == 32
+            and all(character in "0123456789abcdef" for character in value))
+
+
+def fsync_directory(path):
+    descriptor = os.open(path, os.O_RDONLY | CLOEXEC)
+    try:
+        value = os.fstat(descriptor)
+        if not stat.S_ISDIR(value.st_mode):
+            raise RuntimeError(f"not a directory: {path}")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def validate_fence(lease_value):
+    link_value = os.lstat(fence_path)
+    if not stat.S_ISLNK(link_value.st_mode) or link_value.st_uid != os.getuid():
+        return False
+    target = os.readlink(fence_path)
+    if not target.startswith(prefix) or "/" in target:
+        return False
+    nonce = target[len(prefix):]
+    if not valid_nonce(nonce):
+        return False
+    private_path = os.path.join(root_directory, target)
+    private_value = os.lstat(private_path)
+    if (not stat.S_ISDIR(private_value.st_mode)
+            or private_value.st_uid != os.getuid()
+            or stat.S_IMODE(private_value.st_mode) != 0o700
+            or sorted(os.listdir(private_path)) != ["owner", "pid"]):
+        return False
+    pid_path = os.path.join(private_path, "pid")
+    owner_path = os.path.join(private_path, "owner")
+    pid_fd, pid_value = open_owned_regular(pid_path)
+    owner_fd, owner_value = open_owned_regular(owner_path)
+    try:
+        expected_owner = (
+            f"iwe-oauth-fence-v4 {lease_value.st_dev} "
+            f"{lease_value.st_ino} {nonce}"
+        )
+        return (
+            read_ascii(pid_fd) == "-1"
+            and read_ascii(owner_fd) == expected_owner
+            and path_names_inode(fence_path, link_value)
+            and os.readlink(fence_path) == target
+            and path_names_inode(private_path, private_value)
+            and path_names_inode(pid_path, pid_value)
+            and path_names_inode(owner_path, owner_value)
+        )
+    finally:
+        os.close(owner_fd)
+        os.close(pid_fd)
+
+
+os.makedirs(root_directory, mode=0o700, exist_ok=True)
+root_value = os.lstat(root_directory)
+if not stat.S_ISDIR(root_value.st_mode) or root_value.st_uid != os.getuid():
+    raise SystemExit("ERROR: unsafe OAuth lock root")
+os.chmod(root_directory, 0o700)
+lease_fd, lease_value = open_owned_regular(lease_path, create=True)
+try:
+    try:
+        fcntl.flock(lease_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        if exc.errno in (errno.EACCES, errno.EAGAIN):
+            raise SystemExit("ERROR: OAuth lineage is active; cutover refused")
+        raise
+    if not path_names_inode(lease_path, lease_value):
+        raise SystemExit("ERROR: OAuth lease changed during cutover")
+    if os.path.lexists(fence_path):
+        if validate_fence(lease_value) and not os.path.lexists(lineage_path):
+            print("OAuth lineage v4 cutover already complete")
+            raise SystemExit(0)
+        raise SystemExit("ERROR: existing OAuth bridge is not the exact v4 fence")
+    if os.path.lexists(lineage_path):
+        raise SystemExit("ERROR: existing OAuth v4 lineage blocks cutover")
+
+    nonce = secrets.token_hex(16)
+    target = f"{prefix}{nonce}"
+    private_path = os.path.join(root_directory, target)
+    pid_path = os.path.join(private_path, "pid")
+    owner_path = os.path.join(private_path, "owner")
+    os.mkdir(private_path, 0o700)
+    published = False
+    try:
+        publish_owned_regular(pid_path, "-1")
+        publish_owned_regular(
+            owner_path,
+            f"iwe-oauth-fence-v4 {lease_value.st_dev} "
+            f"{lease_value.st_ino} {nonce}",
+        )
+        fsync_directory(private_path)
+        os.symlink(target, fence_path)
+        published = True
+        fsync_directory(root_directory)
+        if not validate_fence(lease_value):
+            raise RuntimeError("published OAuth v4 fence failed validation")
+    except Exception:
+        if not published:
+            for path in (owner_path, pid_path):
+                try:
+                    os.unlink(path)
+                except FileNotFoundError:
+                    pass
+            try:
+                os.rmdir(private_path)
+            except FileNotFoundError:
+                pass
+        raise
+    print("OAuth lineage v4 cutover complete")
+finally:
+    os.close(lease_fd)
+PY
+  exit $?
+fi
+
 # Codex's Linux sandbox disables network for non-escalated commands; the Kimi
 # CLI cannot reach its API from there (WP-524, verified live 15.08 — the run
 # died even earlier, on the read-only semaphore path).  Fail fast, same as
 # claude-peer-adapter.sh.
 peer_adapter_check_sandbox_network "Kimi CLI" 1
-
-# Declared before cleanup_peer's trap is armed (below) so `set -u` can't fault
-# on an unset read if the script exits early, before the lock is ever attempted.
-OAUTH_LOCK_DIR="${IWE_PEER_LOCK_DIR:-/tmp/kimi-peer-locks}/kimi-oauth-refresh.lockdir"
-OAUTH_LOCK_HELD=false
 
 # KIMI_BIN auto-detect: env override → PATH → VS Code extension paths (macOS/Linux/WSL)
 KIMI_BIN="${KIMI_BIN:-$(command -v kimi 2>/dev/null || true)}"
@@ -368,6 +557,23 @@ KIMI_TASK="$(basename "${ADD_DIRS[0]:-}" 2>/dev/null)"
 if [ -z "$KIMI_TASK" ]; then
   KIMI_TASK="kimi-peer-ppid-${PPID:-$$}"
 fi
+# Machine identity remains the full session id; this field is only an
+# operator-facing classification.  Prefer the explicit caller contract, then
+# derive a WP marker from the human session label, otherwise say NO-WP instead
+# of attributing every peer call to WP-7.
+KIMI_WP="${IWE_PEER_WP:-}"
+if [ -z "$KIMI_WP" ]; then
+  if [[ "-$KIMI_TASK-" =~ [-_.][Ww][Pp]-?([1-9][0-9]*)([-_.]|$) ]]; then
+    KIMI_WP="WP-${BASH_REMATCH[1]}"
+  else
+    KIMI_WP="NO-WP"
+  fi
+fi
+if ! [[ "$KIMI_WP" =~ ^(WP-[1-9][0-9]*|NO-WP)$ ]]; then
+  echo "ERROR: IWE_PEER_WP must be WP-N or NO-WP." >&2
+  rm -rf "$TMP_ROOT"
+  exit 1
+fi
 KIMI_SESSION_ID="$KIMI_TASK"
 case "$KIMI_SESSION_ID" in
   [A-Za-z0-9]* )
@@ -385,50 +591,179 @@ case "$IWE_PEER_HEARTBEAT_SECONDS" in
     exit 1
     ;;
 esac
+IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS="${IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS:-90}"
+case "$IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS" in
+  ''|*[!0-9]*|0)
+    echo "ERROR: IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS must be a positive integer." >&2
+    rm -rf "$TMP_ROOT"
+    exit 1
+    ;;
+esac
 _KIMI_SESSION_START_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
-# === Kernel-held exact lock for one peer-session id ===
-# The old check-then-overwrite pidfile let concurrent adapters both become
-# owners and let one cleanup unlink the other's lock.  A tiny Python helper
-# holds `flock(2)` for the adapter lifetime; owner death reparents the helper,
-# which exits and lets the kernel release the lock without stale cleanup.
+# === Kernel-held exact lock + process-lineage lease for one peer-session id ===
+# Authority is flock(2) on an owned, stable per-id regular `lease` file, not
+# on mutable owner.pid metadata. Removing owner.pid cannot release that flock. A
+# private FIFO writer (fixed fd 9 for macOS Bash 3.2) is inherited only by the
+# command-substitution/supervisor/vendor lineage; background helpers and
+# capability probes close it. A private controller process group contains the
+# Python helper and its forked sentinel; both share every open-file authority.
+# An explicit, immutable v4 fence keeps every deployed mkdir-based launcher
+# fail-closed. New writers use a separate atomically-published runtime lineage;
+# its negative holder moves from the controller group to the gated vendor
+# group. Either owner surviving a single fault drains the vendor; even loss of
+# both owners leaves new writers blocked by the live vendor group until FIFO
+# lineage is gone.
 LOCK_DIR="${IWE_PEER_LOCK_DIR:-/tmp/kimi-peer-locks}"
-LOCK_FILE="$LOCK_DIR/${KIMI_SESSION_ID}.pid"
+SESSION_LOCK_DIR="$LOCK_DIR/${KIMI_SESSION_ID}.lock"
+LOCK_FILE="$SESSION_LOCK_DIR/owner.pid"
+LEGACY_LOCK_FILE="$LOCK_DIR/${KIMI_SESSION_ID}.pid"
 SESSION_LOCK_READY="$TMP_ROOT/session-lock.ready"
+SESSION_LOCK_ARMED="$TMP_ROOT/session-lock.armed"
+SESSION_LOCK_FAILURE="$TMP_ROOT/session-lock.failed"
+SESSION_LIFETIME_FIFO="$TMP_ROOT/session-lifetime.fifo"
+SESSION_VENDOR_PGID_FILE="$TMP_ROOT/session-vendor.pgid"
+SESSION_VENDOR_ARMED="$TMP_ROOT/session-vendor.armed"
+SESSION_VENDOR_EXEC_GATE="$TMP_ROOT/session-vendor.exec-gate"
+SESSION_OAUTH_REQUEST="$TMP_ROOT/oauth-lock.request"
+SESSION_OAUTH_READY="$TMP_ROOT/oauth-lock.ready"
 SESSION_LOCK_HELPER_PID=""
 SESSION_LOCK_HELD=false
+SESSION_LIFETIME_FD_OPEN=false
 OUR_PID="$$"
 
+if ! mkfifo "$SESSION_LIFETIME_FIFO" || ! chmod 600 "$SESSION_LIFETIME_FIFO"; then
+  echo "ERROR: cannot create private peer-session lifetime FIFO." >&2
+  rm -rf "$TMP_ROOT"
+  exit 1
+fi
+if ! exec 9<> "$SESSION_LIFETIME_FIFO"; then
+  echo "ERROR: cannot open private peer-session lifetime FIFO." >&2
+  rm -rf "$TMP_ROOT"
+  exit 1
+fi
+SESSION_LIFETIME_FD_OPEN=true
+
 release_session_lock() {
+  local helper_reap_guard=""
   [ "$SESSION_LOCK_HELD" = true ] || return 0
+  if [ "$SESSION_LIFETIME_FD_OPEN" = true ]; then
+    exec 9>&-
+    SESSION_LIFETIME_FD_OPEN=false
+  fi
+  # EOF is the normal release signal. Give the helper a bounded chance to
+  # observe it and release both kernel locks without recording a false fault.
   if jobs -pr | grep -qx "$SESSION_LOCK_HELPER_PID"; then
-    kill "$SESSION_LOCK_HELPER_PID" 2>/dev/null || true
+    ( exec 9>&-; sleep 5; kill "$SESSION_LOCK_HELPER_PID" 2>/dev/null ) &
+    helper_reap_guard=$!
   fi
   wait "$SESSION_LOCK_HELPER_PID" 2>/dev/null || true
+  [ -z "$helper_reap_guard" ] || kill "$helper_reap_guard" 2>/dev/null || true
   SESSION_LOCK_HELD=false
 }
 
 acquire_session_lock() {
-  local _wait status helper_rc=1
+  local _wait status helper_rc=1 attempt=1 max_attempts=3
   mkdir -p "$LOCK_DIR" || return 1
-  python3 - "$LOCK_DIR" "$LOCK_FILE" "$SESSION_LOCK_READY" "$OUR_PID" <<'PY' &
+  while [ "$attempt" -le "$max_attempts" ]; do
+    rm -f "$SESSION_LOCK_READY"
+    rm -f "$SESSION_LOCK_ARMED"
+    helper_rc=1
+    python3 - "$LOCK_DIR" "$SESSION_LOCK_DIR" "$LOCK_FILE" \
+      "$LEGACY_LOCK_FILE" "$SESSION_LOCK_READY" "$SESSION_LOCK_ARMED" \
+      "$SESSION_LOCK_FAILURE" "$SESSION_LIFETIME_FIFO" \
+      "$SESSION_VENDOR_PGID_FILE" "$SESSION_VENDOR_ARMED" \
+      "$SESSION_VENDOR_EXEC_GATE" "$OAUTH_LOCK_DIR" \
+      "$SESSION_OAUTH_REQUEST" "$SESSION_OAUTH_READY" \
+      "$IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS" "$OUR_PID" 9>&- <<'PY' &
 import errno
 import fcntl
+import json
 import os
+import secrets
 import signal
 import stat
 import sys
 import time
 
-directory, path, ready, owner_pid_text = sys.argv[1:]
+(
+    root_directory,
+    session_directory,
+    owner_path,
+    legacy_path,
+    ready,
+    armed,
+    failure,
+    lifetime_fifo,
+    pgid_path,
+    vendor_armed_path,
+    vendor_exec_gate,
+    oauth_lock_directory,
+    oauth_request,
+    oauth_ready,
+    oauth_timeout_text,
+    owner_pid_text,
+) = sys.argv[1:]
 owner_pid = int(owner_pid_text)
+oauth_timeout = int(oauth_timeout_text)
+nonce = secrets.token_hex(16)
+controller_pgid = None
+lock_acquired = False
+lease_armed = False
+stop_requested = False
+oauth_wait_started = None
+oauth_lease_path = os.path.join(root_directory, "kimi-oauth-refresh.lease")
+oauth_lease_fd = None
+oauth_lease_value = None
+oauth_fence_name = None
+oauth_fence_directory = None
+oauth_fence_link_value = None
+oauth_fence_directory_value = None
+oauth_fence_pid_fd = None
+oauth_fence_pid_value = None
+oauth_fence_owner_fd = None
+oauth_fence_owner_value = None
+oauth_fence_owner_payload = None
+oauth_lineage_path = os.path.join(
+    root_directory, "kimi-oauth-refresh.lineage-v4",
+)
+oauth_bridge_name = f"kimi-oauth-refresh.lineage-v4.{nonce}"
+oauth_bridge_directory = os.path.join(root_directory, oauth_bridge_name)
+oauth_link_value = None
+oauth_directory_created = False
+oauth_directory_value = None
+oauth_pid_fd = None
+oauth_pid_value = None
+oauth_token_fd = None
+oauth_token_value = None
+oauth_lock_acquired = False
+oauth_holder_record = None
+oauth_cleanup_holder_records = set()
+oauth_owner_payload = None
+oauth_cleanup_owner_payloads = set()
+sentinel_pid = None
+sentinel_reaped = False
+vendor_handoff_pgid = None
+vendor_gate_open = False
+lease_path = os.path.join(session_directory, "lease")
+lease_fd = None
+lease_value = None
+legacy_fd = None
+legacy_value = None
+owner_fd = None
+owner_value = None
+fifo_fd = None
+NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+CLOEXEC = getattr(os, "O_CLOEXEC", 0)
+CREATE_FLAGS = os.O_RDWR | os.O_CREAT | NOFOLLOW | CLOEXEC
+EXCLUSIVE_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_EXCL | NOFOLLOW | CLOEXEC
+READ_FLAGS = os.O_RDONLY | NOFOLLOW | CLOEXEC
+READWRITE_FLAGS = os.O_RDWR | NOFOLLOW | CLOEXEC
 
 
 def publish_status(value):
     tmp = f"{ready}.{os.getpid()}"
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-    flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-    out = os.open(tmp, flags, 0o600)
+    out = os.open(tmp, EXCLUSIVE_FLAGS, 0o600)
     try:
         os.write(out, (value + "\n").encode("utf-8", "replace"))
         os.fsync(out)
@@ -437,133 +772,1216 @@ def publish_status(value):
     os.replace(tmp, ready)
 
 
-def process_alive(pid):
+def publish_failure(value):
     try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    return True
+        out = os.open(failure, EXCLUSIVE_FLAGS, 0o600)
+    except FileExistsError:
+        return
+    try:
+        os.write(out, (value + "\n").encode("utf-8", "replace"))
+        os.fsync(out)
+    finally:
+        os.close(out)
 
 
-try:
-    os.makedirs(directory, mode=0o700, exist_ok=True)
-    directory_stat = os.lstat(directory)
-    if not stat.S_ISDIR(directory_stat.st_mode) or directory_stat.st_uid != os.getuid():
-        raise RuntimeError("unsafe peer lock directory")
-    os.chmod(directory, 0o700)
+def publish_exclusive(path, value):
+    out = os.open(path, EXCLUSIVE_FLAGS, 0o600)
+    try:
+        os.write(out, (value + "\n").encode("utf-8", "replace"))
+        os.fsync(out)
+    finally:
+        os.close(out)
 
-    flags = os.O_RDWR | os.O_CREAT
-    flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-    fd = os.open(path, flags, 0o600)
+
+def publish_atomic(path, value):
+    tmp = f"{path}.{os.getpid()}.{secrets.token_hex(8)}.tmp"
+    out = os.open(tmp, EXCLUSIVE_FLAGS, 0o600)
+    try:
+        os.write(out, (value + "\n").encode("ascii"))
+        os.fsync(out)
+    finally:
+        os.close(out)
+    try:
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def fsync_directory(path):
+    directory_fd = os.open(path, os.O_RDONLY | CLOEXEC)
+    try:
+        value = os.fstat(directory_fd)
+        if not stat.S_ISDIR(value.st_mode):
+            raise RuntimeError(f"not a directory: {path}")
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def same_inode(left, right):
+    return (left.st_dev, left.st_ino) == (right.st_dev, right.st_ino)
+
+
+def path_names_inode(path, value):
+    return same_inode(value, os.lstat(path))
+
+
+def ensure_owned_directory(path):
+    os.makedirs(path, mode=0o700, exist_ok=True)
+    value = os.lstat(path)
+    if not stat.S_ISDIR(value.st_mode) or value.st_uid != os.getuid():
+        raise RuntimeError(f"unsafe peer lock directory: {path}")
+    os.chmod(path, 0o700)
+
+
+def open_owned_regular(path):
+    fd = os.open(path, CREATE_FLAGS, 0o600)
     value = os.fstat(fd)
-    current = os.lstat(path)
     if (not stat.S_ISREG(value.st_mode)
             or value.st_uid != os.getuid()
             or value.st_nlink != 1
-            or (value.st_dev, value.st_ino) != (current.st_dev, current.st_ino)):
-        raise RuntimeError("unsafe peer lock file")
+            or not path_names_inode(path, value)):
+        os.close(fd)
+        raise RuntimeError(f"unsafe peer lock file: {path}")
     os.fchmod(fd, 0o600)
+    return fd, value
+
+
+def open_existing_owned_regular(path, writable=False):
+    fd = os.open(path, READWRITE_FLAGS if writable else READ_FLAGS)
+    value = os.fstat(fd)
+    if (not stat.S_ISREG(value.st_mode)
+            or value.st_uid != os.getuid()
+            or value.st_nlink != 1
+            or not path_names_inode(path, value)):
+        os.close(fd)
+        raise RuntimeError(f"unsafe peer lock file: {path}")
+    return fd, value
+
+
+def read_ascii(fd, limit=256):
+    # Helper and sentinel inherit the same open-file descriptions. pread keeps
+    # their concurrent metadata checks from racing on a shared seek offset.
+    return os.pread(fd, limit, 0).decode("ascii", "strict").strip()
+
+
+def overwrite_ascii(fd, value):
+    os.ftruncate(fd, 0)
+    os.pwrite(fd, (value + "\n").encode("ascii"), 0)
+    os.fsync(fd)
+
+
+def oauth_owner_record():
+    if oauth_lease_value is None:
+        raise RuntimeError("OAuth lease identity unavailable")
+    return (
+        f"iwe-oauth-lineage-v4 {oauth_lease_value.st_dev} "
+        f"{oauth_lease_value.st_ino} {nonce}"
+    )
+
+
+def identity_fault(path, value, changed, missing):
+    try:
+        return None if path_names_inode(path, value) else changed
+    except FileNotFoundError:
+        return missing
+
+
+def metadata_fault(path, value, fd, expected, changed, missing):
+    fault = identity_fault(path, value, changed, missing)
+    if fault:
+        return fault
+    return None if read_ascii(fd) == expected else changed
+
+
+def process_alive(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def fifo_eof(fd):
+    try:
+        return os.read(fd, 1) == b""
+    except (BlockingIOError, OSError):
+        return False
+
+
+def read_vendor_pgid():
+    try:
+        marker_fd = os.open(pgid_path, READ_FLAGS)
+    except FileNotFoundError:
+        return None
+    try:
+        value = os.fstat(marker_fd)
+        if (not stat.S_ISREG(value.st_mode)
+                or value.st_uid != os.getuid()
+                or value.st_nlink != 1):
+            raise RuntimeError("unsafe vendor PGID marker")
+        payload = os.read(marker_fd, 1024).decode("utf-8")
+    finally:
+        os.close(marker_fd)
+    record = json.loads(payload)
+    pid = record.get("pid")
+    pgid = record.get("pgid")
+    if (record.get("nonce") != nonce
+            or not isinstance(pid, int)
+            or not isinstance(pgid, int)
+            or pid <= 1
+            or pid != pgid
+            or pgid == os.getpgrp()):
+        raise RuntimeError("invalid vendor PGID marker")
+    try:
+        if os.getpgid(pid) != pgid:
+            raise RuntimeError("vendor PGID identity changed")
+    except ProcessLookupError:
+        # The setsid leader may already be reaped while a grandchild remains
+        # in the published group and still owns the lifetime FIFO. Keep using
+        # that PGID until the kernel reports the whole group gone.
+        return pgid if group_alive(pgid) else 0
+    return pgid
+
+
+def group_alive(pgid):
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Permission-unknown is not proof of death: retain the admission lock.
+        return True
+    return True
+
+
+def terminate_vendor_group(pgid):
+    if not pgid or not group_alive(pgid):
+        return True
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if not group_alive(pgid):
+            return True
+        time.sleep(0.05)
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline and group_alive(pgid):
+        time.sleep(0.05)
+    return not group_alive(pgid)
+
+
+def drain_lineage():
+    terminated_pgid = None
+    marker_error_reported = False
+    while True:
+        if fifo_eof(fifo_fd):
+            return
+        try:
+            pgid = read_vendor_pgid()
+            if (pgid is not None
+                    and pgid != terminated_pgid
+                    and terminate_vendor_group(pgid)):
+                terminated_pgid = pgid
+        except (OSError, RuntimeError, TypeError, ValueError) as exc:
+            # A malformed/replaced marker or permission-unknown group cannot
+            # justify unlocking. Keep the kernel locks until FIFO EOF proves
+            # that every inheriting process has exited.
+            if not marker_error_reported:
+                sys.stderr.write(f"WARN: untrusted vendor PGID marker: {exc}\n")
+                marker_error_reported = True
+        # No PGID with a live FIFO writer is the fork-before-publish boundary.
+        # Never timeout-unlock: the child will either publish or close the FIFO.
+        time.sleep(0.05)
+
+
+def oauth_pid_path():
+    return os.path.join(oauth_bridge_directory, "pid")
+
+
+def oauth_owner_path():
+    return os.path.join(oauth_bridge_directory, "owner")
+
+
+def adopt_vendor_pid_if_published():
+    """Adopt the sentinel's atomic controller-PGID to vendor-PGID handoff."""
+    global oauth_pid_fd, oauth_pid_value, oauth_holder_record
+    global vendor_handoff_pgid
+    if oauth_pid_fd is None:
+        return False
+    try:
+        if (path_names_inode(oauth_pid_path(), oauth_pid_value)
+                and read_ascii(oauth_pid_fd) == oauth_holder_record):
+            return True
+    except FileNotFoundError:
+        pass
+
+    pgid = read_vendor_pgid()
+    if not pgid:
+        return False
+    candidate_fd, candidate_value = open_existing_owned_regular(
+        oauth_pid_path(), writable=True,
+    )
+    expected = f"-{pgid}"
+    try:
+        if read_ascii(candidate_fd) != expected:
+            return False
+        if not path_names_inode(oauth_pid_path(), candidate_value):
+            return False
+        if not group_alive(pgid):
+            return False
+        previous_fd = oauth_pid_fd
+        oauth_pid_fd = candidate_fd
+        candidate_fd = None
+        oauth_pid_value = candidate_value
+        oauth_holder_record = expected
+        oauth_cleanup_holder_records.add(expected)
+        vendor_handoff_pgid = pgid
+        os.close(previous_fd)
+        return True
+    finally:
+        if candidate_fd is not None:
+            os.close(candidate_fd)
+
+
+def oauth_link_fault():
+    if oauth_link_value is None:
+        return "oauth-link-unavailable"
+    fault = identity_fault(
+        oauth_lineage_path, oauth_link_value,
+        "oauth-lineage-identity-changed", "oauth-lineage-missing",
+    )
+    if fault:
+        return fault
+    if (not stat.S_ISLNK(oauth_link_value.st_mode)
+            or os.readlink(oauth_lineage_path) != oauth_bridge_name):
+        return "oauth-lineage-target-changed"
+    return None
+
+
+def current_authority_fault():
+    fault = identity_fault(
+        lease_path, lease_value,
+        "lock-lease-identity-changed", "lock-lease-missing",
+    )
+    fault = fault or metadata_fault(
+        legacy_path, legacy_value, legacy_fd, str(owner_pid),
+        "legacy-lock-identity-changed", "legacy-lock-missing",
+    )
+    fault = fault or metadata_fault(
+        owner_path, owner_value, owner_fd, f"{owner_pid} {nonce}",
+        "lock-owner-metadata-changed", "lock-owner-metadata-missing",
+    )
+    if not fault and oauth_lease_fd is not None:
+        fault = identity_fault(
+            oauth_lease_path, oauth_lease_value,
+            "oauth-lease-identity-changed", "oauth-lease-missing",
+        )
+        fault = fault or oauth_fence_fault()
+    if not fault and oauth_directory_created:
+        fault = oauth_link_fault()
+        fault = fault or identity_fault(
+            oauth_bridge_directory, oauth_directory_value,
+            "oauth-bridge-identity-changed", "oauth-bridge-missing",
+        )
+    if not fault and oauth_pid_fd is not None:
+        adopt_vendor_pid_if_published()
+        fault = metadata_fault(
+            oauth_pid_path(), oauth_pid_value, oauth_pid_fd,
+            oauth_holder_record,
+            "oauth-pid-changed", "oauth-pid-missing",
+        )
+    if not fault and oauth_token_fd is not None:
+        fault = metadata_fault(
+            oauth_owner_path(),
+            oauth_token_value, oauth_token_fd, oauth_owner_payload,
+            "oauth-owner-changed", "oauth-owner-missing",
+        )
+    return fault
+
+
+def reap_sentinel(block=False):
+    global sentinel_reaped
+    if sentinel_pid is None or sentinel_reaped:
+        return sentinel_reaped
+    options = 0 if block else os.WNOHANG
+    try:
+        child, _status = os.waitpid(sentinel_pid, options)
+    except ChildProcessError:
+        sentinel_reaped = True
+        return True
+    if child == sentinel_pid:
+        sentinel_reaped = True
+    return sentinel_reaped
+
+
+def current_session_fault():
+    if stop_requested:
+        return "lock-helper-stop-requested"
+    if os.getppid() != owner_pid:
+        return "owner-process-gone"
+    fault = current_authority_fault()
+    if not fault and sentinel_pid is not None and reap_sentinel():
+        # Normal EOF may let the sentinel exit between the loop's first EOF
+        # check and this liveness check. Only a dead sentinel with a live
+        # writer is a fault; the helper still owns every authority in that
+        # single-fault case and will drain the lineage itself.
+        if not fifo_eof(fifo_fd):
+            fault = "lock-sentinel-process-gone"
+    return fault
+
+
+def read_oauth_request():
+    try:
+        request_fd, _request_value = open_existing_owned_regular(oauth_request)
+    except FileNotFoundError:
+        return False
+    try:
+        return read_ascii(request_fd) == nonce
+    finally:
+        os.close(request_fd)
+
+
+def valid_nonce(value):
+    return (len(value) == 32
+            and all(char in "0123456789abcdef" for char in value))
+
+
+def load_exact_oauth_fence():
+    """Adopt the immutable legacy fence created by explicit v4 cutover."""
+    global oauth_fence_name, oauth_fence_directory
+    global oauth_fence_link_value, oauth_fence_directory_value
+    global oauth_fence_pid_fd, oauth_fence_pid_value
+    global oauth_fence_owner_fd, oauth_fence_owner_value
+    global oauth_fence_owner_payload
+    prefix = "kimi-oauth-refresh.fence-v4."
+    local_pid_fd = None
+    local_owner_fd = None
+    try:
+        link_value = os.lstat(oauth_lock_directory)
+        if (not stat.S_ISLNK(link_value.st_mode)
+                or link_value.st_uid != os.getuid()):
+            return False
+        fence_name = os.readlink(oauth_lock_directory)
+        if (not fence_name.startswith(prefix)
+                or "/" in fence_name
+                or not valid_nonce(fence_name[len(prefix):])):
+            return False
+        fence_nonce = fence_name[len(prefix):]
+        fence_directory = os.path.join(root_directory, fence_name)
+        directory_value = os.lstat(fence_directory)
+        if (not stat.S_ISDIR(directory_value.st_mode)
+                or directory_value.st_uid != os.getuid()
+                or stat.S_IMODE(directory_value.st_mode) != 0o700
+                or sorted(os.listdir(fence_directory)) != ["owner", "pid"]):
+            return False
+        pid_path = os.path.join(fence_directory, "pid")
+        owner_path_v4 = os.path.join(fence_directory, "owner")
+        local_pid_fd, pid_value = open_existing_owned_regular(pid_path)
+        local_owner_fd, owner_value = open_existing_owned_regular(owner_path_v4)
+        owner_payload = (
+            f"iwe-oauth-fence-v4 {oauth_lease_value.st_dev} "
+            f"{oauth_lease_value.st_ino} {fence_nonce}"
+        )
+        if (read_ascii(local_pid_fd) != "-1"
+                or not process_alive(-1)
+                or read_ascii(local_owner_fd) != owner_payload
+                or not path_names_inode(oauth_lock_directory, link_value)
+                or os.readlink(oauth_lock_directory) != fence_name
+                or not path_names_inode(fence_directory, directory_value)
+                or not path_names_inode(pid_path, pid_value)
+                or not path_names_inode(owner_path_v4, owner_value)):
+            return False
+        oauth_fence_name = fence_name
+        oauth_fence_directory = fence_directory
+        oauth_fence_link_value = link_value
+        oauth_fence_directory_value = directory_value
+        oauth_fence_pid_fd, oauth_fence_pid_value = local_pid_fd, pid_value
+        oauth_fence_owner_fd, oauth_fence_owner_value = (
+            local_owner_fd, owner_value
+        )
+        oauth_fence_owner_payload = owner_payload
+        local_pid_fd = None
+        local_owner_fd = None
+        return True
+    except FileNotFoundError:
+        return False
+    finally:
+        if local_owner_fd is not None:
+            os.close(local_owner_fd)
+        if local_pid_fd is not None:
+            os.close(local_pid_fd)
+
+
+def oauth_fence_fault():
+    if oauth_fence_link_value is None:
+        return "oauth-v4-cutover-required"
+    fault = identity_fault(
+        oauth_lock_directory, oauth_fence_link_value,
+        "oauth-fence-identity-changed", "oauth-fence-missing",
+    )
+    if fault:
+        return fault
+    if (not stat.S_ISLNK(oauth_fence_link_value.st_mode)
+            or os.readlink(oauth_lock_directory) != oauth_fence_name):
+        return "oauth-fence-target-changed"
+    fault = identity_fault(
+        oauth_fence_directory, oauth_fence_directory_value,
+        "oauth-fence-private-changed", "oauth-fence-private-missing",
+    )
+    if fault:
+        return fault
+    if sorted(os.listdir(oauth_fence_directory)) != ["owner", "pid"]:
+        return "oauth-fence-contents-changed"
+    fault = metadata_fault(
+        os.path.join(oauth_fence_directory, "pid"),
+        oauth_fence_pid_value, oauth_fence_pid_fd, "-1",
+        "oauth-fence-pid-changed", "oauth-fence-pid-missing",
+    )
+    return fault or metadata_fault(
+        os.path.join(oauth_fence_directory, "owner"),
+        oauth_fence_owner_value, oauth_fence_owner_fd,
+        oauth_fence_owner_payload,
+        "oauth-fence-owner-changed", "oauth-fence-owner-missing",
+    )
+
+
+def remove_stale_v4_oauth_lineage(link_value):
+    """Remove only an exact dead new-only v4 lineage symlink."""
+    prefix = "kimi-oauth-refresh.lineage-v4."
+
+    def unlink_exact_link(bridge_name):
+        try:
+            current = os.lstat(oauth_lineage_path)
+            if (not same_inode(current, link_value)
+                    or not stat.S_ISLNK(current.st_mode)
+                    or os.readlink(oauth_lineage_path) != bridge_name):
+                return False
+        except FileNotFoundError:
+            return True
+        barrier = os.environ.get("IWE_PEER_TEST_OAUTH_PRE_UNLINK_BARRIER")
+        if barrier:
+            publish_exclusive(f"{barrier}.ready", str(os.getpid()))
+            while not os.path.exists(f"{barrier}.release"):
+                if os.getppid() != owner_pid:
+                    raise RuntimeError("owner gone at OAuth unlink barrier")
+                time.sleep(0.02)
+        try:
+            # The runtime name is new-only and serialized by the stable lease.
+            # unlink(2) still gives replacement-type safety if local tampering
+            # races this exact recheck.
+            os.unlink(oauth_lineage_path)
+        except FileNotFoundError:
+            return True
+        except (IsADirectoryError, PermissionError):
+            return False
+        return True
 
     try:
-        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        if (not stat.S_ISLNK(link_value.st_mode)
+                or link_value.st_uid != os.getuid()):
+            return False
+        bridge_name = os.readlink(oauth_lineage_path)
+        if (not bridge_name.startswith(prefix)
+                or "/" in bridge_name
+                or not valid_nonce(bridge_name[len(prefix):])):
+            return False
+        bridge_nonce = bridge_name[len(prefix):]
+        bridge_directory = os.path.join(root_directory, bridge_name)
+        try:
+            directory_value = os.lstat(bridge_directory)
+        except FileNotFoundError:
+            return unlink_exact_link(bridge_name)
+        if (not stat.S_ISDIR(directory_value.st_mode)
+                or directory_value.st_uid != os.getuid()
+                or stat.S_IMODE(directory_value.st_mode) != 0o700):
+            return False
+        pid_path = os.path.join(bridge_directory, "pid")
+        owner_path_v4 = os.path.join(bridge_directory, "owner")
+        try:
+            pid_fd, pid_value = open_existing_owned_regular(pid_path)
+        except FileNotFoundError:
+            return unlink_exact_link(bridge_name)
+        try:
+            holder = read_ascii(pid_fd)
+            if (not holder.startswith("-")
+                    or not holder[1:].isdigit()
+                    or int(holder[1:]) <= 1):
+                return False
+            if group_alive(int(holder[1:])):
+                return False
+            try:
+                owner_fd_v4, owner_value_v4 = open_existing_owned_regular(
+                    owner_path_v4,
+                )
+            except FileNotFoundError:
+                return unlink_exact_link(bridge_name)
+            try:
+                owner_record = read_ascii(owner_fd_v4)
+                expected_owner = (
+                    f"iwe-oauth-lineage-v4 {oauth_lease_value.st_dev} "
+                    f"{oauth_lease_value.st_ino} {bridge_nonce}"
+                )
+                if owner_record != expected_owner:
+                    return False
+                if (not path_names_inode(oauth_lineage_path, link_value)
+                        or os.readlink(oauth_lineage_path) != bridge_name
+                        or not path_names_inode(
+                            bridge_directory, directory_value,
+                        )
+                        or not path_names_inode(pid_path, pid_value)
+                        or not path_names_inode(owner_path_v4, owner_value_v4)
+                        or read_ascii(pid_fd) != holder
+                        or read_ascii(owner_fd_v4) != owner_record
+                        or not path_names_inode(
+                            oauth_lease_path, oauth_lease_value,
+                        )):
+                    return False
+
+                if not unlink_exact_link(bridge_name):
+                    return False
+                if (not path_names_inode(bridge_directory, directory_value)
+                        or not path_names_inode(pid_path, pid_value)
+                        or not path_names_inode(owner_path_v4, owner_value_v4)
+                        or read_ascii(pid_fd) != holder
+                        or read_ascii(owner_fd_v4) != owner_record):
+                    return True
+                os.unlink(owner_path_v4)
+                os.unlink(pid_path)
+                os.rmdir(bridge_directory)
+                return True
+            finally:
+                os.close(owner_fd_v4)
+        finally:
+            os.close(pid_fd)
+    except FileNotFoundError:
+        return not os.path.lexists(oauth_lineage_path)
+
+
+def remove_stale_oauth_bridge():
+    """Recover only the new-only runtime lineage namespace."""
+    try:
+        value = os.lstat(oauth_lineage_path)
+    except FileNotFoundError:
+        return True
+    if stat.S_ISLNK(value.st_mode):
+        return remove_stale_v4_oauth_lineage(value)
+    # Compliant v4 writers publish only a relative symlink. Unknown objects at
+    # the new-only name indicate tampering and remain fail-closed.
+    return False
+
+
+def cleanup_unpublished_bridge(directory_value, pid_fd_local, pid_value_local,
+                               owner_fd_local, owner_value_local):
+    """Best-effort cleanup for a private bridge never named by canonical."""
+    try:
+        if owner_fd_local is not None and path_names_inode(
+                oauth_owner_path(), owner_value_local):
+            os.unlink(oauth_owner_path())
+        if pid_fd_local is not None and path_names_inode(
+                oauth_pid_path(), pid_value_local):
+            os.unlink(oauth_pid_path())
+        if path_names_inode(oauth_bridge_directory, directory_value):
+            os.rmdir(oauth_bridge_directory)
+    except (FileNotFoundError, OSError):
+        pass
+
+
+def acquire_oauth_once():
+    """One nonblocking acquisition step, owned entirely by this helper."""
+    global oauth_lease_fd, oauth_lease_value
+    global oauth_link_value, oauth_directory_created, oauth_directory_value
+    global oauth_lock_acquired, oauth_holder_record
+    global oauth_pid_fd, oauth_pid_value, oauth_token_fd, oauth_token_value
+    global oauth_owner_payload, oauth_cleanup_owner_payloads
+    global oauth_cleanup_holder_records
+
+    if oauth_lease_fd is None:
+        candidate_fd, candidate_value = open_owned_regular(oauth_lease_path)
+        try:
+            fcntl.flock(candidate_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            os.close(candidate_fd)
+            if exc.errno in (errno.EACCES, errno.EAGAIN):
+                return False
+            raise
+        if not path_names_inode(oauth_lease_path, candidate_value):
+            os.close(candidate_fd)
+            raise RuntimeError("global OAuth lease identity changed")
+        oauth_lease_fd = candidate_fd
+        oauth_lease_value = candidate_value
+        if not load_exact_oauth_fence():
+            publish_failure("oauth-v4-cutover-required")
+            raise RuntimeError(
+                "OAuth v4 cutover fence missing or invalid; explicit "
+                "--cutover-oauth-lineage-v4 required after legacy drain"
+            )
+
+    if oauth_lock_acquired:
+        return True
+    if os.path.lexists(oauth_lineage_path):
+        if not remove_stale_oauth_bridge():
+            return False
+
+    local_pid_fd = None
+    local_pid_value = None
+    local_owner_fd = None
+    local_owner_value = None
+    try:
+        os.mkdir(oauth_bridge_directory, 0o700)
+    except FileExistsError:
+        raise RuntimeError("OAuth bridge nonce collision")
+    directory_value = os.lstat(oauth_bridge_directory)
+    if (not stat.S_ISDIR(directory_value.st_mode)
+            or directory_value.st_uid != os.getuid()
+            or stat.S_IMODE(directory_value.st_mode) != 0o700):
+        raise RuntimeError("unsafe created OAuth private bridge")
+
+    try:
+        mkdir_barrier = os.environ.get("IWE_PEER_TEST_OAUTH_POST_MKDIR_BARRIER")
+        if mkdir_barrier:
+            publish_exclusive(f"{mkdir_barrier}.ready", str(os.getpid()))
+            while not os.path.exists(f"{mkdir_barrier}.release"):
+                fault = current_session_fault()
+                if fault:
+                    raise RuntimeError(f"OAuth post-mkdir barrier: {fault}")
+                time.sleep(0.02)
+
+        controller_holder = f"-{controller_pgid}"
+        publish_exclusive(oauth_pid_path(), controller_holder)
+        local_pid_fd, local_pid_value = open_existing_owned_regular(
+            oauth_pid_path(), writable=True,
+        )
+        barrier = os.environ.get("IWE_PEER_TEST_OAUTH_PRE_OWNER_BARRIER")
+        if barrier:
+            publish_exclusive(f"{barrier}.ready", str(os.getpid()))
+            while not os.path.exists(f"{barrier}.release"):
+                fault = current_session_fault()
+                if fault:
+                    raise RuntimeError(f"OAuth pre-owner barrier: {fault}")
+                time.sleep(0.02)
+
+        owner_record = oauth_owner_record()
+        publish_exclusive(oauth_owner_path(), owner_record)
+        local_owner_fd, local_owner_value = open_existing_owned_regular(
+            oauth_owner_path(), writable=True,
+        )
+        fsync_directory(oauth_bridge_directory)
+        try:
+            os.symlink(oauth_bridge_name, oauth_lineage_path)
+        except FileExistsError:
+            cleanup_unpublished_bridge(
+                directory_value, local_pid_fd, local_pid_value,
+                local_owner_fd, local_owner_value,
+            )
+            os.close(local_owner_fd)
+            os.close(local_pid_fd)
+            return False
+        link_value = os.lstat(oauth_lineage_path)
+        if (not stat.S_ISLNK(link_value.st_mode)
+                or link_value.st_uid != os.getuid()
+                or os.readlink(oauth_lineage_path) != oauth_bridge_name):
+            raise RuntimeError("unsafe published OAuth v4 lineage link")
+        fsync_directory(root_directory)
+    except Exception:
+        if os.path.lexists(oauth_lineage_path):
+            try:
+                link = os.lstat(oauth_lineage_path)
+                if (stat.S_ISLNK(link.st_mode)
+                        and os.readlink(oauth_lineage_path) == oauth_bridge_name):
+                    os.unlink(oauth_lineage_path)
+            except (FileNotFoundError, OSError):
+                pass
+        cleanup_unpublished_bridge(
+            directory_value, local_pid_fd, local_pid_value,
+            local_owner_fd, local_owner_value,
+        )
+        raise
+
+    oauth_link_value = link_value
+    oauth_directory_created = True
+    oauth_directory_value = directory_value
+    oauth_pid_fd, oauth_pid_value = local_pid_fd, local_pid_value
+    oauth_token_fd, oauth_token_value = local_owner_fd, local_owner_value
+    oauth_holder_record = controller_holder
+    oauth_cleanup_holder_records.add(controller_holder)
+    oauth_owner_payload = owner_record
+    oauth_cleanup_owner_payloads.add(owner_record)
+    sentinel_barrier = os.environ.get("IWE_PEER_TEST_OAUTH_PRE_SENTINEL_BARRIER")
+    if sentinel_barrier:
+        publish_exclusive(f"{sentinel_barrier}.ready", str(os.getpid()))
+        while not os.path.exists(f"{sentinel_barrier}.release"):
+            fault = current_session_fault()
+            if fault:
+                raise RuntimeError(f"OAuth pre-sentinel barrier: {fault}")
+            time.sleep(0.02)
+    oauth_lock_acquired = True
+    return True
+
+
+def release_owned_oauth_lock():
+    """Remove only this exact runtime symlink and its private lineage."""
+    if not oauth_directory_created or oauth_directory_value is None:
+        return
+    pid_path = oauth_pid_path()
+    token_path = oauth_owner_path()
+    try:
+        if oauth_link_fault():
+            return
+        if not path_names_inode(oauth_bridge_directory, oauth_directory_value):
+            return
+        if oauth_pid_fd is not None:
+            holder = read_ascii(oauth_pid_fd)
+            if (holder not in oauth_cleanup_holder_records
+                    or not path_names_inode(pid_path, oauth_pid_value)):
+                return
+        if oauth_token_fd is not None and (
+                read_ascii(oauth_token_fd) not in oauth_cleanup_owner_payloads
+                or not path_names_inode(token_path, oauth_token_value)):
+            return
+        # The permanent compatibility fence is never touched. Remove only the
+        # new-only runtime name; every remaining unlink is nonce-private.
+        os.unlink(oauth_lineage_path)
+        if oauth_token_fd is not None:
+            os.unlink(token_path)
+        if oauth_pid_fd is not None:
+            if not path_names_inode(pid_path, oauth_pid_value):
+                return
+            os.unlink(pid_path)
+        if path_names_inode(oauth_bridge_directory, oauth_directory_value):
+            os.rmdir(oauth_bridge_directory)
+    except FileNotFoundError:
+        return
+    except (OSError, RuntimeError) as exc:
+        sys.stderr.write(f"WARN: cannot clean owned OAuth lock: {exc}\n")
+
+
+def sentinel_arm_vendor_if_published():
+    """Atomically move the legacy holder from controller PG to vendor PG."""
+    global oauth_pid_fd, oauth_pid_value, oauth_holder_record
+    global vendor_handoff_pgid
+    if vendor_handoff_pgid is not None:
+        return True
+    pgid = read_vendor_pgid()
+    if pgid is None:
+        return False
+    if not pgid or not group_alive(pgid):
+        raise RuntimeError("published vendor process group is gone")
+
+    tmp_path = (
+        f"{oauth_pid_path()}.{os.getpid()}.{secrets.token_hex(8)}.tmp"
+    )
+    out = os.open(tmp_path, EXCLUSIVE_FLAGS, 0o600)
+    try:
+        os.write(out, f"-{pgid}\n".encode("ascii"))
+        os.fsync(out)
+    finally:
+        os.close(out)
+    os.replace(tmp_path, oauth_pid_path())
+    fsync_directory(oauth_bridge_directory)
+    candidate_fd, candidate_value = open_existing_owned_regular(
+        oauth_pid_path(), writable=True,
+    )
+    expected = f"-{pgid}"
+    if (read_ascii(candidate_fd) != expected
+            or not path_names_inode(oauth_pid_path(), candidate_value)):
+        os.close(candidate_fd)
+        raise RuntimeError("vendor holder publication changed")
+    previous_fd = oauth_pid_fd
+    oauth_pid_fd = candidate_fd
+    oauth_pid_value = candidate_value
+    oauth_holder_record = expected
+    oauth_cleanup_holder_records.add(expected)
+    vendor_handoff_pgid = pgid
+    os.close(previous_fd)
+    publish_atomic(vendor_armed_path, f"{nonce} {pgid}")
+    return True
+
+
+def helper_open_vendor_exec_gate():
+    """Open exec only after sentinel published and retained the vendor PGID."""
+    global vendor_gate_open
+    if vendor_gate_open or sentinel_pid is None:
+        return vendor_gate_open
+    try:
+        armed_fd, _armed_value = open_existing_owned_regular(vendor_armed_path)
+    except FileNotFoundError:
+        return False
+    try:
+        record = read_ascii(armed_fd)
+    finally:
+        os.close(armed_fd)
+    fields = record.split(" ")
+    if (len(fields) != 2 or fields[0] != nonce
+            or not fields[1].isdigit() or int(fields[1]) <= 1):
+        raise RuntimeError("invalid vendor armed acknowledgement")
+    pgid = int(fields[1])
+    if read_vendor_pgid() != pgid or not adopt_vendor_pid_if_published():
+        raise RuntimeError("vendor armed acknowledgement lost authority")
+    if reap_sentinel() or current_authority_fault():
+        raise RuntimeError("sentinel lost before vendor exec gate")
+    publish_atomic(vendor_exec_gate, f"{nonce} {pgid}")
+    vendor_gate_open = True
+    return True
+
+
+def cleanup_authorities():
+    """Release metadata only after this process has proved lineage EOF."""
+    # OAuth first: while either helper or sentinel remains alive, the shared
+    # permanent flock still excludes new adapters. Exact inode+nonce checks
+    # prevent this invocation from removing a replacement bridge.
+    release_owned_oauth_lock()
+    try:
+        if (owner_fd is not None
+                and not metadata_fault(
+                    owner_path, owner_value, owner_fd, f"{owner_pid} {nonce}",
+                    "changed", "missing",
+                )):
+            os.unlink(owner_path)
+    except (FileNotFoundError, OSError) as exc:
+        sys.stderr.write(f"WARN: cannot clean owner metadata: {exc}\n")
+    try:
+        if (legacy_fd is not None
+                and not metadata_fault(
+                    legacy_path, legacy_value, legacy_fd, str(owner_pid),
+                    "changed", "missing",
+                )):
+            os.ftruncate(legacy_fd, 0)
+            os.fsync(legacy_fd)
+    except (FileNotFoundError, OSError) as exc:
+        sys.stderr.write(f"WARN: cannot clean legacy lock metadata: {exc}\n")
+
+
+def run_oauth_sentinel(helper_pid, ack_fd):
+    """Keep every admission authority alive if the Python helper is killed."""
+    global stop_requested
+    sentinel_self = os.getpid()
+    sentinel_armed = False
+    cleanup_on_exit = False
+    failure_reason = None
+    exit_code = 1
+    try:
+        # The bridge already points at the controller process group. This
+        # sentinel is a second member of that group, so deployed Bash readers
+        # keep seeing `kill -0 -PGID` succeed if either controller dies.
+        fault = current_authority_fault()
+        if fault:
+            raise RuntimeError(f"sentinel authority handoff: {fault}")
+        sentinel_armed = True
+        try:
+            os.write(
+                ack_fd,
+                f"armed:{sentinel_self}:{nonce}\n".encode("ascii"),
+            )
+        except BrokenPipeError:
+            # Parent death is exactly the fault this process exists to cover.
+            pass
+
+        while True:
+            sentinel_arm_vendor_if_published()
+            if fifo_eof(fifo_fd):
+                if os.getppid() == helper_pid:
+                    # Normal release belongs to the still-live controller.
+                    # It reaps us before cleaning metadata, so we never race
+                    # its authority checks by truncating a shared inode.
+                    exit_code = 0
+                else:
+                    failure_reason = "lock-helper-process-gone"
+                    cleanup_on_exit = True
+                    publish_failure(failure_reason)
+                break
+            if stop_requested:
+                failure_reason = "lock-sentinel-stop-requested"
+            elif os.getppid() != helper_pid:
+                failure_reason = "lock-helper-process-gone"
+            else:
+                failure_reason = current_authority_fault()
+            if failure_reason:
+                publish_failure(failure_reason)
+                drain_lineage()
+                cleanup_on_exit = True
+                break
+            time.sleep(0.05)
+    except Exception as exc:
+        if sentinel_armed:
+            failure_reason = f"lock-sentinel-error:{type(exc).__name__}"
+            try:
+                publish_failure(failure_reason)
+            except Exception as report_exc:
+                sys.stderr.write(
+                    f"WARN: cannot publish lock-sentinel failure: {report_exc}\n"
+                )
+            drain_lineage()
+            cleanup_on_exit = True
+        else:
+            try:
+                os.write(
+                    ack_fd,
+                    f"error:{type(exc).__name__}\n".encode("ascii"),
+                )
+            except (BrokenPipeError, OSError):
+                pass
+    finally:
+        try:
+            os.close(ack_fd)
+        except OSError:
+            pass
+        if sentinel_armed and cleanup_on_exit:
+            cleanup_authorities()
+    os._exit(exit_code if failure_reason is None else 1)
+
+
+def start_oauth_sentinel():
+    """Fork and verify the second owner before vendor admission is opened."""
+    global sentinel_pid
+    ack_read, ack_write = os.pipe()
+    helper_pid = os.getpid()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os.close(ack_read)
+        run_oauth_sentinel(helper_pid, ack_write)
+    os.close(ack_write)
+    sentinel_pid = child_pid
+
+    flags = fcntl.fcntl(ack_read, fcntl.F_GETFL)
+    fcntl.fcntl(ack_read, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+    expected = f"armed:{child_pid}:{nonce}"
+    payload = b""
+    deadline = time.monotonic() + 5.0
+    try:
+        while time.monotonic() < deadline:
+            if os.getppid() != owner_pid:
+                raise RuntimeError("owner process gone during sentinel handoff")
+            try:
+                chunk = os.read(ack_read, 256)
+            except BlockingIOError:
+                chunk = None
+            if chunk == b"":
+                break
+            if chunk:
+                payload += chunk
+                if b"\n" in payload:
+                    break
+            if reap_sentinel():
+                break
+            time.sleep(0.02)
+    finally:
+        os.close(ack_read)
+
+    status = payload.split(b"\n", 1)[0].decode("ascii", "replace")
+    if status != expected:
+        raise RuntimeError(f"OAuth sentinel failed to arm: {status or 'no status'}")
+    fault = current_authority_fault()
+    if fault:
+        raise RuntimeError(f"OAuth sentinel handoff lost authority: {fault}")
+    sentinel_barrier = os.environ.get("IWE_PEER_TEST_OAUTH_PRE_SENTINEL_BARRIER")
+    if sentinel_barrier:
+        publish_exclusive(f"{sentinel_barrier}.sentinel", str(child_pid))
+
+
+try:
+    os.setsid()
+    controller_pgid = os.getpgrp()
+    if controller_pgid != os.getpid():
+        raise RuntimeError("lock helper did not establish a private process group")
+    ensure_owned_directory(root_directory)
+    ensure_owned_directory(session_directory)
+
+    lease_fd, lease_value = open_owned_regular(lease_path)
+
+    try:
+        fcntl.flock(lease_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError as exc:
         if exc.errno in (errno.EACCES, errno.EAGAIN):
             publish_status("busy")
             raise SystemExit(5)
         raise
 
-    # The previous owner may have unlinked this inode while we were between
-    # open() and flock(). Never hold a private, unreachable lock while another
-    # adapter owns the newly-created path.
-    current = os.lstat(path)
-    if (value.st_dev, value.st_ino) != (current.st_dev, current.st_ino):
+    # Stable lease is never removed by normal cleanup. Detect an unexpected
+    # replacement across open/flock and retry before any vendor can start.
+    if not path_names_inode(lease_path, lease_value):
         publish_status("retry-boundary")
         raise SystemExit(75)
 
-    # Compatibility with an old live adapter that wrote this same pidfile but
-    # did not yet use flock.  A dead legacy PID is stale data, not authority.
-    os.lseek(fd, 0, os.SEEK_SET)
-    previous = os.read(fd, 128).decode("ascii", "ignore").strip()
-    if previous.isdigit() and int(previous) != owner_pid and process_alive(int(previous)):
+    # Rollout compatibility: lock the historical <id>.pid inode too. A live
+    # old adapter therefore blocks the new one, and an old adapter starting
+    # while this invocation runs sees its familiar flock as busy.
+    legacy_fd, legacy_value = open_owned_regular(legacy_path)
+    try:
+        fcntl.flock(legacy_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        if exc.errno in (errno.EACCES, errno.EAGAIN):
+            publish_status("busy-legacy")
+            raise SystemExit(5)
+        raise
+    if not path_names_inode(legacy_path, legacy_value):
+        publish_status("retry-boundary")
+        raise SystemExit(75)
+    previous = read_ascii(legacy_fd, 128)
+    if (previous.isdigit()
+            and int(previous) != owner_pid
+            and process_alive(int(previous))):
         publish_status("busy-legacy")
         raise SystemExit(5)
+    overwrite_ascii(legacy_fd, str(owner_pid))
 
-    os.ftruncate(fd, 0)
-    os.lseek(fd, 0, os.SEEK_SET)
-    os.write(fd, f"{owner_pid}\n".encode("ascii"))
-    os.fsync(fd)
-    publish_status("acquired")
+    owner_fd, owner_value = open_owned_regular(owner_path)
+    overwrite_ascii(owner_fd, f"{owner_pid} {nonce}")
+
+    fifo_flags = os.O_RDONLY | os.O_NONBLOCK
+    fifo_flags |= NOFOLLOW | CLOEXEC
+    fifo_fd = os.open(lifetime_fifo, fifo_flags)
+    fifo_value = os.fstat(fifo_fd)
+    if not stat.S_ISFIFO(fifo_value.st_mode) or fifo_value.st_uid != os.getuid():
+        raise RuntimeError("unsafe peer lifetime FIFO")
+
+    publish_status(f"acquired:{nonce}")
+    lock_acquired = True
+
+    token = b""
+    while b"\n" not in token:
+        if os.getppid() != owner_pid:
+            raise SystemExit(0)
+        try:
+            chunk = os.read(fifo_fd, 256)
+        except BlockingIOError:
+            chunk = None
+        if chunk == b"":
+            raise SystemExit(0)
+        if chunk:
+            token += chunk
+        else:
+            time.sleep(0.02)
+    if token.split(b"\n", 1)[0].decode("ascii", "strict") != nonce:
+        raise RuntimeError("peer lifetime nonce mismatch")
+    publish_exclusive(armed, nonce)
+    lease_armed = True
 
     def request_stop(_signum, _frame):
-        nonlocal_stop[0] = True
+        global stop_requested
+        stop_requested = True
 
-    nonlocal_stop = [False]
     signal.signal(signal.SIGHUP, request_stop)
     signal.signal(signal.SIGINT, request_stop)
     signal.signal(signal.SIGTERM, request_stop)
-    while not nonlocal_stop[0] and os.getppid() == owner_pid:
-        try:
-            linked = os.lstat(path)
-            os.lseek(fd, 0, os.SEEK_SET)
-            payload = os.read(fd, 128).decode("ascii", "ignore").strip()
-            if ((linked.st_dev, linked.st_ino) != (value.st_dev, value.st_ino)
-                    or payload != str(owner_pid)):
-                os.kill(owner_pid, signal.SIGTERM)
-                break
-        except (FileNotFoundError, ProcessLookupError):
+    failure_reason = None
+    while True:
+        if fifo_eof(fifo_fd):
+            break
+        failure_reason = current_session_fault()
+        if not failure_reason and read_oauth_request():
+            if oauth_wait_started is None:
+                oauth_wait_started = time.monotonic()
+            if acquire_oauth_once():
+                if sentinel_pid is None:
+                    start_oauth_sentinel()
+                if not os.path.exists(oauth_ready):
+                    publish_exclusive(oauth_ready, nonce)
+            elif time.monotonic() - oauth_wait_started >= oauth_timeout:
+                failure_reason = "oauth-lock-timeout"
+        if not failure_reason and sentinel_pid is not None:
+            helper_open_vendor_exec_gate()
+        if failure_reason:
+            publish_failure(failure_reason)
+            drain_lineage()
             break
         time.sleep(0.1)
 except SystemExit:
     raise
 except Exception as exc:
-    try:
-        publish_status(f"error:{type(exc).__name__}")
-    except Exception:
-        pass
+    if lock_acquired and lease_armed:
+        try:
+            publish_failure(f"lock-helper-error:{type(exc).__name__}")
+        except Exception as report_exc:
+            sys.stderr.write(f"WARN: cannot publish lock-helper failure: {report_exc}\n")
+        drain_lineage()
+    else:
+        try:
+            publish_status(f"error:{type(exc).__name__}")
+        except Exception as report_exc:
+            sys.stderr.write(f"WARN: cannot publish lock-helper status: {report_exc}\n")
     raise SystemExit(1)
 finally:
-    # Remove only the path that still names our locked inode and still carries
-    # our owner PID. A replacement created by another process is preserved.
-    try:
-        if "fd" in locals():
-            linked = os.lstat(path)
-            value = os.fstat(fd)
-            os.lseek(fd, 0, os.SEEK_SET)
-            payload = os.read(fd, 128).decode("ascii", "ignore").strip()
-            if ((linked.st_dev, linked.st_ino) == (value.st_dev, value.st_ino)
-                    and payload == str(owner_pid)):
-                os.unlink(path)
-    except (FileNotFoundError, OSError):
-        pass
+    # This exact helper/sentinel pair is one dual-owner lock state machine.
+    # Both inherit the same open-file descriptions, so either process
+    # surviving a single fault retains every kernel flock; splitting further
+    # would break that lifetime invariant.
+    if sentinel_pid is not None and not sentinel_reaped:
+        reap_sentinel(block=True)
+    cleanup_authorities()
 PY
-  SESSION_LOCK_HELPER_PID=$!
+    SESSION_LOCK_HELPER_PID=$!
 
-  for _wait in $(seq 1 100); do
-    [ -s "$SESSION_LOCK_READY" ] && break
-    kill -0 "$SESSION_LOCK_HELPER_PID" 2>/dev/null || break
-    sleep 0.05
+    for _wait in $(seq 1 100); do
+      [ -s "$SESSION_LOCK_READY" ] && break
+      kill -0 "$SESSION_LOCK_HELPER_PID" 2>/dev/null || break
+      sleep 0.05
+    done
+    status="$(cat "$SESSION_LOCK_READY" 2>/dev/null || true)"
+    case "$status" in
+      acquired:*)
+        SESSION_LOCK_NONCE="${status#acquired:}"
+        if ! printf '%s\n' "$SESSION_LOCK_NONCE" >&9; then
+          status="arm-write-failed"
+        else
+          for _wait in $(seq 1 100); do
+            [ -s "$SESSION_LOCK_ARMED" ] && break
+            kill -0 "$SESSION_LOCK_HELPER_PID" 2>/dev/null || break
+            sleep 0.02
+          done
+          if [ "$(cat "$SESSION_LOCK_ARMED" 2>/dev/null || true)" = "$SESSION_LOCK_NONCE" ]; then
+            SESSION_LOCK_HELD=true
+            return 0
+          fi
+          status="arm-failed"
+        fi
+        ;;
+      retry-boundary)
+        wait "$SESSION_LOCK_HELPER_PID" 2>/dev/null || helper_rc=$?
+        if [ "$helper_rc" -eq 75 ] && [ "$attempt" -lt "$max_attempts" ]; then
+          echo "WARN: peer-session lock path changed during acquisition; retrying ($attempt/$max_attempts)." >&2
+          attempt=$((attempt + 1))
+          continue
+        fi
+        ;;
+      busy|busy-legacy)
+        wait "$SESSION_LOCK_HELPER_PID" 2>/dev/null || helper_rc=$?
+        echo "ABORT: peer session '$KIMI_SESSION_ID' already running." >&2
+        [ "$helper_rc" -eq 5 ] && return 5
+        return 1
+        ;;
+    esac
+    # If acquisition reached the armed state but its acknowledgement was lost,
+    # TERM makes the helper drain its FIFO. Close our only possible writer
+    # first; no vendor is allowed to start before acquire_session_lock returns.
+    if [ "$SESSION_LIFETIME_FD_OPEN" = true ]; then
+      exec 9>&-
+      SESSION_LIFETIME_FD_OPEN=false
+    fi
+    if jobs -pr | grep -qx "$SESSION_LOCK_HELPER_PID"; then
+      kill "$SESSION_LOCK_HELPER_PID" 2>/dev/null || true
+    fi
+    wait "$SESSION_LOCK_HELPER_PID" 2>/dev/null || helper_rc=$?
+    echo "ERROR: cannot acquire exact peer-session lock for '$KIMI_SESSION_ID' (${status:-no status}, rc=$helper_rc)." >&2
+    return 1
   done
-  status="$(cat "$SESSION_LOCK_READY" 2>/dev/null || true)"
-  case "$status" in
-    acquired)
-      SESSION_LOCK_HELD=true
-      return 0
-      ;;
-    busy|busy-legacy)
-      wait "$SESSION_LOCK_HELPER_PID" 2>/dev/null || helper_rc=$?
-      echo "ABORT: peer session '$KIMI_SESSION_ID' already running." >&2
-      [ "$helper_rc" -eq 5 ] && return 5
-      return 1
-      ;;
-    *)
-      if jobs -pr | grep -qx "$SESSION_LOCK_HELPER_PID"; then
-        kill "$SESSION_LOCK_HELPER_PID" 2>/dev/null || true
-      fi
-      wait "$SESSION_LOCK_HELPER_PID" 2>/dev/null || helper_rc=$?
-      echo "ERROR: cannot acquire exact peer-session lock for '$KIMI_SESSION_ID' (${status:-no status}, rc=$helper_rc)." >&2
-      return 1
-      ;;
-  esac
+  return 1
 }
 
 acquire_session_lock
@@ -592,14 +2010,14 @@ PEER_HEARTBEAT_READY="$TMP_ROOT/peer-heartbeat.ready"
 create_peer_heartbeat() {
   local identity
   identity=$(python3 - "$PEER_HEARTBEAT_DIR" "$PEER_HEARTBEAT_FILE" "$KIMI_TASK" \
-    "$OUR_PID" <<'PY'
+    "$KIMI_WP" "$OUR_PID" <<'PY'
 import datetime
 import os
 import stat
 import sys
 import uuid
 
-directory, path, task, owner_pid = sys.argv[1:]
+directory, path, task, wp, owner_pid = sys.argv[1:]
 os.makedirs(directory, mode=0o700, exist_ok=True)
 directory_stat = os.lstat(directory)
 if (not stat.S_ISDIR(directory_stat.st_mode)
@@ -637,7 +2055,7 @@ try:
     os.ftruncate(fd, 0)
     payload = (
         f"opened_at: {opened_at}\n"
-        "wp: WP-7\n"
+        f"wp: {wp}\n"
         f"task: {task}\n"
         "agent: kimi-peer\n"
         f"owner_pid: {owner_pid}\n"
@@ -678,7 +2096,7 @@ PY
 
 start_peer_heartbeat() {
   python3 - "$PEER_HEARTBEAT_FILE" "$PEER_HEARTBEAT_DEV" "$PEER_HEARTBEAT_INO" \
-    "$OUR_PID" "$IWE_PEER_HEARTBEAT_SECONDS" "$PEER_HEARTBEAT_READY" <<'PY' &
+    "$OUR_PID" "$IWE_PEER_HEARTBEAT_SECONDS" "$PEER_HEARTBEAT_READY" 9>&- <<'PY' &
 import datetime
 import os
 import signal
@@ -769,7 +2187,7 @@ cleanup_peer() {
   local hb_reap_guard
   [ "$CLEANUP_PEER_STARTED" = false ] || return 0
   CLEANUP_PEER_STARTED=true
-  [ -x "$_IWE_ARS" ] && bash "$_IWE_ARS" --session-id "$KIMI_SESSION_ID" kimi idle 2>/dev/null &
+  [ -x "$_IWE_ARS" ] && bash "$_IWE_ARS" --session-id "$KIMI_SESSION_ID" kimi idle 9>&- 2>/dev/null &
   # Stop and reap the direct heartbeat helper. It checks the adapter's exact
   # parent relationship itself, so SIGKILL of the adapter also makes it exit.
   # The bounded reap guard prevents an unexpected helper fault from hanging
@@ -777,7 +2195,7 @@ cleanup_peer() {
   if [ -n "$PEER_HB_PID" ]; then
     if jobs -pr | grep -qx "$PEER_HB_PID"; then
       kill "$PEER_HB_PID" 2>/dev/null || true
-      ( sleep 5; kill -9 "$PEER_HB_PID" 2>/dev/null ) &
+      ( exec 9>&-; sleep 5; kill -9 "$PEER_HB_PID" 2>/dev/null ) &
       hb_reap_guard=$!
     else
       hb_reap_guard=""
@@ -789,11 +2207,9 @@ cleanup_peer() {
     remove_peer_heartbeat 2>/dev/null || true
   fi
   release_session_lock
+  # The helper/sentinel authority pair releases OAuth by exact versioned
+  # lease+PID+nonce after FIFO EOF. The top adapter never removes that bridge.
   rm -rf "$TMP_ROOT"
-  # Only release the OAuth-refresh lock if this invocation actually holds it —
-  # an invocation that gave up waiting must never remove the winner's lock.
-  # rm -rf, not rmdir: the lock dir holds a pid file (staleness check), not empty.
-  [ "$OAUTH_LOCK_HELD" = true ] && rm -rf "$OAUTH_LOCK_DIR" 2>/dev/null
   return 0
 }
 trap cleanup_peer EXIT
@@ -810,7 +2226,7 @@ if ! start_peer_heartbeat; then
   exit 1
 fi
 
-[ -x "$_IWE_ARS" ] && bash "$_IWE_ARS" --session-id "$KIMI_SESSION_ID" kimi peer-session "$KIMI_TASK" 2>/dev/null &
+[ -x "$_IWE_ARS" ] && bash "$_IWE_ARS" --session-id "$KIMI_SESSION_ID" kimi peer-session "$KIMI_TASK" 9>&- 2>/dev/null &
 
 # === Запуск Kimi with process-group deadline ===
 # `perl alarm; exec` used to signal only the CLI launcher.  If Kimi had spawned
@@ -841,7 +2257,7 @@ fi
 # Legacy CLI: prompt via stdin, flags --quiet --yolo.  Modern CLI: `-p` plus
 # `--agent-file`, stream-json, and no auto-approved tools.
 KIMI_HELP_FILE="$TMP_ROOT/kimi-help.txt"
-"$KIMI_BIN" --help > "$KIMI_HELP_FILE" 2>/dev/null || true
+"$KIMI_BIN" --help 9>&- > "$KIMI_HELP_FILE" 2>/dev/null || true
 if grep -q -- '--agent-file' "$KIMI_HELP_FILE"; then
   KIMI_CLI_STYLE="prompt-arg"
 else
@@ -940,47 +2356,57 @@ fi
 # Ory reuse-detection, which revokes the token and forces a fresh browser login.
 # We can't patch the closed Kimi binary, so we serialize our own invocations instead.
 #
-# Portable mkdir-based lock (peer-session 2026-08-04-08-wp7-f44-sandbox-review):
-# the previous `lockf` binary is BSD/macOS-only and absent on most Linux
-# distros — the old code silently skipped serialization when missing (found
-# 04.08, pilot decision: eliminate the dependency rather than choose between
-# fail-open and fail-closed). `mkdir` is atomic on every POSIX filesystem.
+# After an explicit quiescent cutover, deployed schedulers remain blocked on an
+# immutable legacy fence. New adapters serialize on a permanent regular-file
+# flock shared by a lineage helper and its fault-isolated sentinel, plus a
+# separate new-only runtime symlink. A mandatory pre-exec gate transfers the
+# runtime holder from the helper/sentinel group to the vendor group before code
+# runs. The top shell only sends a private request, so its SIGKILL cannot
+# interrupt publication or release admission while a vendor survives.
 acquire_oauth_lock() {
-  mkdir -p "$(dirname "$OAUTH_LOCK_DIR")" 2>/dev/null
-  local waited=0
-  while true; do
-    if mkdir "$OAUTH_LOCK_DIR" 2>/dev/null; then
-      echo "$$" > "$OAUTH_LOCK_DIR/pid" 2>/dev/null
-      OAUTH_LOCK_HELD=true
+  local request_tmp="${SESSION_OAUTH_REQUEST}.$$" status _wait
+  rm -f "$SESSION_OAUTH_READY" "$request_tmp"
+  if ! printf '%s\n' "$SESSION_LOCK_NONCE" > "$request_tmp" \
+     || ! mv "$request_tmp" "$SESSION_OAUTH_REQUEST" 9>&-; then
+    rm -f "$request_tmp"
+    return 1
+  fi
+  for _wait in $(seq 1 $((IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS * 20 + 40))); do
+    status=$(cat "$SESSION_OAUTH_READY" 2>/dev/null || true)
+    if [ "$status" = "$SESSION_LOCK_NONCE" ]; then
       return 0
     fi
-    # Stale-lock guard: liveness (kill -0 on the holder's PID), not age — a
-    # legitimate Kimi call can run up to 300s (perl alarm below), well past
-    # any fixed timeout, so a time-based guard would steal a live holder's
-    # lock (found in cold review of peer-session
-    # 2026-08-04-08-wp7-f44-sandbox-review, same pattern already used for
-    # the pidfile lock above). No sleep is skipped on this branch — always
-    # falls through to the shared wait below, so a holder whose pid file
-    # hasn't landed yet (mkdir/pid-write isn't atomic together) just waits
-    # a beat instead of racing to break a lock it can't yet identify.
-    local holder_pid
-    holder_pid=$(cat "$OAUTH_LOCK_DIR/pid" 2>/dev/null | tr -d '[:space:]')
-    if [ -n "$holder_pid" ] && ! kill -0 "$holder_pid" 2>/dev/null; then
-      rm -rf "$OAUTH_LOCK_DIR" 2>/dev/null
-    fi
-    [ "$waited" -ge 90 ] && return 1
-    sleep 1
-    waited=$((waited + 1))
+    [ -s "$SESSION_LOCK_FAILURE" ] && return 1
+    kill -0 "$SESSION_LOCK_HELPER_PID" 2>/dev/null || return 1
+    sleep 0.05
   done
+  return 1
 }
 if ! acquire_oauth_lock; then
-  echo "ERROR: OAuth refresh lock busy after 90s — another Kimi process is mid-refresh on $OAUTH_LOCK_DIR." >&2
+  if [ "$(cat "$SESSION_LOCK_FAILURE" 2>/dev/null || true)" = "oauth-v4-cutover-required" ]; then
+    echo "ERROR: OAuth lineage v4 cutover is required. Disable and drain every legacy Kimi launcher, then run with --cutover-oauth-lineage-v4 and IWE_OAUTH_CUTOVER_QUIESCED=1." >&2
+  else
+    echo "ERROR: OAuth refresh lock busy after ${IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS}s — another Kimi process is mid-refresh on $OAUTH_LOCK_DIR." >&2
+  fi
   exit 1
 fi
 
 # Text-only mode always inlines the filtered context.  Passing --add-dir would
 # re-expose a workspace even though the no-tools profile does not need it.
 KIMI_DIR_ARGS=()
+KIMI_LINEAGE_ARGS=(
+  --pgid-file "$SESSION_VENDOR_PGID_FILE"
+  --lineage-nonce "$SESSION_LOCK_NONCE"
+  --exec-gate-file "$SESSION_VENDOR_EXEC_GATE"
+)
+# Deterministic process-boundary seams used only by the adapter regression
+# suite. They are inert unless an explicit test path is supplied.
+if [ -n "${IWE_PEER_TEST_PRE_SETSID_BARRIER:-}" ]; then
+  KIMI_LINEAGE_ARGS+=(--pre-setsid-barrier "$IWE_PEER_TEST_PRE_SETSID_BARRIER")
+fi
+if [ -n "${IWE_PEER_TEST_PRE_EXEC_BARRIER:-}" ]; then
+  KIMI_LINEAGE_ARGS+=(--pre-exec-barrier "$IWE_PEER_TEST_PRE_EXEC_BARRIER")
+fi
 
 if [ "$KIMI_CLI_STYLE" = "prompt-arg" ]; then
   # kimi-code 0.29 gates --agent-file behind the v2 engine, enabled by this
@@ -991,6 +2417,7 @@ if [ "$KIMI_CLI_STYLE" = "prompt-arg" ]; then
     export KIMI_CODE_EXPERIMENTAL_FLAG=1
   fi
   KIMI_RAW=$(cd "$KIMI_TEXT_ONLY_WORKDIR" && run_with_deadline "$IWE_PEER_TIMEOUT_SECONDS" \
+    "${KIMI_LINEAGE_ARGS[@]}" \
     "${GUARD_ARGS[@]+"${GUARD_ARGS[@]}"}" "$KIMI_BIN" \
     "${KIMI_PROMPT_ARGS[@]}" \
     ${MODEL_ARG[@]+"${MODEL_ARG[@]}"} \
@@ -999,6 +2426,7 @@ if [ "$KIMI_CLI_STYLE" = "prompt-arg" ]; then
     2>"$KIMI_STDERR")
 else
   KIMI_RAW=$(run_with_deadline "$IWE_PEER_TIMEOUT_SECONDS" \
+    "${KIMI_LINEAGE_ARGS[@]}" \
     "${GUARD_ARGS[@]+"${GUARD_ARGS[@]}"}" "$KIMI_BIN" --quiet --yolo \
     ${MODEL_ARG[@]+"${MODEL_ARG[@]}"} \
     ${KIMI_DIR_ARGS[@]+"${KIMI_DIR_ARGS[@]}"} \
@@ -1018,6 +2446,16 @@ adapter_diagnostic() {
   printf 'DIAGNOSTIC: vendor=kimi cli_exit=%s timeout_seconds=%s stdout_bytes=%s stderr_bytes=%s\n' \
     "$cli_exit" "$IWE_PEER_TIMEOUT_SECONDS" "$stdout_bytes" "$stderr_bytes" >&2
 }
+
+# Exact peer-session ownership was revoked while the vendor process was live.
+# The lifetime helper has terminated the published CLI process group and held
+# both admission flocks until every FIFO-owning descendant exited.
+if [ -s "$SESSION_LOCK_FAILURE" ]; then
+  LOCK_FAILURE_REASON="$(cat "$SESSION_LOCK_FAILURE" 2>/dev/null || echo unknown)"
+  echo "ERROR: exact peer-session lock lost ($LOCK_FAILURE_REASON); Kimi process group was terminated." >&2
+  adapter_diagnostic "$PERL_EXIT"
+  exit 1
+fi
 
 if [ "$KIMI_CLI_STYLE" = "prompt-arg" ]; then
   # stream-json: keep only assistant text; meta lines (resume hint) drop out naturally.
@@ -1143,6 +2581,7 @@ fi
 HINDSIGHT_SCRIPT="$SCRIPT_DIR/hindsight_trigger.py"
 if [ "${IWE_HINDSIGHT_RETAIN:-}" = "1" ] && [ -n "$KIMI_OUTPUT" ] && [ -f "$HINDSIGHT_SCRIPT" ]; then
   {
+    exec 9>&-
     echo "{\"action\":\"retain\",\"source\":\"kimi-peer\",\"text\":$(echo "$KIMI_OUTPUT" | head -c 4000 | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}" \
     | python3 "$HINDSIGHT_SCRIPT" 2>/dev/null || true
   } &
@@ -1152,6 +2591,7 @@ fi
 # Writes one entry per adapter call. Caller groups by session_id on read.
 # Security: only timestamps and duration written — no content from KIMI_OUTPUT.
 {
+  exec 9>&-
   _KIMI_END="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   _SID="$KIMI_SESSION_ID"
   _START="$_KIMI_SESSION_START_TIME"

--- a/scripts/lib/find-python3.sh
+++ b/scripts/lib/find-python3.sh
@@ -3,7 +3,10 @@
 # issues #453/#463, Evgenii 18.08).
 #
 # Contract (peer-session 2026-08-19-01, codex В1): standalone executable, not a
-# sourced lib. stdout = path to a python3 whose `import yaml` succeeds, exit 0.
+# sourced lib. By default stdout = path to a python3 whose `import yaml`
+# succeeds, exit 0. `--stdlib-only` keeps the same candidate resolution but
+# requires only the Python standard library; callers that do not import PyYAML
+# must use it rather than acquiring an unrelated optional dependency.
 # No candidate → exit 1 with actionable diagnostics on stderr. Callers use
 # command substitution and MUST check the exit code, failing with an explicit
 # dependency error instead of a misleading domain error ("calendar_ids не
@@ -15,6 +18,14 @@
 # to a yaml-less interpreter.
 set -u
 
+stdlib_only=false
+case "${1:-}" in
+    --stdlib-only) stdlib_only=true; shift ;;
+    "") ;;
+    *) echo "ERROR: unknown find-python3.sh argument: $1" >&2; exit 2 ;;
+esac
+[ "$#" -eq 0 ] || { echo "ERROR: find-python3.sh accepts only --stdlib-only" >&2; exit 2; }
+
 candidates=(
     python3
     /opt/homebrew/bin/python3
@@ -24,7 +35,7 @@ candidates=(
 
 for cand in "${candidates[@]}"; do
     resolved=$(command -v "$cand" 2>/dev/null) || continue
-    if "$resolved" -c "import yaml" >/dev/null 2>&1; then
+    if $stdlib_only || "$resolved" -c "import yaml" >/dev/null 2>&1; then
         printf '%s\n' "$resolved"
         exit 0
     fi
@@ -36,11 +47,16 @@ done
 # that made this branch dead code in server-calendar.sh).
 if [ -d /nix/store ]; then
     while IFS= read -r cand; do
-        if "$cand" -c "import yaml" >/dev/null 2>&1; then
+        if $stdlib_only || "$cand" -c "import yaml" >/dev/null 2>&1; then
             printf '%s\n' "$cand"
             exit 0
         fi
     done < <(find /nix/store -maxdepth 3 -name python3 -path "*env*/bin/*" 2>/dev/null)
+fi
+
+if $stdlib_only; then
+    echo "ERROR: python3 не найден (проверены: PATH, /opt/homebrew, /usr/local, /usr/bin, Nix)." >&2
+    exit 1
 fi
 
 {

--- a/scripts/lib/peer-adapter-common.sh
+++ b/scripts/lib/peer-adapter-common.sh
@@ -25,38 +25,152 @@ peer_adapter_check_sandbox_network() {
   fi
 }
 
-# run_with_deadline <seconds> <cmd> [args...]
+# run_with_deadline <seconds> [--pgid-file <path> --lineage-nonce <hex>]
+#                   [--exec-gate-file <path>]
+#                   [--pre-exec-barrier <path>]
+#                   [--pre-setsid-barrier <path>] <cmd> [args...]
 # Runs cmd in its own process group and kills the whole group (TERM then
 # KILL) on timeout, so a supervised CLI can't leave an orphaned child behind
 # a plain `timeout` (WP-516: the previous `perl alarm; exec` signalled only
-# the launcher, not a forked CLI child).
+# the launcher, not a forked CLI child). `--pgid-file` publishes the group id
+# after setsid and before exec so an external lifetime/lock helper can stop the
+# group even after SIGKILL of the top adapter. The barrier options are
+# deterministic test seams for the fork/setsid/exec hand-off boundaries.
 run_with_deadline() {
   local deadline_seconds="$1"
   shift
-  perl -MPOSIX=setsid -e '
+  perl -MPOSIX=setsid,WNOHANG -MFcntl=O_RDONLY,O_WRONLY,O_CREAT,O_EXCL -MIO::Handle -e '
     use strict;
     use warnings;
+    use Errno qw(EPERM ESRCH);
+    use Time::HiRes qw(time);
 
     my $seconds = shift @ARGV;
+    my ($pgid_file, $lineage_nonce, $exec_gate_file, $pre_exec_barrier, $pre_setsid_barrier);
+    while (@ARGV >= 2) {
+      if ($ARGV[0] eq "--pgid-file") {
+        shift @ARGV;
+        $pgid_file = shift @ARGV;
+        next;
+      }
+      if ($ARGV[0] eq "--lineage-nonce") {
+        shift @ARGV;
+        $lineage_nonce = shift @ARGV;
+        next;
+      }
+      if ($ARGV[0] eq "--exec-gate-file") {
+        shift @ARGV;
+        $exec_gate_file = shift @ARGV;
+        next;
+      }
+      if ($ARGV[0] eq "--pre-exec-barrier") {
+        shift @ARGV;
+        $pre_exec_barrier = shift @ARGV;
+        next;
+      }
+      if ($ARGV[0] eq "--pre-setsid-barrier") {
+        shift @ARGV;
+        $pre_setsid_barrier = shift @ARGV;
+        next;
+      }
+      last;
+    }
+    die "ERROR: peer CLI command is empty\n" unless @ARGV;
     my $child = fork();
     die "ERROR: cannot fork peer CLI supervisor: $!\n" unless defined $child;
     if ($child == 0) {
+      if (defined $pre_setsid_barrier) {
+        sysopen(my $ready_out, "$pre_setsid_barrier.ready", O_WRONLY | O_CREAT | O_EXCL, 0600)
+          or die "ERROR: cannot publish pre-setsid barrier: $!\n";
+        print {$ready_out} "$$\n";
+        close $ready_out;
+        select undef, undef, undef, 0.01 until -e "$pre_setsid_barrier.release";
+      }
       setsid() or die "ERROR: cannot isolate peer CLI process group: $!\n";
+      if (defined $pgid_file) {
+        die "ERROR: lineage nonce required with pgid file\n"
+          unless defined $lineage_nonce && $lineage_nonce =~ /\A[0-9a-f]{32}\z/;
+        die "ERROR: setsid did not establish pid=pgid\n" unless getpgrp() == $$;
+        my $pgid_tmp = "$pgid_file.$$.tmp";
+        sysopen(my $pgid_out, $pgid_tmp, O_WRONLY | O_CREAT | O_EXCL, 0600)
+          or die "ERROR: cannot publish peer CLI process group: $!\n";
+        print {$pgid_out} "{\"nonce\":\"$lineage_nonce\",\"pid\":$$,\"pgid\":$$}\n";
+        $pgid_out->sync or die "ERROR: cannot sync peer CLI process-group marker: $!\n";
+        close $pgid_out or die "ERROR: cannot close peer CLI process-group marker: $!\n";
+        rename $pgid_tmp, $pgid_file
+          or die "ERROR: cannot publish peer CLI process-group marker atomically: $!\n";
+      }
+      if (defined $exec_gate_file) {
+        die "ERROR: lineage nonce required with exec gate\n"
+          unless defined $lineage_nonce && $lineage_nonce =~ /\A[0-9a-f]{32}\z/;
+        my $expected_gate = "$lineage_nonce $$\n";
+        my $gate_deadline = time + 10;
+        while (1) {
+          if (sysopen(my $gate_in, $exec_gate_file, O_RDONLY)) {
+            local $/;
+            my $gate = <$gate_in>;
+            close $gate_in;
+            die "ERROR: invalid peer CLI exec gate\n"
+              unless defined $gate && $gate eq $expected_gate;
+            last;
+          }
+          die "ERROR: peer CLI exec gate timed out\n" if time >= $gate_deadline;
+          select undef, undef, undef, 0.01;
+        }
+      }
+      if (defined $pre_exec_barrier) {
+        sysopen(my $ready_out, "$pre_exec_barrier.ready", O_WRONLY | O_CREAT | O_EXCL, 0600)
+          or die "ERROR: cannot publish pre-exec barrier: $!\n";
+        print {$ready_out} "$$\n";
+        close $ready_out;
+        select undef, undef, undef, 0.01 until -e "$pre_exec_barrier.release";
+      }
       exec @ARGV or die "ERROR: cannot exec peer CLI: $!\n";
     }
 
-    my $timed_out = 0;
-    local $SIG{ALRM} = sub {
-      $timed_out = 1;
-      kill "TERM", -$child;
-      select undef, undef, undef, 2;
-      kill "KILL", -$child;
-    };
-    alarm $seconds;
-    waitpid($child, 0);
-    my $status = $?;
-    alarm 0;
-    exit 142 if $timed_out;
+    sub child_group_alive {
+      local $! = 0;
+      return 1 if kill 0, -$child;
+      return 1 if $! == EPERM;
+      return 0 if $! == ESRCH;
+      return 1; # unknown kernel result is not proof that the group is gone
+    }
+
+    sub stop_child_group {
+      my $reaped = 0;
+      kill "TERM", -$child if child_group_alive();
+      for (1 .. 20) {
+        if (!$reaped) {
+          my $done = waitpid($child, WNOHANG);
+          $reaped = 1 if $done == $child;
+        }
+        if (!child_group_alive()) {
+          waitpid($child, 0) unless $reaped;
+          return;
+        }
+        select undef, undef, undef, 0.1;
+      }
+      # A TERM-resistant grandchild keeps the original group observable even
+      # after its leader exits. Re-check immediately before KILL so a vanished
+      # group is never signalled later after that numeric PGID is reused.
+      kill "KILL", -$child if child_group_alive();
+      waitpid($child, 0) unless $reaped;
+    }
+
+    my $deadline = time + $seconds;
+    my $status;
+    while (1) {
+      my $done = waitpid($child, WNOHANG);
+      if ($done == $child) {
+        $status = $?;
+        last;
+      }
+      if (time >= $deadline) {
+        stop_child_group();
+        exit 142;
+      }
+      select undef, undef, undef, 0.05;
+    }
     exit 128 + ($status & 127) if $status & 127;
     exit $status >> 8;
   ' "$deadline_seconds" "$@"
@@ -102,7 +216,7 @@ peer_adapter_check_language() {
   lang_check="$lib_dir/language-check.py"
   python_resolver="$lib_dir/find-python3.sh"
   if [ -f "$lang_check" ] && [ -x "$python_resolver" ]; then
-    resolved_python=$("$python_resolver" 2>/dev/null || true)
+    resolved_python=$("$python_resolver" --stdlib-only 2>/dev/null || true)
   else
     resolved_python=""
   fi

--- a/seed/strategy/scripts/lib/find-python3.sh
+++ b/seed/strategy/scripts/lib/find-python3.sh
@@ -4,7 +4,10 @@
 # issues #453/#463, Evgenii 18.08).
 #
 # Contract (peer-session 2026-08-19-01, codex В1): standalone executable, not a
-# sourced lib. stdout = path to a python3 whose `import yaml` succeeds, exit 0.
+# sourced lib. By default stdout = path to a python3 whose `import yaml`
+# succeeds, exit 0. `--stdlib-only` keeps the same candidate resolution but
+# requires only the Python standard library; callers that do not import PyYAML
+# must use it rather than acquiring an unrelated optional dependency.
 # No candidate → exit 1 with actionable diagnostics on stderr. Callers use
 # command substitution and MUST check the exit code, failing with an explicit
 # dependency error instead of a misleading domain error ("calendar_ids не
@@ -16,6 +19,14 @@
 # to a yaml-less interpreter.
 set -u
 
+stdlib_only=false
+case "${1:-}" in
+    --stdlib-only) stdlib_only=true; shift ;;
+    "") ;;
+    *) echo "ERROR: unknown find-python3.sh argument: $1" >&2; exit 2 ;;
+esac
+[ "$#" -eq 0 ] || { echo "ERROR: find-python3.sh accepts only --stdlib-only" >&2; exit 2; }
+
 candidates=(
     python3
     /opt/homebrew/bin/python3
@@ -25,7 +36,7 @@ candidates=(
 
 for cand in "${candidates[@]}"; do
     resolved=$(command -v "$cand" 2>/dev/null) || continue
-    if "$resolved" -c "import yaml" >/dev/null 2>&1; then
+    if $stdlib_only || "$resolved" -c "import yaml" >/dev/null 2>&1; then
         printf '%s\n' "$resolved"
         exit 0
     fi
@@ -37,11 +48,16 @@ done
 # that made this branch dead code in server-calendar.sh).
 if [ -d /nix/store ]; then
     while IFS= read -r cand; do
-        if "$cand" -c "import yaml" >/dev/null 2>&1; then
+        if $stdlib_only || "$cand" -c "import yaml" >/dev/null 2>&1; then
             printf '%s\n' "$cand"
             exit 0
         fi
     done < <(find /nix/store -maxdepth 3 -name python3 -path "*env*/bin/*" 2>/dev/null)
+fi
+
+if $stdlib_only; then
+    echo "ERROR: python3 не найден (проверены: PATH, /opt/homebrew, /usr/local, /usr/bin, Nix)." >&2
+    exit 1
 fi
 
 {

--- a/setup/test-update-edge-cases.sh
+++ b/setup/test-update-edge-cases.sh
@@ -3094,11 +3094,13 @@ echo "--- T40: Kimi peer heartbeat namespace and watchdog consumer (WP-484) ---"
 T40_ROOT="$TEST_WS/t40-kimi-peer-heartbeat"
 T40_IWE="$T40_ROOT/iwe"
 T40_HOME="$T40_ROOT/home"
-T40_ADD_DIR="$T40_ROOT/peer-beacon-session"
+T40_ADD_DIR="$T40_ROOT/2026-09-12-01-wp484-peer-beacon"
 T40_LOCK_DIR="$T40_ROOT/locks"
 T40_BIN="$T40_ROOT/fake-kimi"
 T40_READY="$T40_ROOT/ready"
 T40_RELEASE="$T40_ROOT/release"
+T40_OAUTH_DIR="$T40_LOCK_DIR/kimi-oauth-refresh.lockdir"
+T40_OAUTH_LINEAGE="$T40_LOCK_DIR/kimi-oauth-refresh.lineage-v4"
 mkdir -p "$T40_HOME" "$T40_ADD_DIR"
 
 cat > "$T40_BIN" <<'EOF'
@@ -3114,6 +3116,34 @@ EOF
 chmod +x "$T40_BIN"
 export T40_READY T40_RELEASE
 
+if HOME="$T40_HOME" CODEX_SANDBOX='' CODEX_SANDBOX_NETWORK_DISABLED='' \
+    IWE_PEER_PLAIN=1 IWE_ROOT="$T40_IWE" IWE_PEER_LOCK_DIR="$T40_LOCK_DIR" \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" \
+    --cutover-oauth-lineage-v4 \
+    >"$T40_ROOT/cutover-unasserted.out" 2>"$T40_ROOT/cutover-unasserted.err"; then
+    T40_CUTOVER_UNASSERTED_RC=0
+else
+    T40_CUTOVER_UNASSERTED_RC=$?
+fi
+HOME="$T40_HOME" CODEX_SANDBOX='' CODEX_SANDBOX_NETWORK_DISABLED='' \
+    IWE_PEER_PLAIN=1 IWE_ROOT="$T40_IWE" IWE_PEER_LOCK_DIR="$T40_LOCK_DIR" \
+    IWE_OAUTH_CUTOVER_QUIESCED=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" \
+    --cutover-oauth-lineage-v4 \
+    >"$T40_ROOT/cutover.out" 2>"$T40_ROOT/cutover.err"
+T40_CUTOVER_RC=$?
+T40_FENCE_TARGET=$(readlink "$T40_OAUTH_DIR" 2>/dev/null || true)
+T40_FENCE_PID=$(cat "$T40_OAUTH_DIR/pid" 2>/dev/null || true)
+T40_FENCE_OWNER=$(cat "$T40_OAUTH_DIR/owner" 2>/dev/null || true)
+T40_FENCE_LEASE_ID=$(python3 -c 'import os,sys; s=os.stat(sys.argv[1]); print(f"{s.st_dev} {s.st_ino}")' "$T40_LOCK_DIR/kimi-oauth-refresh.lease" 2>/dev/null || true)
+HOME="$T40_HOME" CODEX_SANDBOX='' CODEX_SANDBOX_NETWORK_DISABLED='' \
+    IWE_PEER_PLAIN=1 IWE_ROOT="$T40_IWE" IWE_PEER_LOCK_DIR="$T40_LOCK_DIR" \
+    IWE_OAUTH_CUTOVER_QUIESCED=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" \
+    --cutover-oauth-lineage-v4 \
+    >"$T40_ROOT/cutover-again.out" 2>"$T40_ROOT/cutover-again.err"
+T40_CUTOVER_AGAIN_RC=$?
+
 HOME="$T40_HOME" CODEX_SANDBOX='' CODEX_SANDBOX_NETWORK_DISABLED='' \
     IWE_PEER_PLAIN=1 IWE_ROOT="$T40_IWE" \
     IWE_PEER_LOCK_DIR="$T40_LOCK_DIR" IWE_PEER_HEARTBEAT_SECONDS=1 \
@@ -3127,14 +3157,40 @@ for _t40_wait in $(seq 1 200); do
     sleep 0.05
 done
 
-T40_BEACON="$T40_IWE/.iwe-runtime/peer-heartbeats/kimi-peer-peer-beacon-session.heartbeat"
+T40_BEACON="$T40_IWE/.iwe-runtime/peer-heartbeats/kimi-peer-2026-09-12-01-wp484-peer-beacon.heartbeat"
 mkdir -p "$T40_IWE/.iwe-runtime/sessions"
 T40_OPEN_COUNT=$(find "$T40_IWE/.iwe-runtime/sessions" -name '*.open' 2>/dev/null | wc -l | tr -d ' ')
 if [ -f "$T40_READY" ] && [ -f "$T40_BEACON" ] && [ ! -L "$T40_BEACON" ] && \
-   [ "$T40_OPEN_COUNT" = 0 ] && grep -q '^agent: kimi-peer$' "$T40_BEACON"; then
+   [ "$T40_OPEN_COUNT" = 0 ] && grep -q '^agent: kimi-peer$' "$T40_BEACON" && \
+   grep -q '^wp: WP-484$' "$T40_BEACON"; then
     pass "T40a: peer adapter writes visibility beacon outside sessions/*.open"
 else
     fail "T40a: peer beacon entered admission namespace or was not created: $(find "$T40_IWE/.iwe-runtime" -type f 2>/dev/null | tr '\n' ' ')"
+fi
+
+T40_OAUTH_HOLDER=$(cat "$T40_OAUTH_LINEAGE/pid" 2>/dev/null || true)
+T40_OAUTH_OWNER=$(cat "$T40_OAUTH_LINEAGE/owner" 2>/dev/null || true)
+T40_SESSION_OWNER=$(cat "$T40_LOCK_DIR/2026-09-12-01-wp484-peer-beacon.lock/owner.pid" 2>/dev/null || true)
+T40_SESSION_NONCE=${T40_SESSION_OWNER#* }
+T40_OAUTH_LEASE_ID=$(python3 -c 'import os,sys; s=os.stat(sys.argv[1]); print(f"{s.st_dev} {s.st_ino}")' "$T40_LOCK_DIR/kimi-oauth-refresh.lease" 2>/dev/null || true)
+T40_EXPECTED_OWNER="iwe-oauth-lineage-v4 $T40_OAUTH_LEASE_ID $T40_SESSION_NONCE"
+T40_OAUTH_TARGET=$(readlink "$T40_OAUTH_LINEAGE" 2>/dev/null || true)
+if [ "$T40_CUTOVER_UNASSERTED_RC" -eq 1 ] && \
+   [ "$T40_CUTOVER_RC" -eq 0 ] && [ "$T40_CUTOVER_AGAIN_RC" -eq 0 ] && \
+   [[ "$T40_FENCE_TARGET" =~ ^kimi-oauth-refresh\.fence-v4\.[0-9a-f]{32}$ ]] && \
+   [ "$T40_FENCE_PID" = -1 ] && \
+   [ "$T40_FENCE_OWNER" = "iwe-oauth-fence-v4 $T40_FENCE_LEASE_ID ${T40_FENCE_TARGET##*.}" ] && \
+   [[ "$T40_OAUTH_HOLDER" =~ ^-[0-9]+$ ]] && \
+   kill -0 "$T40_OAUTH_HOLDER" 2>/dev/null && \
+   [ -L "$T40_OAUTH_DIR" ] && \
+   [ -L "$T40_OAUTH_LINEAGE" ] && \
+   [ "$T40_OAUTH_TARGET" = "kimi-oauth-refresh.lineage-v4.$T40_SESSION_NONCE" ] && \
+   [ "${T40_SESSION_OWNER%% *}" = "$T40_ADAPTER_PID" ] && \
+   [[ "$T40_SESSION_NONCE" =~ ^[0-9a-f]{32}$ ]] && \
+   [ "$T40_OAUTH_OWNER" = "$T40_EXPECTED_OWNER" ]; then
+    pass "T40b: explicit idempotent cutover keeps immutable fence while v4 lineage publishes vendor PGID"
+else
+    fail "T40b: v4 cutover/fence/lineage is not exact (cutover=$T40_CUTOVER_UNASSERTED_RC/$T40_CUTOVER_RC/$T40_CUTOVER_AGAIN_RC fence=$T40_FENCE_TARGET/$T40_FENCE_PID/$T40_FENCE_OWNER adapter=$T40_ADAPTER_PID holder=$T40_OAUTH_HOLDER target=$T40_OAUTH_TARGET owner=$T40_OAUTH_OWNER expected=$T40_EXPECTED_OWNER)"
 fi
 
 T40_ID_BEFORE=$(python3 -c 'import os,sys; s=os.lstat(sys.argv[1]); print(f"{s.st_dev}:{s.st_ino}")' "$T40_BEACON" 2>/dev/null)
@@ -3154,9 +3210,9 @@ T40_ID_AFTER=$(python3 -c 'import os,sys; s=os.lstat(sys.argv[1]); print(f"{s.st
 T40_SUM_AFTER=$(head -6 "$T40_BEACON" | cksum 2>/dev/null)
 if [ "$T40_DUPLICATE_RC" -eq 5 ] && [ -n "$T40_ID_BEFORE" ] && \
    [ "$T40_ID_AFTER" = "$T40_ID_BEFORE" ] && [ "$T40_SUM_AFTER" = "$T40_SUM_BEFORE" ]; then
-    pass "T40b: rejected duplicate cannot replace the live owner's beacon"
+    pass "T40c: rejected duplicate cannot replace the live owner's beacon"
 else
-    fail "T40b: duplicate mutated the beacon (rc=$T40_DUPLICATE_RC before=$T40_ID_BEFORE/$T40_SUM_BEFORE after=$T40_ID_AFTER/$T40_SUM_AFTER)"
+    fail "T40c: duplicate mutated the beacon (rc=$T40_DUPLICATE_RC before=$T40_ID_BEFORE/$T40_SUM_BEFORE after=$T40_ID_AFTER/$T40_SUM_AFTER)"
 fi
 
 touch "$T40_RELEASE"
@@ -3166,10 +3222,13 @@ else
     T40_ADAPTER_RC=$?
 fi
 if [ "$T40_ADAPTER_RC" -eq 0 ] && [ ! -e "$T40_BEACON" ] && \
-   [ ! -e "$T40_IWE/.iwe-runtime/sessions/kimi-peer-peer-beacon-session.open" ]; then
-    pass "T40c: normal peer exit removes its beacon without leaving .open"
+   ! kill -0 "$T40_OAUTH_HOLDER" 2>/dev/null && \
+   [ -L "$T40_OAUTH_DIR" ] && [ "$(readlink "$T40_OAUTH_DIR")" = "$T40_FENCE_TARGET" ] && \
+   [ ! -e "$T40_OAUTH_LINEAGE" ] && [ ! -L "$T40_OAUTH_LINEAGE" ] && \
+   [ ! -e "$T40_IWE/.iwe-runtime/sessions/kimi-peer-2026-09-12-01-wp484-peer-beacon.open" ]; then
+    pass "T40d: normal peer exit reaps runtime lineage, preserves permanent fence, and removes its beacon"
 else
-    fail "T40c: peer heartbeat cleanup failed (rc=$T40_ADAPTER_RC)"
+    fail "T40d: normal peer cleanup leaked vendor group/beacon (rc=$T40_ADAPTER_RC holder=$T40_OAUTH_HOLDER)"
 fi
 
 T40_JOURNAL="$T40_HOME/.iwe/agent-sessions.jsonl"
@@ -3186,14 +3245,14 @@ import sys
 path = pathlib.Path(sys.argv[1])
 record = json.loads(path.read_text(encoding="utf-8").splitlines()[-1])
 assert record["agent"] == "kimi"
-assert record["session_id"] == "peer-beacon-session"
+assert record["session_id"] == "2026-09-12-01-wp484-peer-beacon"
 datetime.datetime.fromisoformat(record["start_time"].replace("Z", "+00:00"))
 datetime.datetime.fromisoformat(record["end_time"].replace("Z", "+00:00"))
 PY
 then
-    pass "T40d: successful peer call records a timestamped session journal entry"
+    pass "T40e: successful peer call records a timestamped session journal entry"
 else
-    fail "T40d: successful peer call lost its session journal entry"
+    fail "T40e: successful peer call lost its session journal entry"
 fi
 
 # Start eight adapters on one id without a pre-established winner. Exactly one
@@ -3240,47 +3299,783 @@ T40_RACE_OK=$(grep -l '^0$' "$T40_ROOT"/race-results/*.rc 2>/dev/null | wc -l | 
 T40_RACE_BUSY=$(grep -l '^5$' "$T40_ROOT"/race-results/*.rc 2>/dev/null | wc -l | tr -d ' ')
 if [ "$T40_RACE_ENTERED" -eq 1 ] && [ "$T40_RACE_OK" -eq 1 ] && \
    [ "$T40_RACE_BUSY" -eq 7 ]; then
-    pass "T40e: concurrent same-id adapters elect exactly one owner"
+    pass "T40f: concurrent same-id adapters elect exactly one owner"
 else
-    fail "T40e: peer lock split ownership (entered=$T40_RACE_ENTERED ok=$T40_RACE_OK busy=$T40_RACE_BUSY)"
+    fail "T40f: peer lock split ownership (entered=$T40_RACE_ENTERED ok=$T40_RACE_OK busy=$T40_RACE_BUSY)"
 fi
 
-# SIGKILL skips the adapter's EXIT trap. Its two direct helpers must observe
-# reparenting, release the kernel lock and remove only their own beacon.
+# Exercise the adapter with isolated paths while preserving the exact env used
+# by the installed template. These helpers keep every race case below concise.
+T40_ADAPTER_ENV=(
+    env
+    HOME="$T40_HOME"
+    CODEX_SANDBOX=''
+    CODEX_SANDBOX_NETWORK_DISABLED=''
+    IWE_PEER_PLAIN=1
+    IWE_ROOT="$T40_IWE"
+    IWE_PEER_LOCK_DIR="$T40_LOCK_DIR"
+    IWE_PEER_HEARTBEAT_SECONDS=1
+)
+t40_run_peer() {
+    local add_dir="$1" kimi_bin="$2" stdout_file="$3" stderr_file="$4"
+    shift 4
+    "${T40_ADAPTER_ENV[@]}" "$@" KIMI_BIN="$kimi_bin" \
+        bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$add_dir" \
+        </dev/null >"$stdout_file" 2>"$stderr_file"
+}
+t40_launch_peer() {
+    local add_dir="$1" kimi_bin="$2" stdout_file="$3" stderr_file="$4"
+    shift 4
+    exec "${T40_ADAPTER_ENV[@]}" "$@" KIMI_BIN="$kimi_bin" \
+        bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$add_dir" \
+        </dev/null >"$stdout_file" 2>"$stderr_file"
+}
+t40_process_is_non_zombie() {
+    local process_pid="$1" process_state
+    process_state=$(ps -o stat= -p "$process_pid" 2>/dev/null | tr -d '[:space:]')
+    if [ -n "$process_state" ]; then
+        [[ "$process_state" != Z* ]]
+    else
+        kill -0 "$process_pid" 2>/dev/null
+    fi
+}
+t40_wait_for_process_exit() {
+    local process_pid="$1" _wait
+    for _wait in $(seq 1 120); do
+        t40_process_is_non_zombie "$process_pid" || return 0
+        sleep 0.05
+    done
+    return 1
+}
+t40_run_recovery() {
+    local add_dir="$1" kimi_bin="$2" stdout_file="$3" stderr_file="$4" _wait
+    shift 4
+    T40_RECOVERY_RC=5
+    for _wait in $(seq 1 80); do
+        if t40_run_peer "$add_dir" "$kimi_bin" "$stdout_file" "$stderr_file" "$@"; then
+            T40_RECOVERY_RC=0
+        else
+            T40_RECOVERY_RC=$?
+        fi
+        [ "$T40_RECOVERY_RC" -eq 5 ] || break
+        sleep 0.05
+    done
+}
+
+# Removing mutable owner metadata must stop the vendor fail-closed while the
+# stable lease remains locked. A duplicate must never enter during that drain.
+T40_UNLINK_ADD="$T40_ROOT/peer-without-wp-label"
+T40_UNLINK_READY="$T40_ROOT/unlink-ready"
+T40_UNLINK_CHILD_PID_FILE="$T40_ROOT/unlink-child.pid"
+T40_UNLINK_BIN="$T40_ROOT/fake-kimi-unlink"
+mkdir -p "$T40_UNLINK_ADD"
+cat > "$T40_UNLINK_BIN" <<'EOF'
+#!/bin/bash
+if [ "${1:-}" = "--help" ]; then
+    echo "--agent-file Load an agent definition from a Markdown file"
+    exit 0
+fi
+trap '' TERM
+echo "$$" > "$T40_UNLINK_CHILD_PID_FILE"
+: > "$T40_UNLINK_READY"
+while :; do sleep 0.05; done
+EOF
+chmod +x "$T40_UNLINK_BIN"
+export T40_UNLINK_READY T40_UNLINK_CHILD_PID_FILE
+t40_launch_peer "$T40_UNLINK_ADD" "$T40_UNLINK_BIN" \
+    "$T40_ROOT/unlink.out" "$T40_ROOT/unlink.err" IWE_PEER_TIMEOUT_SECONDS=20 &
+T40_UNLINK_ADAPTER_PID=$!
+for _t40_wait in $(seq 1 200); do
+    [ -s "$T40_UNLINK_CHILD_PID_FILE" ] && break
+    sleep 0.05
+done
+T40_UNLINK_OWNER="$T40_LOCK_DIR/peer-without-wp-label.lock/owner.pid"
+rm -f "$T40_UNLINK_OWNER"
+if t40_run_peer "$T40_UNLINK_ADD" "$T40_UNLINK_BIN" \
+    "$T40_ROOT/unlink-duplicate.out" "$T40_ROOT/unlink-duplicate.err" \
+    IWE_PEER_TIMEOUT_SECONDS=20; then
+    T40_UNLINK_DUPLICATE_RC=0
+else
+    T40_UNLINK_DUPLICATE_RC=$?
+fi
+if wait "$T40_UNLINK_ADAPTER_PID"; then
+    T40_UNLINK_RC=0
+else
+    T40_UNLINK_RC=$?
+fi
+T40_UNLINK_CHILD_PID=$(cat "$T40_UNLINK_CHILD_PID_FILE" 2>/dev/null || true)
+T40_UNLINK_CHILD_LIVE=false
+t40_wait_for_process_exit "$T40_UNLINK_CHILD_PID" || T40_UNLINK_CHILD_LIVE=true
+if [ "$T40_UNLINK_DUPLICATE_RC" -eq 5 ] && [ "$T40_UNLINK_RC" -eq 1 ] && \
+   [ "$T40_UNLINK_CHILD_LIVE" = false ] && \
+   [ -f "$T40_LOCK_DIR/peer-without-wp-label.lock/lease" ] && \
+   grep -q 'exact peer-session lock lost (lock-owner-metadata-missing)' "$T40_ROOT/unlink.err"; then
+    pass "T40g: owner metadata loss keeps stable admission closed and kills vendor fail-closed"
+else
+    fail "T40g: unlink race escaped stable lease (duplicate=$T40_UNLINK_DUPLICATE_RC rc=$T40_UNLINK_RC child_live=$T40_UNLINK_CHILD_LIVE)"
+fi
+
+# SIGKILL of the top adapter must not orphan a TERM-resistant vendor/grandchild.
+# A same-id duplicate is rejected, while a different id waits on global OAuth;
+# sampled live vendor count may never exceed one.
 T40_CRASH_ADD="$T40_ROOT/peer-crash-session"
+T40_CROSS_ADD="$T40_ROOT/peer-crash-cross-session"
 T40_CRASH_READY="$T40_ROOT/crash-ready"
-T40_CRASH_RELEASE="$T40_ROOT/crash-release"
-T40_CRASH_BEACON="$T40_IWE/.iwe-runtime/peer-heartbeats/kimi-peer-peer-crash-session.heartbeat"
-T40_CRASH_LOCK="$T40_LOCK_DIR/peer-crash-session.pid"
-mkdir -p "$T40_CRASH_ADD"
-HOME="$T40_HOME" CODEX_SANDBOX='' CODEX_SANDBOX_NETWORK_DISABLED='' \
-    IWE_PEER_PLAIN=1 IWE_ROOT="$T40_IWE" \
-    IWE_PEER_LOCK_DIR="$T40_LOCK_DIR" IWE_PEER_HEARTBEAT_SECONDS=1 \
-    IWE_PEER_TIMEOUT_SECONDS=10 T40_READY="$T40_CRASH_READY" \
-    T40_RELEASE="$T40_CRASH_RELEASE" KIMI_BIN="$T40_BIN" \
-    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_CRASH_ADD" \
-    </dev/null >"$T40_ROOT/crash.out" 2>"$T40_ROOT/crash.err" &
+T40_CROSS_READY="$T40_ROOT/cross-ready"
+T40_CRASH_ENTRIES="$T40_ROOT/crash-entries"
+T40_CRASH_VENDOR_PID_FILE="$T40_ROOT/crash-vendor.pid"
+T40_CRASH_GRANDCHILD_PID_FILE="$T40_ROOT/crash-grandchild.pid"
+T40_CRASH_BIN="$T40_ROOT/fake-kimi-crash"
+mkdir -p "$T40_CRASH_ADD" "$T40_CROSS_ADD"
+cat > "$T40_CRASH_BIN" <<'EOF'
+#!/bin/bash
+if [ "${1:-}" = "--help" ]; then
+    echo "--agent-file Load an agent definition from a Markdown file"
+    exit 0
+fi
+if [ "${T40_CROSS_SESSION:-0}" = "1" ]; then
+    printf '%s\n' "$$" >> "$T40_CRASH_ENTRIES"
+    : > "$T40_CROSS_READY"
+    sleep 0.5
+    printf '%s\n' '{"role":"assistant","content":"cross-session complete"}'
+    exit 0
+fi
+if [ "${T40_RECOVERY:-0}" = "1" ]; then
+    printf '%s\n' '{"role":"assistant","content":"SIGKILL recovery complete"}'
+    exit 0
+fi
+trap '' HUP INT TERM
+printf '%s\n' "$$" >> "$T40_CRASH_ENTRIES"
+echo "$$" > "$T40_CRASH_VENDOR_PID_FILE"
+(
+    trap '' HUP INT TERM
+    while :; do sleep 0.05; done
+) &
+grandchild=$!
+echo "$grandchild" > "$T40_CRASH_GRANDCHILD_PID_FILE"
+: > "$T40_CRASH_READY"
+wait "$grandchild"
+EOF
+chmod +x "$T40_CRASH_BIN"
+export T40_CRASH_READY T40_CROSS_READY T40_CRASH_ENTRIES
+export T40_CRASH_VENDOR_PID_FILE T40_CRASH_GRANDCHILD_PID_FILE
+t40_launch_peer "$T40_CRASH_ADD" "$T40_CRASH_BIN" \
+    "$T40_ROOT/crash.out" "$T40_ROOT/crash.err" IWE_PEER_TIMEOUT_SECONDS=30 &
 T40_CRASH_PID=$!
 for _t40_wait in $(seq 1 200); do
-    [ -s "$T40_CRASH_READY" ] && [ -f "$T40_CRASH_BEACON" ] && break
-    sleep 0.05
+    [ -e "$T40_CRASH_READY" ] && [ -s "$T40_CRASH_GRANDCHILD_PID_FILE" ] && break
+    sleep 0.025
 done
-T40_CRASH_STARTED=0
-if [ -s "$T40_CRASH_READY" ] && [ -f "$T40_CRASH_BEACON" ]; then
-    T40_CRASH_STARTED=1
-fi
+T40_CRASH_VENDOR_PID=$(cat "$T40_CRASH_VENDOR_PID_FILE" 2>/dev/null || true)
+T40_CRASH_GRANDCHILD_PID=$(cat "$T40_CRASH_GRANDCHILD_PID_FILE" 2>/dev/null || true)
 kill -9 "$T40_CRASH_PID" 2>/dev/null || true
-wait "$T40_CRASH_PID" 2>/dev/null || true
-touch "$T40_CRASH_RELEASE"
-for _t40_wait in $(seq 1 100); do
-    [ ! -e "$T40_CRASH_BEACON" ] && [ ! -e "$T40_CRASH_LOCK" ] && break
-    sleep 0.05
+t40_launch_peer "$T40_CROSS_ADD" "$T40_CRASH_BIN" \
+    "$T40_ROOT/cross.out" "$T40_ROOT/cross.err" \
+    IWE_PEER_TIMEOUT_SECONDS=30 T40_CROSS_SESSION=1 &
+T40_CROSS_PID=$!
+t40_launch_peer "$T40_CRASH_ADD" "$T40_CRASH_BIN" \
+    "$T40_ROOT/crash-duplicate.out" "$T40_ROOT/crash-duplicate.err" \
+    IWE_PEER_TIMEOUT_SECONDS=30 &
+T40_CRASH_DUPLICATE_PID=$!
+T40_CRASH_MAX_LIVE=0
+for _t40_sample in $(seq 1 900); do
+    T40_CRASH_LIVE=0
+    while IFS= read -r _t40_entry_pid; do
+        if [ -n "$_t40_entry_pid" ] && t40_process_is_non_zombie "$_t40_entry_pid"; then
+            T40_CRASH_LIVE=$((T40_CRASH_LIVE + 1))
+        fi
+    done < "$T40_CRASH_ENTRIES"
+    [ "$T40_CRASH_LIVE" -le "$T40_CRASH_MAX_LIVE" ] || T40_CRASH_MAX_LIVE="$T40_CRASH_LIVE"
+    t40_process_is_non_zombie "$T40_CROSS_PID" || break
+    sleep 0.01
 done
-if [ "$T40_CRASH_STARTED" -eq 1 ] && \
-   [ ! -e "$T40_CRASH_BEACON" ] && [ ! -e "$T40_CRASH_LOCK" ]; then
-    pass "T40f: owner SIGKILL cannot leave a live-looking beacon or held lock"
+if wait "$T40_CRASH_DUPLICATE_PID"; then
+    T40_CRASH_DUPLICATE_RC=0
 else
-    fail "T40f: owner SIGKILL setup/cleanup failed (started=$T40_CRASH_STARTED beacon=$(test -e "$T40_CRASH_BEACON" && echo yes || echo no) lock=$(test -e "$T40_CRASH_LOCK" && echo yes || echo no))"
+    T40_CRASH_DUPLICATE_RC=$?
+fi
+if wait "$T40_CROSS_PID"; then
+    T40_CROSS_RC=0
+else
+    T40_CROSS_RC=$?
+fi
+wait "$T40_CRASH_PID" 2>/dev/null || true
+T40_CRASH_VENDOR_LIVE=false
+T40_CRASH_GRANDCHILD_LIVE=false
+t40_wait_for_process_exit "$T40_CRASH_VENDOR_PID" || T40_CRASH_VENDOR_LIVE=true
+t40_wait_for_process_exit "$T40_CRASH_GRANDCHILD_PID" || T40_CRASH_GRANDCHILD_LIVE=true
+t40_run_recovery "$T40_CRASH_ADD" "$T40_CRASH_BIN" \
+    "$T40_ROOT/crash-recovery.out" "$T40_ROOT/crash-recovery.err" T40_RECOVERY=1
+T40_CRASH_RECOVERY_RC="$T40_RECOVERY_RC"
+if [ "$T40_CRASH_DUPLICATE_RC" -eq 5 ] && [ "$T40_CROSS_RC" -eq 0 ] && \
+   [ "$(wc -l < "$T40_CRASH_ENTRIES" | tr -d ' ')" -eq 2 ] && \
+   [ "$T40_CRASH_MAX_LIVE" -le 1 ] && [ "$T40_CRASH_VENDOR_LIVE" = false ] && \
+   [ "$T40_CRASH_GRANDCHILD_LIVE" = false ] && [ "$T40_CRASH_RECOVERY_RC" -eq 0 ]; then
+    pass "T40h: top SIGKILL preserves same/cross-id exclusion until resistant lineage is dead"
+else
+    fail "T40h: SIGKILL overlap (same=$T40_CRASH_DUPLICATE_RC cross=$T40_CROSS_RC max_live=$T40_CRASH_MAX_LIVE vendor=$T40_CRASH_VENDOR_LIVE grandchild=$T40_CRASH_GRANDCHILD_LIVE recovery=$T40_CRASH_RECOVERY_RC)"
+fi
+
+# The helper and sentinel deliberately share the same open-file authorities.
+# Killing either one while a resistant vendor+grandchild is live must leave the
+# survivor in charge of same-id and cross-id exclusion through complete drain.
+t40_exercise_authority_sigkill() {
+    local role="$1" label="$2" sequence="$3" cross_sequence="$4"
+    local prefix="${role}-sigkill"
+    local add_dir="$T40_ROOT/peer-${sequence}-${prefix}"
+    local cross_dir="$T40_ROOT/peer-${cross_sequence}-${prefix}-cross"
+    local barrier="$T40_ROOT/${prefix}-pre-owner"
+    local sentinel_barrier="$T40_ROOT/${prefix}-pre-sentinel"
+    local adapter_pid helper_pid sentinel_pid target_pid expected_reason
+    local vendor_pid grandchild_pid session_id session_owner session_nonce
+    local oauth_owner lease_id expected_owner duplicate_pid cross_pid
+    local duplicate_rc cross_rc adapter_rc max_live=0 live entry_pid
+    local vendor_live=false grandchild_live=false recovery_rc
+
+    mkdir -p "$add_dir" "$cross_dir"
+    rm -f "$T40_CRASH_READY" "$T40_CROSS_READY" \
+        "$T40_CRASH_VENDOR_PID_FILE" "$T40_CRASH_GRANDCHILD_PID_FILE"
+    : > "$T40_CRASH_ENTRIES"
+    : > "$sentinel_barrier.release"
+    t40_launch_peer "$add_dir" "$T40_CRASH_BIN" \
+        "$T40_ROOT/${prefix}.out" "$T40_ROOT/${prefix}.err" \
+        IWE_PEER_TIMEOUT_SECONDS=30 \
+        IWE_PEER_TEST_OAUTH_PRE_OWNER_BARRIER="$barrier" \
+        IWE_PEER_TEST_OAUTH_PRE_SENTINEL_BARRIER="$sentinel_barrier" &
+    adapter_pid=$!
+    for _t40_authority_owner_wait in $(seq 1 200); do
+        [ -s "$barrier.ready" ] && break
+        sleep 0.025
+    done
+    helper_pid=$(cat "$barrier.ready" 2>/dev/null || true)
+    touch "$barrier.release"
+    for _t40_authority_ready_wait in $(seq 1 200); do
+        [ -e "$T40_CRASH_READY" ] && [ -s "$T40_CRASH_GRANDCHILD_PID_FILE" ] && break
+        sleep 0.025
+    done
+    vendor_pid=$(cat "$T40_CRASH_VENDOR_PID_FILE" 2>/dev/null || true)
+    grandchild_pid=$(cat "$T40_CRASH_GRANDCHILD_PID_FILE" 2>/dev/null || true)
+    sentinel_pid=$(cat "$sentinel_barrier.sentinel" 2>/dev/null || true)
+    session_id=$(basename "$add_dir")
+    session_owner=$(cat "$T40_LOCK_DIR/$session_id.lock/owner.pid" 2>/dev/null || true)
+    session_nonce=${session_owner#* }
+    oauth_owner=$(cat "$T40_OAUTH_LINEAGE/owner" 2>/dev/null || true)
+    lease_id=$(python3 -c 'import os,sys; s=os.stat(sys.argv[1]); print(f"{s.st_dev} {s.st_ino}")' "$T40_LOCK_DIR/kimi-oauth-refresh.lease" 2>/dev/null || true)
+    expected_owner="iwe-oauth-lineage-v4 $lease_id $session_nonce"
+    if [ "$role" = helper ]; then
+        target_pid="$helper_pid"
+        expected_reason=lock-helper-process-gone
+    else
+        target_pid="$sentinel_pid"
+        expected_reason=lock-sentinel-process-gone
+    fi
+    kill -9 "$target_pid" 2>/dev/null || true
+
+    t40_launch_peer "$cross_dir" "$T40_CRASH_BIN" \
+        "$T40_ROOT/${prefix}-cross.out" "$T40_ROOT/${prefix}-cross.err" \
+        IWE_PEER_TIMEOUT_SECONDS=30 T40_CROSS_SESSION=1 &
+    cross_pid=$!
+    t40_launch_peer "$add_dir" "$T40_CRASH_BIN" \
+        "$T40_ROOT/${prefix}-duplicate.out" "$T40_ROOT/${prefix}-duplicate.err" \
+        IWE_PEER_TIMEOUT_SECONDS=30 &
+    duplicate_pid=$!
+    for _t40_authority_sample in $(seq 1 900); do
+        live=0
+        while IFS= read -r entry_pid; do
+            if [ -n "$entry_pid" ] && t40_process_is_non_zombie "$entry_pid"; then
+                live=$((live + 1))
+            fi
+        done < "$T40_CRASH_ENTRIES"
+        [ "$live" -le "$max_live" ] || max_live="$live"
+        t40_process_is_non_zombie "$cross_pid" || break
+        sleep 0.01
+    done
+    if wait "$duplicate_pid"; then duplicate_rc=0; else duplicate_rc=$?; fi
+    if wait "$cross_pid"; then cross_rc=0; else cross_rc=$?; fi
+    if wait "$adapter_pid"; then adapter_rc=0; else adapter_rc=$?; fi
+    t40_wait_for_process_exit "$vendor_pid" || vendor_live=true
+    t40_wait_for_process_exit "$grandchild_pid" || grandchild_live=true
+    t40_run_recovery "$add_dir" "$T40_CRASH_BIN" \
+        "$T40_ROOT/${prefix}-recovery.out" "$T40_ROOT/${prefix}-recovery.err" \
+        T40_RECOVERY=1
+    recovery_rc="$T40_RECOVERY_RC"
+
+    if [[ "$sentinel_pid" =~ ^[0-9]+$ ]] && [[ "$helper_pid" =~ ^[0-9]+$ ]] && \
+       [ "${session_owner%% *}" = "$adapter_pid" ] && \
+       [[ "$session_nonce" =~ ^[0-9a-f]{32}$ ]] && \
+       [ "$oauth_owner" = "$expected_owner" ] && \
+       [ "$duplicate_rc" -eq 5 ] && [ "$cross_rc" -eq 0 ] && \
+       [ "$adapter_rc" -eq 1 ] && [ "$max_live" -le 1 ] && \
+       [ "$vendor_live" = false ] && [ "$grandchild_live" = false ] && \
+       [ "$recovery_rc" -eq 0 ] && \
+       ! t40_process_is_non_zombie "$helper_pid" && \
+       ! t40_process_is_non_zombie "$sentinel_pid" && \
+       grep -q "$expected_reason" "$T40_ROOT/${prefix}.err" && \
+       grep -q '^cross-session complete$' "$T40_ROOT/${prefix}-cross.out" && \
+       grep -q '^SIGKILL recovery complete$' "$T40_ROOT/${prefix}-recovery.out"; then
+        pass "T40${label}: SIGKILL $role leaves its survivor authoritative through same/cross drain and reaps both"
+    else
+        fail "T40${label}: $role SIGKILL opened or leaked authority (helper=$helper_pid sentinel=$sentinel_pid duplicate=$duplicate_rc cross=$cross_rc adapter=$adapter_rc max_live=$max_live vendor=$vendor_live grandchild=$grandchild_live recovery=$recovery_rc)"
+    fi
+}
+
+t40_exercise_authority_sigkill helper i 10 11
+t40_exercise_authority_sigkill sentinel j 12 13
+
+# The exec gate transfers legacy liveness from the controller group to the
+# vendor group. Losing both Python owners after admission must still block a
+# cross-id contender until the last resistant vendor descendant is gone.
+T40_DOUBLE_ADD="$T40_ROOT/peer-16-double-controller-fault"
+T40_DOUBLE_CROSS="${T40_DOUBLE_ADD}-cross"
+T40_DOUBLE_OWNER_BARRIER="$T40_ROOT/double-pre-owner"
+T40_DOUBLE_SENTINEL_BARRIER="$T40_ROOT/double-pre-sentinel"
+mkdir -p "$T40_DOUBLE_ADD" "$T40_DOUBLE_CROSS"
+rm -f "$T40_CRASH_READY" "$T40_CROSS_READY" \
+    "$T40_CRASH_VENDOR_PID_FILE" "$T40_CRASH_GRANDCHILD_PID_FILE"
+: > "$T40_CRASH_ENTRIES"
+: > "$T40_DOUBLE_SENTINEL_BARRIER.release"
+t40_launch_peer "$T40_DOUBLE_ADD" "$T40_CRASH_BIN" \
+    "$T40_ROOT/double.out" "$T40_ROOT/double.err" \
+    IWE_PEER_TIMEOUT_SECONDS=30 \
+    IWE_PEER_TEST_OAUTH_PRE_OWNER_BARRIER="$T40_DOUBLE_OWNER_BARRIER" \
+    IWE_PEER_TEST_OAUTH_PRE_SENTINEL_BARRIER="$T40_DOUBLE_SENTINEL_BARRIER" &
+T40_DOUBLE_ADAPTER_PID=$!
+for _t40_double_owner_wait in $(seq 1 200); do
+    [ -s "$T40_DOUBLE_OWNER_BARRIER.ready" ] && break
+    sleep 0.025
+done
+T40_DOUBLE_HELPER_PID=$(cat "$T40_DOUBLE_OWNER_BARRIER.ready" 2>/dev/null || true)
+touch "$T40_DOUBLE_OWNER_BARRIER.release"
+for _t40_double_vendor_wait in $(seq 1 240); do
+    [ -s "$T40_DOUBLE_SENTINEL_BARRIER.sentinel" ] && \
+        [ -s "$T40_CRASH_VENDOR_PID_FILE" ] && \
+        [ -s "$T40_CRASH_GRANDCHILD_PID_FILE" ] && break
+    sleep 0.025
+done
+T40_DOUBLE_SENTINEL_PID=$(cat "$T40_DOUBLE_SENTINEL_BARRIER.sentinel" 2>/dev/null || true)
+T40_DOUBLE_VENDOR_PID=$(cat "$T40_CRASH_VENDOR_PID_FILE" 2>/dev/null || true)
+T40_DOUBLE_GRANDCHILD_PID=$(cat "$T40_CRASH_GRANDCHILD_PID_FILE" 2>/dev/null || true)
+T40_DOUBLE_HOLDER=$(cat "$T40_OAUTH_LINEAGE/pid" 2>/dev/null || true)
+T40_DOUBLE_HOLDER_LIVE=false
+kill -0 "$T40_DOUBLE_HOLDER" 2>/dev/null && T40_DOUBLE_HOLDER_LIVE=true
+kill -9 "$T40_DOUBLE_HELPER_PID" "$T40_DOUBLE_SENTINEL_PID" 2>/dev/null || true
+if t40_run_peer "$T40_DOUBLE_CROSS" "$T40_CRASH_BIN" \
+    "$T40_ROOT/double-blocked.out" "$T40_ROOT/double-blocked.err" \
+    IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS=1 T40_CROSS_SESSION=1; then
+    T40_DOUBLE_BLOCKED_RC=0
+else
+    T40_DOUBLE_BLOCKED_RC=$?
+fi
+T40_DOUBLE_ENTRIES_LIVE=$(wc -l < "$T40_CRASH_ENTRIES" | tr -d ' ')
+kill -9 "$T40_DOUBLE_HOLDER" 2>/dev/null || true
+wait "$T40_DOUBLE_ADAPTER_PID" 2>/dev/null || true
+t40_wait_for_process_exit "$T40_DOUBLE_VENDOR_PID" || true
+t40_wait_for_process_exit "$T40_DOUBLE_GRANDCHILD_PID" || true
+t40_run_recovery "$T40_DOUBLE_CROSS" "$T40_CRASH_BIN" \
+    "$T40_ROOT/double-recovery.out" "$T40_ROOT/double-recovery.err" \
+    T40_RECOVERY=1 T40_CROSS_SESSION=1
+T40_DOUBLE_RECOVERY_RC="$T40_RECOVERY_RC"
+if [[ "$T40_DOUBLE_HELPER_PID" =~ ^[0-9]+$ ]] && \
+   [[ "$T40_DOUBLE_SENTINEL_PID" =~ ^[0-9]+$ ]] && \
+   [[ "$T40_DOUBLE_HOLDER" =~ ^-[0-9]+$ ]] && \
+   [ "$T40_DOUBLE_HOLDER_LIVE" = true ] && \
+   [ "$T40_DOUBLE_BLOCKED_RC" -eq 1 ] && \
+   [ "$T40_DOUBLE_ENTRIES_LIVE" -eq 1 ] && \
+   [ "$T40_DOUBLE_RECOVERY_RC" -eq 0 ] && \
+   ! t40_process_is_non_zombie "$T40_DOUBLE_VENDOR_PID" && \
+   ! t40_process_is_non_zombie "$T40_DOUBLE_GRANDCHILD_PID"; then
+    pass "T40v: double controller fault remains closed by vendor PGID until group death"
+else
+    fail "T40v: exec gate lost vendor-group visibility (helper=$T40_DOUBLE_HELPER_PID sentinel=$T40_DOUBLE_SENTINEL_PID holder=$T40_DOUBLE_HOLDER blocked=$T40_DOUBLE_BLOCKED_RC entries=$T40_DOUBLE_ENTRIES_LIVE recovery=$T40_DOUBLE_RECOVERY_RC)"
+fi
+
+# A hung capability probe runs before PGID publication. It must not inherit fd9
+# and turn top SIGKILL into a permanent per-session blocker.
+T40_HELP_ADD="$T40_ROOT/peer-hung-help-session"
+T40_HELP_READY="$T40_ROOT/help-ready"
+T40_HELP_PID_FILE="$T40_ROOT/help.pid"
+T40_HELP_BIN="$T40_ROOT/fake-kimi-hung-help"
+mkdir -p "$T40_HELP_ADD"
+cat > "$T40_HELP_BIN" <<'EOF'
+#!/bin/bash
+if [ "${1:-}" = "--help" ]; then
+    if [ "${T40_HELP_RECOVERY:-0}" = "1" ]; then
+        echo "--agent-file Load an agent definition from a Markdown file"
+        exit 0
+    fi
+    echo "$$" > "$T40_HELP_PID_FILE"
+    : > "$T40_HELP_READY"
+    trap '' HUP INT TERM
+    while :; do sleep 0.05; done
+fi
+printf '%s\n' '{"role":"assistant","content":"hung-help recovery complete"}'
+EOF
+chmod +x "$T40_HELP_BIN"
+export T40_HELP_READY T40_HELP_PID_FILE
+t40_launch_peer "$T40_HELP_ADD" "$T40_HELP_BIN" \
+    "$T40_ROOT/help.out" "$T40_ROOT/help.err" IWE_PEER_TIMEOUT_SECONDS=30 &
+T40_HELP_ADAPTER_PID=$!
+for _t40_wait in $(seq 1 200); do
+    [ -s "$T40_HELP_PID_FILE" ] && [ -e "$T40_HELP_READY" ] && break
+    sleep 0.025
+done
+T40_HELP_PID=$(cat "$T40_HELP_PID_FILE" 2>/dev/null || true)
+kill -9 "$T40_HELP_ADAPTER_PID" 2>/dev/null || true
+wait "$T40_HELP_ADAPTER_PID" 2>/dev/null || true
+t40_run_recovery "$T40_HELP_ADD" "$T40_HELP_BIN" \
+    "$T40_ROOT/help-recovery.out" "$T40_ROOT/help-recovery.err" T40_HELP_RECOVERY=1
+T40_HELP_RECOVERY_RC="$T40_RECOVERY_RC"
+T40_HELP_ORPHAN_LIVE=false
+t40_process_is_non_zombie "$T40_HELP_PID" && T40_HELP_ORPHAN_LIVE=true
+kill -9 "$T40_HELP_PID" 2>/dev/null || true
+t40_wait_for_process_exit "$T40_HELP_PID" || true
+if [ "$T40_HELP_ORPHAN_LIVE" = true ] && [ "$T40_HELP_RECOVERY_RC" -eq 0 ] && \
+   grep -q '^hung-help recovery complete$' "$T40_ROOT/help-recovery.out"; then
+    pass "T40k: hung --help cannot pin the lifetime FIFO after top SIGKILL"
+else
+    fail "T40k: capability probe pinned admission (probe=$T40_HELP_PID live=$T40_HELP_ORPHAN_LIVE recovery=$T40_HELP_RECOVERY_RC)"
+fi
+
+# Exact helper death in mkdir→pid and pid→owner can leave only an inert private
+# runtime staging directory; the immutable legacy fence remains unchanged.
+t40_unpublished_bridge_sigkill() {
+    local label="$1" sequence="$2" seam="$3" expected_mode="$4"
+    local add_dir="$T40_ROOT/peer-${sequence}-oauth-${label}"
+    local recovery_dir="${add_dir}-cross"
+    local barrier="$T40_ROOT/oauth-${label}"
+    local adapter_pid helper_pid bridge_dir staged_pid owner_absent=true
+    local adapter_rc recovery_rc pid_ok=false
+
+    mkdir -p "$add_dir" "$recovery_dir"
+    rm -f "$T40_CRASH_READY" "$T40_CROSS_READY" \
+        "$T40_CRASH_VENDOR_PID_FILE" "$T40_CRASH_GRANDCHILD_PID_FILE"
+    : > "$T40_CRASH_ENTRIES"
+    t40_launch_peer "$add_dir" "$T40_CRASH_BIN" \
+        "$T40_ROOT/oauth-${label}.out" "$T40_ROOT/oauth-${label}.err" \
+        IWE_PEER_TIMEOUT_SECONDS=30 T40_RECOVERY=1 "$seam=$barrier" &
+    adapter_pid=$!
+    for _t40_oauth_boundary_wait in $(seq 1 200); do
+        [ -s "$barrier.ready" ] && break
+        sleep 0.025
+    done
+    helper_pid=$(cat "$barrier.ready" 2>/dev/null || true)
+    bridge_dir=$(find "$T40_LOCK_DIR" -maxdepth 1 -type d \
+        -name 'kimi-oauth-refresh.lineage-v4.*' -print -quit)
+    staged_pid=$(cat "$bridge_dir/pid" 2>/dev/null || true)
+    [ -e "$bridge_dir/owner" ] && owner_absent=false
+    if { [ "$expected_mode" = absent ] && [ -z "$staged_pid" ]; } || \
+       { [ "$expected_mode" = controller-group ] && \
+         [ "$staged_pid" = "-$helper_pid" ]; }; then
+        pid_ok=true
+    fi
+    kill -9 "$helper_pid" 2>/dev/null || true
+    if wait "$adapter_pid" 2>/dev/null; then adapter_rc=0; else adapter_rc=$?; fi
+    t40_run_recovery "$recovery_dir" "$T40_CRASH_BIN" \
+        "$T40_ROOT/oauth-${label}-recovery.out" \
+        "$T40_ROOT/oauth-${label}-recovery.err" \
+        T40_RECOVERY=1 T40_CROSS_SESSION=1
+    recovery_rc="$T40_RECOVERY_RC"
+
+    if [[ "$helper_pid" =~ ^[0-9]+$ ]] && [ -n "$bridge_dir" ] && \
+       [ -L "$T40_OAUTH_DIR" ] && \
+       [ "$(readlink "$T40_OAUTH_DIR")" = "$T40_FENCE_TARGET" ] && \
+       [ ! -e "$T40_OAUTH_LINEAGE" ] && [ ! -L "$T40_OAUTH_LINEAGE" ] && \
+       [ "$pid_ok" = true ] && [ "$owner_absent" = true ] && \
+       [ "$adapter_rc" -eq 1 ] && [ "$recovery_rc" -eq 0 ] && \
+       [ "$(wc -l < "$T40_CRASH_ENTRIES" | tr -d ' ')" -eq 1 ]; then
+        [ -z "$bridge_dir" ] || rm -rf -- "$bridge_dir"
+        return 0
+    fi
+    T40_UNPUBLISHED_ERROR="label=$label helper=$helper_pid bridge=$bridge_dir pid=$staged_pid expected=$expected_mode owner_absent=$owner_absent adapter=$adapter_rc recovery=$recovery_rc"
+    [ -z "$bridge_dir" ] || rm -rf -- "$bridge_dir"
+    return 1
+}
+
+T40_UNPUBLISHED_ERROR=""
+if t40_unpublished_bridge_sigkill post-mkdir 08 \
+       IWE_PEER_TEST_OAUTH_POST_MKDIR_BARRIER absent && \
+   t40_unpublished_bridge_sigkill pre-owner 14 \
+       IWE_PEER_TEST_OAUTH_PRE_OWNER_BARRIER controller-group; then
+    pass "T40l: helper SIGKILL in both staging windows preserves fence and leaves runtime free"
+else
+    fail "T40l: unpublished v4 staging blocked recovery ($T40_UNPUBLISHED_ERROR)"
+fi
+
+# A pre-v4 contender may pause after its stale-PID decision. Ordinary
+# admission and asserted cutover preserve that real directory. After external
+# quiescence and drain, explicit cutover installs an immutable -1 fence that a
+# rollback implementation observes as permanently live.
+T40_ABA_LOCK_DIR="$T40_ROOT/oauth-aba-locks"
+T40_ABA_CANONICAL="$T40_ABA_LOCK_DIR/kimi-oauth-refresh.lockdir"
+T40_ABA_ADD="$T40_ROOT/peer-15-legacy-aba"
+T40_ABA_CHECKED="$T40_ROOT/legacy-aba.checked"
+T40_ABA_RELEASE="$T40_ROOT/legacy-aba.release"
+T40_ABA_ENTERED="$T40_ROOT/legacy-aba.entered"
+T40_ABA_DONE="$T40_ROOT/legacy-aba.done"
+mkdir -p "$T40_ABA_LOCK_DIR" "$T40_ABA_CANONICAL" "$T40_ABA_ADD"
+printf '%s\n' 99999999 > "$T40_ABA_CANONICAL/pid"
+python3 - "$T40_ABA_CANONICAL" "$T40_ABA_CHECKED" "$T40_ABA_RELEASE" \
+    "$T40_ABA_ENTERED" "$T40_ABA_DONE" <<'PY' &
+import os
+import shutil
+import sys
+import time
+
+canonical, checked, release, entered, done = sys.argv[1:]
+holder = open(os.path.join(canonical, "pid"), encoding="ascii").read().strip()
+try:
+    os.kill(int(holder), 0)
+    raise SystemExit("fixture holder unexpectedly alive")
+except ProcessLookupError:
+    pass
+open(checked, "w", encoding="ascii").close()
+while not os.path.exists(release):
+    time.sleep(0.02)
+shutil.rmtree(canonical)
+os.mkdir(canonical, 0o700)
+with open(os.path.join(canonical, "pid"), "w", encoding="ascii") as stream:
+    stream.write(f"{os.getpid()}\n")
+open(entered, "w", encoding="ascii").close()
+while not os.path.exists(done):
+    time.sleep(0.02)
+shutil.rmtree(canonical)
+PY
+T40_ABA_LEGACY_PID=$!
+for _t40_aba_wait in $(seq 1 200); do
+    [ -e "$T40_ABA_CHECKED" ] && break
+    sleep 0.025
+done
+T40_ABA_INODE=$(python3 -c 'import os,sys; s=os.lstat(sys.argv[1]); print(f"{s.st_dev}:{s.st_ino}")' "$T40_ABA_CANONICAL")
+rm -f "$T40_CRASH_READY"
+if "${T40_ADAPTER_ENV[@]}" IWE_PEER_LOCK_DIR="$T40_ABA_LOCK_DIR" \
+    KIMI_BIN="$T40_CRASH_BIN" T40_RECOVERY=1 \
+    IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_ABA_ADD" \
+    </dev/null >"$T40_ROOT/legacy-aba-peer.out" 2>"$T40_ROOT/legacy-aba-peer.err"; then
+    T40_ABA_PEER_RC=0
+else
+    T40_ABA_PEER_RC=$?
+fi
+if "${T40_ADAPTER_ENV[@]}" IWE_PEER_LOCK_DIR="$T40_ABA_LOCK_DIR" \
+    IWE_OAUTH_CUTOVER_QUIESCED=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" \
+    --cutover-oauth-lineage-v4 \
+    >"$T40_ROOT/legacy-aba-cutover-blocked.out" \
+    2>"$T40_ROOT/legacy-aba-cutover-blocked.err"; then
+    T40_ABA_CUTOVER_BLOCKED_RC=0
+else
+    T40_ABA_CUTOVER_BLOCKED_RC=$?
+fi
+T40_ABA_INODE_AFTER=$(python3 -c 'import os,sys; s=os.lstat(sys.argv[1]); print(f"{s.st_dev}:{s.st_ino}")' "$T40_ABA_CANONICAL" 2>/dev/null || true)
+touch "$T40_ABA_RELEASE"
+for _t40_aba_enter_wait in $(seq 1 200); do
+    [ -e "$T40_ABA_ENTERED" ] && break
+    sleep 0.025
+done
+if "${T40_ADAPTER_ENV[@]}" IWE_PEER_LOCK_DIR="$T40_ABA_LOCK_DIR" \
+    IWE_OAUTH_CUTOVER_QUIESCED=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" \
+    --cutover-oauth-lineage-v4 \
+    >"$T40_ROOT/legacy-aba-live-cutover.out" \
+    2>"$T40_ROOT/legacy-aba-live-cutover.err"; then
+    T40_ABA_LIVE_CUTOVER_RC=0
+else
+    T40_ABA_LIVE_CUTOVER_RC=$?
+fi
+touch "$T40_ABA_DONE"
+wait "$T40_ABA_LEGACY_PID" 2>/dev/null || true
+if "${T40_ADAPTER_ENV[@]}" IWE_PEER_LOCK_DIR="$T40_ABA_LOCK_DIR" \
+    IWE_OAUTH_CUTOVER_QUIESCED=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" \
+    --cutover-oauth-lineage-v4 \
+    >"$T40_ROOT/legacy-aba-cutover.out" 2>"$T40_ROOT/legacy-aba-cutover.err"; then
+    T40_ABA_CUTOVER_RC=0
+else
+    T40_ABA_CUTOVER_RC=$?
+fi
+T40_ABA_FENCE_INODE=$(python3 -c 'import os,sys; s=os.lstat(sys.argv[1]); print(f"{s.st_dev}:{s.st_ino}")' "$T40_ABA_CANONICAL" 2>/dev/null || true)
+T40_ABA_ROLLBACK_BLOCKED=false
+if ! mkdir "$T40_ABA_CANONICAL" 2>/dev/null; then
+    T40_ABA_ROLLBACK_HOLDER=$(cat "$T40_ABA_CANONICAL/pid" 2>/dev/null || true)
+    if [ "$T40_ABA_ROLLBACK_HOLDER" = -1 ] && \
+       kill -0 "$T40_ABA_ROLLBACK_HOLDER" 2>/dev/null; then
+        T40_ABA_ROLLBACK_BLOCKED=true
+    fi
+fi
+T40_ABA_FENCE_INODE_AFTER=$(python3 -c 'import os,sys; s=os.lstat(sys.argv[1]); print(f"{s.st_dev}:{s.st_ino}")' "$T40_ABA_CANONICAL" 2>/dev/null || true)
+if [ "$T40_ABA_PEER_RC" -eq 1 ] && \
+   [ "$T40_ABA_CUTOVER_BLOCKED_RC" -eq 1 ] && \
+   [ "$T40_ABA_INODE_AFTER" = "$T40_ABA_INODE" ] && \
+   [ -e "$T40_ABA_ENTERED" ] && [ "$T40_ABA_LIVE_CUTOVER_RC" -eq 1 ] && \
+   [ "$T40_ABA_CUTOVER_RC" -eq 0 ] && \
+   [ "$T40_ABA_ROLLBACK_BLOCKED" = true ] && \
+   [ "$T40_ABA_FENCE_INODE_AFTER" = "$T40_ABA_FENCE_INODE" ] && \
+   [ ! -e "$T40_CRASH_READY" ]; then
+    pass "T40w: paused legacy ABA blocks admission/cutover; drained cutover fence blocks rollback"
+else
+    fail "T40w: v4 quiescence/fence boundary failed (peer=$T40_ABA_PEER_RC cutover_paused=$T40_ABA_CUTOVER_BLOCKED_RC inode=$T40_ABA_INODE/$T40_ABA_INODE_AFTER live_cutover=$T40_ABA_LIVE_CUTOVER_RC cutover=$T40_ABA_CUTOVER_RC rollback=$T40_ABA_ROLLBACK_BLOCKED fence=$T40_ABA_FENCE_INODE/$T40_ABA_FENCE_INODE_AFTER)"
+fi
+
+# Ordinary calls must never infer quiescence or create the fence themselves.
+T40_NO_FENCE_ROOT="$T40_ROOT/oauth-no-fence-locks"
+T40_NO_FENCE_ADD="$T40_ROOT/peer-17-no-fence"
+mkdir -p "$T40_NO_FENCE_ROOT" "$T40_NO_FENCE_ADD"
+rm -f "$T40_CRASH_READY"
+if "${T40_ADAPTER_ENV[@]}" IWE_PEER_LOCK_DIR="$T40_NO_FENCE_ROOT" \
+    KIMI_BIN="$T40_CRASH_BIN" T40_RECOVERY=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_NO_FENCE_ADD" \
+    </dev/null >"$T40_ROOT/no-fence.out" 2>"$T40_ROOT/no-fence.err"; then
+    T40_NO_FENCE_RC=0
+else
+    T40_NO_FENCE_RC=$?
+fi
+if [ "$T40_NO_FENCE_RC" -eq 1 ] && \
+   [ ! -e "$T40_NO_FENCE_ROOT/kimi-oauth-refresh.lockdir" ] && \
+   [ ! -L "$T40_NO_FENCE_ROOT/kimi-oauth-refresh.lockdir" ] && \
+   [ ! -e "$T40_NO_FENCE_ROOT/kimi-oauth-refresh.lineage-v4" ] && \
+   [ ! -e "$T40_CRASH_READY" ] && \
+   grep -q 'OAuth lineage v4 cutover is required' "$T40_ROOT/no-fence.err"; then
+    pass "T40x: no-fence ordinary call fails closed without auto-cutover or vendor entry"
+else
+    fail "T40x: no-fence state was auto-upgraded/admitted (rc=$T40_NO_FENCE_RC)"
+fi
+
+# Exact OAuth metadata is byte-exact. Invalid bytes must fault rather than be
+# dropped during decoding and turn a tampered payload back into a valid one.
+T40_NONASCII_ROOT="$T40_ROOT/oauth-nonascii-locks"
+T40_NONASCII_ADD="$T40_ROOT/peer-18-oauth-nonascii"
+T40_NONASCII_FENCE="$T40_NONASCII_ROOT/kimi-oauth-refresh.lockdir"
+mkdir -p "$T40_NONASCII_ROOT" "$T40_NONASCII_ADD"
+if "${T40_ADAPTER_ENV[@]}" IWE_PEER_LOCK_DIR="$T40_NONASCII_ROOT" \
+    IWE_OAUTH_CUTOVER_QUIESCED=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" \
+    --cutover-oauth-lineage-v4 \
+    >"$T40_ROOT/nonascii-cutover.out" 2>"$T40_ROOT/nonascii-cutover.err"; then
+    T40_NONASCII_CUTOVER_RC=0
+else
+    T40_NONASCII_CUTOVER_RC=$?
+fi
+T40_NONASCII_OWNER=$(cat "$T40_NONASCII_FENCE/owner" 2>/dev/null || true)
+printf '%s\377\n' "$T40_NONASCII_OWNER" > "$T40_NONASCII_FENCE/owner"
+rm -f "$T40_CRASH_READY"
+if "${T40_ADAPTER_ENV[@]}" IWE_PEER_LOCK_DIR="$T40_NONASCII_ROOT" \
+    KIMI_BIN="$T40_CRASH_BIN" T40_RECOVERY=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_NONASCII_ADD" \
+    </dev/null >"$T40_ROOT/nonascii.out" 2>"$T40_ROOT/nonascii.err"; then
+    T40_NONASCII_RC=0
+else
+    T40_NONASCII_RC=$?
+fi
+if [ "$T40_NONASCII_CUTOVER_RC" -eq 0 ] && \
+   [ "$T40_NONASCII_RC" -eq 1 ] && \
+   [ -L "$T40_NONASCII_FENCE" ] && \
+   [ ! -e "$T40_NONASCII_ROOT/kimi-oauth-refresh.lineage-v4" ] && \
+   [ ! -L "$T40_NONASCII_ROOT/kimi-oauth-refresh.lineage-v4" ] && \
+   [ ! -e "$T40_CRASH_READY" ]; then
+    pass "T40z: non-ASCII OAuth metadata faults closed without vendor entry"
+else
+    fail "T40z: metadata validation accepted invalid ASCII (cutover=$T40_NONASCII_CUTOVER_RC rc=$T40_NONASCII_RC)"
+fi
+
+# Rollout boundary: every historical real directory is untrusted. Live,
+# dead ownerless, raw-nonce and fully staged v2 variants all remain untouched.
+T40_LEGACY_ROOT="$T40_ROOT/oauth-legacy-locks"
+T40_LEGACY_DIR="$T40_LEGACY_ROOT/kimi-oauth-refresh.lockdir"
+T40_LEGACY_ADD="$T40_ROOT/peer-oauth-legacy-session"
+mkdir -p "$T40_LEGACY_ROOT" "$T40_LEGACY_DIR" "$T40_LEGACY_ADD"
+( sleep 5 ) &
+T40_LEGACY_HOLDER_PID=$!
+printf '%s\n' "$T40_LEGACY_HOLDER_PID" > "$T40_LEGACY_DIR/pid"
+if "${T40_ADAPTER_ENV[@]}" IWE_PEER_LOCK_DIR="$T40_LEGACY_ROOT" \
+    KIMI_BIN="$T40_CRASH_BIN" T40_RECOVERY=1 \
+    IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_LEGACY_ADD" \
+    </dev/null >"$T40_ROOT/legacy-live.out" 2>"$T40_ROOT/legacy-live.err"; then
+    T40_LEGACY_LIVE_RC=0
+else
+    T40_LEGACY_LIVE_RC=$?
+fi
+T40_LEGACY_PID_AFTER=$(cat "$T40_LEGACY_DIR/pid" 2>/dev/null || true)
+if [ "$T40_LEGACY_LIVE_RC" -eq 1 ] && \
+   [ "$T40_LEGACY_PID_AFTER" = "$T40_LEGACY_HOLDER_PID" ]; then
+    pass "T40m: live pid-only scheduler remains untouched before explicit cutover"
+else
+    fail "T40m: live legacy OAuth holder was altered (rc=$T40_LEGACY_LIVE_RC expected=$T40_LEGACY_HOLDER_PID actual=$T40_LEGACY_PID_AFTER)"
+fi
+kill "$T40_LEGACY_HOLDER_PID" 2>/dev/null || true
+wait "$T40_LEGACY_HOLDER_PID" 2>/dev/null || true
+if "${T40_ADAPTER_ENV[@]}" IWE_PEER_LOCK_DIR="$T40_LEGACY_ROOT" \
+    KIMI_BIN="$T40_CRASH_BIN" T40_RECOVERY=1 \
+    IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_LEGACY_ADD" \
+    </dev/null >"$T40_ROOT/legacy-dead.out" 2>"$T40_ROOT/legacy-dead.err"; then
+    T40_LEGACY_DEAD_RC=0
+else
+    T40_LEGACY_DEAD_RC=$?
+fi
+T40_RAW_NONCE=0123456789abcdef0123456789abcdef
+printf '%s\n' "$T40_RAW_NONCE" > "$T40_LEGACY_DIR/owner"
+if "${T40_ADAPTER_ENV[@]}" IWE_PEER_LOCK_DIR="$T40_LEGACY_ROOT" \
+    KIMI_BIN="$T40_CRASH_BIN" T40_RECOVERY=1 \
+    IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_LEGACY_ADD" \
+    </dev/null >"$T40_ROOT/raw-dead.out" 2>"$T40_ROOT/raw-dead.err"; then
+    T40_RAW_DEAD_RC=0
+else
+    T40_RAW_DEAD_RC=$?
+fi
+if [ "$T40_LEGACY_DEAD_RC" -eq 1 ] && [ "$T40_RAW_DEAD_RC" -eq 1 ] && \
+   [ -d "$T40_LEGACY_DIR" ] && \
+   [ "$(cat "$T40_LEGACY_DIR/pid" 2>/dev/null || true)" = "$T40_LEGACY_HOLDER_PID" ] && \
+   [ "$(cat "$T40_LEGACY_DIR/owner" 2>/dev/null || true)" = "$T40_RAW_NONCE" ]; then
+    pass "T40n: dead ownerless/raw legacy directories remain fail-closed"
+else
+    fail "T40n: dead legacy/raw directory was altered (legacy=$T40_LEGACY_DEAD_RC raw=$T40_RAW_DEAD_RC)"
+fi
+
+rm -rf "$T40_LEGACY_DIR"
+mkdir -p "$T40_LEGACY_DIR"
+T40_SHARED_LEASE_ID=$(python3 -c 'import os,sys; s=os.stat(sys.argv[1]); print(f"{s.st_dev} {s.st_ino}")' "$T40_LEGACY_ROOT/kimi-oauth-refresh.lease")
+T40_VERSIONED_NONCE=fedcba9876543210fedcba9876543210
+printf '%s\n' 99999999 > "$T40_LEGACY_DIR/pid"
+printf 'iwe-oauth-sentinel-v2 %s %s\n' "$T40_SHARED_LEASE_ID" "$T40_VERSIONED_NONCE" > "$T40_LEGACY_DIR/owner"
+if "${T40_ADAPTER_ENV[@]}" IWE_PEER_LOCK_DIR="$T40_LEGACY_ROOT" \
+    KIMI_BIN="$T40_CRASH_BIN" T40_RECOVERY=1 \
+    IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS=1 \
+    bash "$TEMPLATE_DIR/scripts/kimi-peer-adapter.sh" --add-dir "$T40_LEGACY_ADD" \
+    </dev/null >"$T40_ROOT/versioned-recovery.out" 2>"$T40_ROOT/versioned-recovery.err"; then
+    T40_VERSIONED_RECOVERY_RC=0
+else
+    T40_VERSIONED_RECOVERY_RC=$?
+fi
+if [ "$T40_VERSIONED_RECOVERY_RC" -eq 1 ] && \
+   [ -d "$T40_LEGACY_DIR" ] && [ ! -L "$T40_LEGACY_DIR" ] && \
+   [ "$(cat "$T40_LEGACY_DIR/pid")" = 99999999 ] && \
+   [ "$(cat "$T40_LEGACY_DIR/owner")" = "iwe-oauth-sentinel-v2 $T40_SHARED_LEASE_ID $T40_VERSIONED_NONCE" ]; then
+    pass "T40o: valid v2 real directory stays fail-closed at the cutover boundary"
+else
+    fail "T40o: v2 real directory was removed (rc=$T40_VERSIONED_RECOVERY_RC)"
+fi
+
+# Only the separate new-only runtime namespace supports automatic recovery.
+T40_V4_MISSING_NONCE=0123456789abcdefabcdef0123456789
+T40_V4_MISSING_TARGET="kimi-oauth-refresh.lineage-v4.$T40_V4_MISSING_NONCE"
+ln -s "$T40_V4_MISSING_TARGET" "$T40_OAUTH_LINEAGE"
+if t40_run_peer "$T40_LEGACY_ADD" "$T40_CRASH_BIN" \
+    "$T40_ROOT/v4-missing-recovery.out" "$T40_ROOT/v4-missing-recovery.err" \
+    IWE_PEER_OAUTH_LOCK_TIMEOUT_SECONDS=2 T40_RECOVERY=1; then
+    T40_V4_MISSING_RC=0
+else
+    T40_V4_MISSING_RC=$?
+fi
+if [ "$T40_V4_MISSING_RC" -eq 0 ] && \
+   [ ! -e "$T40_OAUTH_LINEAGE" ] && [ ! -L "$T40_OAUTH_LINEAGE" ] && \
+   [ -L "$T40_OAUTH_DIR" ] && \
+   [ "$(readlink "$T40_OAUTH_DIR")" = "$T40_FENCE_TARGET" ] && \
+   grep -q '^SIGKILL recovery complete$' "$T40_ROOT/v4-missing-recovery.out"; then
+    pass "T40y: missing-target v4 runtime recovers without changing permanent fence"
+else
+    fail "T40y: v4 runtime recovery failed (rc=$T40_V4_MISSING_RC runtime=$(test -L "$T40_OAUTH_LINEAGE" -o -e "$T40_OAUTH_LINEAGE" && echo present || echo absent) fence=$(readlink "$T40_OAUTH_DIR" 2>/dev/null || true))"
 fi
 
 # TERM must terminate the adapter after cleanup; the old multi-signal cleanup
@@ -3312,9 +4107,9 @@ else
 fi
 if [ "$T40_TERM_RC" -eq 143 ] && [ ! -s "$T40_ROOT/term.out" ] && \
    [ ! -e "$T40_TERM_BEACON" ]; then
-    pass "T40g: TERM exits after exact cleanup and cannot continue the peer call"
+    pass "T40p: TERM exits after exact cleanup and cannot continue the peer call"
 else
-    fail "T40g: TERM did not stop the adapter (rc=$T40_TERM_RC output=$(wc -c < "$T40_ROOT/term.out" | tr -d ' '))"
+    fail "T40p: TERM did not stop the adapter (rc=$T40_TERM_RC output=$(wc -c < "$T40_ROOT/term.out" | tr -d ' '))"
 fi
 
 mkdir -p "$T40_IWE/.iwe-runtime/peer-heartbeats"
@@ -3330,9 +4125,9 @@ T40_WATCHDOG_OUT=$(IWE_ROOT="$T40_IWE" SILENCE_THRESHOLD_S=1 \
     t40 "$TEMPLATE_DIR/scripts/kimi-session-watchdog.sh" 2>&1)
 T40_WATCHDOG_RC=$?
 if [ "$T40_WATCHDOG_RC" -eq 0 ] && [[ "$T40_WATCHDOG_OUT" == *"$T40_BEACON|"* ]]; then
-    pass "T40h: watchdog consumes the separate peer-heartbeats namespace"
+    pass "T40q: watchdog consumes the separate peer-heartbeats namespace"
 else
-    fail "T40h: watchdog ignored the peer heartbeat (rc=$T40_WATCHDOG_RC out=$T40_WATCHDOG_OUT)"
+    fail "T40q: watchdog ignored the peer heartbeat (rc=$T40_WATCHDOG_RC out=$T40_WATCHDOG_OUT)"
 fi
 
 T40_FRESH_NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -3347,9 +4142,9 @@ T40_FRESH_OUT=$(IWE_ROOT="$T40_IWE" SILENCE_THRESHOLD_S=300 \
     bash -c 'source "$1"; notify_pilot(){ printf "%s|%s\n" "$1" "$2"; }; scan_once' \
     t40 "$TEMPLATE_DIR/scripts/kimi-session-watchdog.sh" 2>&1)
 if [ -z "$T40_FRESH_OUT" ]; then
-    pass "T40i: watchdog does not alert on a fresh peer heartbeat"
+    pass "T40r: watchdog does not alert on a fresh peer heartbeat"
 else
-    fail "T40i: watchdog falsely reported a fresh heartbeat: $T40_FRESH_OUT"
+    fail "T40r: watchdog falsely reported a fresh heartbeat: $T40_FRESH_OUT"
 fi
 
 if IWE_ROOT="$T40_IWE" CHECK_INTERVAL_S=0 \
@@ -3369,9 +4164,9 @@ fi
 if [ "$T40_BAD_INTERVAL_RC" -ne 0 ] && [ "$T40_BAD_THRESHOLD_RC" -ne 0 ] && \
    grep -q 'positive integer' "$T40_ROOT/invalid-interval.out" && \
    grep -q 'positive integer' "$T40_ROOT/invalid-threshold.out"; then
-    pass "T40j: watchdog rejects zero and non-numeric timing controls"
+    pass "T40s: watchdog rejects zero and non-numeric timing controls"
 else
-    fail "T40j: watchdog accepted an unsafe timing value (interval=$T40_BAD_INTERVAL_RC threshold=$T40_BAD_THRESHOLD_RC)"
+    fail "T40s: watchdog accepted an unsafe timing value (interval=$T40_BAD_INTERVAL_RC threshold=$T40_BAD_THRESHOLD_RC)"
 fi
 
 T40_OSA_DIR="$T40_ROOT/fake-osa-bin"
@@ -3390,7 +4185,7 @@ EOF
 chmod +x "$T40_OSA_DIR/osascript"
 export T40_OSA_CAPTURE
 if ! PATH="$T40_OSA_DIR:$PATH" command -v osascript >/dev/null 2>&1; then
-    fail "T40k: fake osascript is not discoverable"
+    fail "T40t: fake osascript is not discoverable"
 fi
 cat > "$T40_BEACON" <<'EOF'
 opened_at: 2020-01-01T00:00:00Z
@@ -3414,9 +4209,9 @@ assert 'subtitle "probe\\"; display dialog \\"PWN"' in program
 assert 'subtitle "probe"; display dialog "PWN"' not in program
 PY
 then
-    pass "T40k: watchdog escapes peer labels before AppleScript interpolation"
+    pass "T40t: watchdog escapes peer labels before AppleScript interpolation"
 else
-    fail "T40k: watchdog exposed an unescaped peer label to AppleScript"
+    fail "T40t: watchdog exposed an unescaped peer label to AppleScript"
 fi
 
 T40_PYTHON3=$("$TEMPLATE_DIR/scripts/lib/find-python3.sh" 2>/dev/null || true)
@@ -3434,9 +4229,9 @@ result = json.loads(sys.argv[1])
 assert result["alert"] is True
 PY
 then
-    pass "T40l: template delivers the peer language-check dependency"
+    pass "T40u: template delivers the peer language-check dependency"
 else
-    fail "T40l: peer language-check dependency is missing or inactive"
+    fail "T40u: peer language-check dependency is missing or inactive"
 fi
 
 # ============================================================

--- a/update-manifest.json
+++ b/update-manifest.json
@@ -217,7 +217,7 @@
     },
     {
       "path": ".claude/lib/find-python3.sh",
-      "sha256": "b938fca2780186b9383f3174a6d21b218f3b5f3a50e5d411a38179d584689cdd"
+      "sha256": "34ad77a7d721309dee10244843ea900db26954fc953d3dfc529eaa28f6ff25a0"
     },
     {
       "path": ".claude/lib/frontmatter.sh",
@@ -2389,7 +2389,7 @@
     },
     {
       "path": "scripts/kimi-peer-adapter.sh",
-      "sha256": "c91b04fa03d3e15a856c79266f07d1146989b670b584c2e0442781315554da69"
+      "sha256": "f3667622efc5b83d51d6d7364d95072e804cc470206b7d2c3ff17f9c310f57ef"
     },
     {
       "path": "scripts/kimi-session-watchdog.sh",
@@ -2421,7 +2421,7 @@
     },
     {
       "path": "scripts/lib/find-python3.sh",
-      "sha256": "b938fca2780186b9383f3174a6d21b218f3b5f3a50e5d411a38179d584689cdd"
+      "sha256": "34ad77a7d721309dee10244843ea900db26954fc953d3dfc529eaa28f6ff25a0"
     },
     {
       "path": "scripts/lib/language-check.py",
@@ -2449,7 +2449,7 @@
     },
     {
       "path": "scripts/lib/peer-adapter-common.sh",
-      "sha256": "874e916b4914f32b6918ffee44080c30ab7e4cf0f3ced7252e4dd6de6abf6088"
+      "sha256": "65b3a09582fb2bcb61b2c0a8ac7914b21ed5479ed8805ed438978264cb390682"
     },
     {
       "path": "scripts/lib/telegram.sh",
@@ -2981,7 +2981,7 @@
     },
     {
       "path": "seed/strategy/scripts/lib/find-python3.sh",
-      "sha256": "0d11e4e5a7e96e8125f2679632dca144c7cdf614221c536947b58d95943d6e13"
+      "sha256": "d0cc830a53adde80c4bff2d3c92c28efa45d8e2e6c67e5a54c48d1774818ca69"
     },
     {
       "path": "seed/strategy/scripts/lib/ledger-path.sh",


### PR DESCRIPTION
## Что исправлено

- отдельная v4-линия владения OAuth с явным переходом;
- неизменяемая отсечка старых запускателей;
- fail-closed защита при SIGKILL, потере метаданных и гонках;
- сохранение наблюдаемости без использования peer-beacon как полномочия сессии;
- обновлённый поиск Python для проверки языка.

## Проверка

- edge cases: 190/190;
- manifest verify: пройдено;
- manifest coverage: 950/950;
- специализированные проверки адаптера в DS-my-strategy: 53/53, 10/10, 13/13, 15/15.

Analyzed-by: Kimi <noreply@moonshot.ai>